### PR TITLE
Number literals support underscores

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -180,7 +180,24 @@ SHOW REL[ATIONSHIP] [PROPERTY] EXIST[ENCE] CONSTRAINTS
 // === Updated features
 
 
-// === New features
+=== New features
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:syntax[]
+label:added[]
+[source, cypher, role="noheader"]
+----
+1_000_000, 0x_FF_FF, 0o_88_88
+----
+a|
+Cypher now supports number literals with underscores between digits.
+
+|===
 
 
 

--- a/modules/ROOT/pages/syntax/expressions.adoc
+++ b/modules/ROOT/pages/syntax/expressions.adoc
@@ -65,7 +65,13 @@ String literals can contain the following escape sequences:
 |`\Uxxxxxxxx`|Unicode UTF-32 code point (8 hex digits must follow the `\U`)
 |===================
 
-//neo4j-manual-modeling-antora/cypherManual/build/4.4/antora/modules/ROOT/partials/neo4j-cypher-docs/docs/dev/ql/query-syntax-case.adoc
+
+[[cypher-expressions-number-literals]]
+== Note on number literals
+
+Any number literal may contain an underscore `_` between digits.
+There may be an underscore between the `0x` or `0o` and the digits for hexadecimal and octal literals.
+
 
 [[query-syntax-case]]
 == `CASE` expressions


### PR DESCRIPTION
`100000` can be written as `1_000_000`

`0xFFFF` can be written as `0x_FF_FF`

`0o8888` can be written as `0o_88_88`

This PR is based on the PR https://github.com/neo4j/neo4j-documentation/pull/1326