### PR TITLE
SHOW CONSTRAINTS VERBOSE has been removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -115,6 +115,23 @@ Replaced by:
 SHOW CONSTRAINTS
 ----
 
+
+a|
+label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+SHOW CONSTRAINTS VERBOSE
+----
+a|
+The keyword `VERBOSE` for the command `SHOW CONSTRAINTS` has been removed.
+
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW CONSTRAINTS YIELD *
+----
+
 |===
 
 // === Deprecated features


### PR DESCRIPTION
Use `SHOW CONSTRAINTS YIELD *` instead.

This PR is based on https://github.com/neo4j/neo4j-documentation/pull/1340