### PR TITLE
SHOW INDEXES VERBOSE has been removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -104,6 +104,23 @@ Replaced by:
 SHOW INDEXES
 ----
 
+
+a|
+label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+SHOW INDEXES VERBOSE
+----
+a|
+The keyword `VERBOSE` for the command `SHOW INDEXES` has been removed.
+
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW INDEXES YIELD *
+----
+
 |===
 
 // === Deprecated features


### PR DESCRIPTION
Use `SHOW INDEXES YIELD *` instead.

This PR is based on the PR https://github.com/neo4j/neo4j-documentation/pull/1340