### PR TITLE
SHOW INDEXES BRIEF has been removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -87,6 +87,23 @@ The ability to dropp a constraint based on the schema has been removed.
 
 Use the command to drop a constraint by the name of the constraint instead, `DROP CONSTRAINT constraint_name`.
 
+
+a|
+label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+SHOW INDEXES BRIEF
+----
+a|
+The keyword `BRIEF` for the command `SHOW INDEXES` has been removed.
+
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW INDEXES
+----
+
 |===
 
 // === Deprecated features


### PR DESCRIPTION
Use `SHOW INDEXES` instead.

This PR is based on https://github.com/neo4j/neo4j-documentation/pull/1340