### PR TITLE
Note for the SHOW USER name PRIVILEGES

### DIFF
--- a/modules/ROOT/pages/access-control/manage-privileges.adoc
+++ b/modules/ROOT/pages/access-control/manage-privileges.adoc
@@ -271,7 +271,6 @@ SHOW USER[S] [name[, ...]] PRIVILEGE[S] [AS [REVOKE] COMMAND[S]]
 |
 It is only possible for a user to show their own privileges.
 Therefore, if a non-native auth provider like LDAP is in use, `SHOW USER PRIVILEGES` will only work in a limited capacity.
-
 Other users' privileges cannot be listed when using a non-native auth provider.
 
 |===


### PR DESCRIPTION
Added a note for the `SHOW USER user_name PRIVILEGES` syntax.

This is based on te PR https://github.com/neo-technology/neo4j-manual-modeling/pull/2927