### PR TITLE
SHOW EXISTS CONSTRAINTS syntax removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -132,6 +132,43 @@ Replaced by:
 SHOW CONSTRAINTS YIELD *
 ----
 
+
+a|
+label:syntax[]
+label:removed[]
+
+[source, cypher, role="noheader"]
+----
+SHOW EXISTS CONSTRAINTS
+----
+
+[source, cypher, role="noheader"]
+----
+SHOW NODE EXISTS CONSTRAINTS
+----
+
+[source, cypher, role="noheader"]
+----
+SHOW RELATIONSHIP EXISTS CONSTRAINTS
+----
+a|
+Replaced by:
+
+[source, cypher, role="noheader"]
+----
+SHOW [PROPERTY] EXIST[ENCE] CONSTRAINTS
+----
+
+[source, cypher, role="noheader"]
+----
+SHOW NODE [PROPERTY] EXIST[ENCE] CONSTRAINTS
+----
+
+[source, cypher, role="noheader"]
+----
+SHOW REL[ATIONSHIP] [PROPERTY] EXIST[ENCE] CONSTRAINTS
+----
+
 |===
 
 // === Deprecated features


### PR DESCRIPTION
removed:     `SHOW EXISTS CONSTRAINTS`
replaced by: `SHOW [PROPERTY] EXIST[ENCE] CONSTRAINTS`

removed:     `SHOW NODE EXISTS CONSTRAINTS`
replaced by: `SHOW NODE [PROPERTY] EXIST[ENCE] CONSTRAINTS`

removed:     `SHOW RELATIONSHIP EXISTS CONSTRAINTS`
replaced by: `SHOW REL[ATIONSHIP] [PROPERTY] EXIST[ENCE] CONSTRAINTS`

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1340