### PR TITLE
Escape comparative operators (#3)

### DIFF
--- a/modules/ROOT/pages/clauses/where.adoc
+++ b/modules/ROOT/pages/clauses/where.adoc
@@ -770,7 +770,7 @@ The name and age values for nodes that have name `'Peter'` but no belt property 
 [[simple-range]]
 === Simple range
 
-To check for an element being inside a specific range, use the inequality operators `<`, `\<=`, `>=`, `>`.
+To check for an element being inside a specific range, use the inequality operators `+<+`, `+<=+`, `+>=+`, `+>+`.
 
 .Query
 [source, cypher, indent=0]

--- a/modules/ROOT/pages/syntax/operators.adoc
+++ b/modules/ROOT/pages/syntax/operators.adoc
@@ -53,7 +53,7 @@ This section contains an overview of operators.
 | xref::syntax/operators.adoc#query-operators-aggregation[Aggregation operators] | `DISTINCT`
 | xref::syntax/operators.adoc#query-operators-property[Property operators] | `.` for static property access, `[]` for dynamic property access, `=` for replacing all properties, `+=` for mutating specific properties
 | xref::syntax/operators.adoc#query-operators-mathematical[Mathematical operators] | `+`, `-`, `*`, `/`, `%`, `^`
-| xref::syntax/operators.adoc#query-operators-comparison[Comparison operators]     | `=`, `<>`, `<`, `>`, `+<=+`, `>=`, `IS NULL`, `IS NOT NULL`
+| xref::syntax/operators.adoc#query-operators-comparison[Comparison operators]     | `+=+`, `+<>+`, `+<+`, `+>+`, `+<=+`, `+>=+`, `IS NULL`, `IS NOT NULL`
 | xref::syntax/operators.adoc#query-operators-comparison[String-specific comparison operators] | `STARTS WITH`, `ENDS WITH`, `CONTAINS`
 | xref::syntax/operators.adoc#query-operators-boolean[Boolean operators] | `AND`, `OR`, `XOR`, `NOT`
 | xref::syntax/operators.adoc#query-operators-string[String operators]   | `+` for concatenation, `=~` for regex matching
@@ -292,12 +292,12 @@ RETURN b - a AS result
 
 The comparison operators comprise:
 
-* equality: `=`
-* inequality: `<>`
-* less than: `<`
-* greater than: `>`
-* less than or equal to: `\<=`
-* greater than or equal to: `>=`
+* equality: `+=+`
+* inequality: `+<>+`
+* less than: `+<+`
+* greater than: `+>+`
+* less than or equal to: `+<=+`
+* greater than or equal to: `+>=+`
 * `IS NULL`
 * `IS NOT NULL`
 
@@ -385,11 +385,11 @@ It is an error to compare values that cannot be compared.
 [[cypher-ordering]]
 === Ordering and comparison of values
 
-The comparison operators `\<=`, `<` (for ascending) and `>=`, `>` (for descending) are used to compare values for ordering.
+The comparison operators `+<=+`, `+<+` (for ascending) and `+>=+`, `+>+` (for descending) are used to compare values for ordering.
 The following points give some details on how the comparison is performed.
 
 * Numerical values are compared for ordering using numerical order (e.g. `3 < 4` is true).
-* All comparability tests (<, <=, >, >=) with `java.lang.Double.NaN` evaluate as false.
+* All comparability tests (`+<+`, `+<=+`, `+>+`, `+>=+`) with `java.lang.Double.NaN` evaluate as false.
 For example, `1 > b` and `1 < b` are both false when b is NaN.
 * String values are compared for ordering using lexicographic order (e.g. `"x" < "xy"`).
 * Boolean values are compared for ordering such that `false < true`.
@@ -448,9 +448,10 @@ For example, `[1, 'foo', 3]` is ordered before `[1, 2, 'bar']` since `'foo'` is 
 
 [[cypher-operations-chaining]]
 === Chaining comparison operations
-Comparisons can be chained arbitrarily, e.g., `x < y \<= z` is equivalent to `x < y AND y \<= z`.
 
-Formally, if `a, b, c, \..., y, z` are expressions and `op1, op2, \..., opN` are comparison operators, then `a op1 b op2 c \... y opN z` is equivalent to `a op1 b and b op2 c and \... y opN z`.
+Comparisons can be chained arbitrarily, e.g., `+x < y <= z+` is equivalent to `+x < y AND y <= z+`.
+
+Formally, if `+a, b, c, ..., y, z+` are expressions and `+op1, op2, ..., opN+` are comparison operators, then `+a op1 b op2 c ... y opN z+` is equivalent to `+a op1 b and b op2 c and ... y opN z+`.
 
 Note that `a op1 b op2 c` does not imply any kind of comparison between `a` and `c`, so that, e.g., `x < y > z` is perfectly legal (although perhaps not elegant).
 

--- a/modules/ROOT/pages/syntax/spatial.adoc
+++ b/modules/ROOT/pages/syntax/spatial.adoc
@@ -262,7 +262,7 @@ xref::query-tuning/indexes.adoc#administration-indexes-spatial-distance-searches
 == Comparability and orderability
 
 The comparability and orderability of spacial values are due to change in an upcoming future release.
-This means that queries that rely on the comparison of two points using the inequality operators, `<`, `+<=+`, `>`, and `>=`, or the specific order of an `ORDER BY n.point` query will need to be rewritten.
+This means that queries that rely on the comparison of two points using the inequality operators, `+<+`, `+<=+`, `+>+`, and `+>=+`, or the specific order of an `ORDER BY n.point` query will need to be rewritten.
 
 The most efficient way to do this is to explicitly specify the ordering. For example, by using `point.x`, `point.y` in _cartesian coordinates_, or `point.longitude` and `point.latitude` in _geographic coordinates_.
 


### PR DESCRIPTION
Escape the arrows <= and => and other comparative operators for consistency.