### PR TITLE
SHOW CONSTRAINTS BRIEF has been removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -121,6 +121,23 @@ Replaced by:
 SHOW INDEXES YIELD *
 ----
 
+
+a|
+label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+SHOW CONSTRAINTS BRIEF
+----
+a|
+The keyword `BRIEF` for the command `SHOW CONSTRAINTS` has been removed.
+
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW CONSTRAINTS
+----
+
 |===
 
 // === Deprecated features


### PR DESCRIPTION
Use `SHOW CONSTRAINTS` instead.

This PR is based on https://github.com/neo4j/neo4j-documentation/pull/1340