### PR TITLE
Removed deprecated create index syntax

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -37,6 +37,23 @@ Use the command to drop an index by the name of the index instead, `DROP INDEX i
 
 
 a|
+label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+CREATE INDEX ON :Label(prop)
+----
+a|
+Deprecated syntax for creating an index has been removed.
+
+Replaced by:
+[source, cypher, role="noheader"]
+----
+CREATE INDEX FOR (n:Label) ON (n.prop)
+----
+
+
+a|
 label:functionality[]
 label:removed[]
 


### PR DESCRIPTION
`CREATE INDEX ON :Label(prop)` removed syntax.

Replaced by:

`CREATE INDEX FOR (n:Label) ON (n.prop)`

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1439