### PR TITLE
ON DEFAULT DATABASE has been removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -169,6 +169,23 @@ SHOW NODE [PROPERTY] EXIST[ENCE] CONSTRAINTS
 SHOW REL[ATIONSHIP] [PROPERTY] EXIST[ENCE] CONSTRAINTS
 ----
 
+
+a|
+label:syntax[]
+label:removed[]
+
+For privilege commands:
+[source, cypher, role="noheader"]
+----
+ON DEFAULT DATABASE
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+ON HOME DATABASE
+----
+
 |===
 
 // === Deprecated features
@@ -838,7 +855,8 @@ Still allows `BRIEF` and `VERBOSE` but not `YIELD` or `WHERE`.
 
 a|
 label:syntax[]
-label:deprecated[] +
+label:deprecated[]
+
 For privilege commands:
 [source, cypher, role="noheader", indent=0]
 ----


### PR DESCRIPTION
Use `ON HOME DATABASE` instead.

This PR is based on the PR https://github.com/neo4j/neo4j-documentation/pull/1420