### PR TITLE
Editorial review of the built in roles for access control section (#31)

### DIFF
--- a/modules/ROOT/pages/access-control/built-in-roles.adoc
+++ b/modules/ROOT/pages/access-control/built-in-roles.adoc
@@ -1,5 +1,4 @@
 :description: The default privileges of the built-in roles in Neo4j and how to recreate them if needed.
-
 [role=enterprise-edition]
 [[access-control-built-in-roles]]
 = Built-in roles and privileges
@@ -19,23 +18,22 @@ The privileges listed in the following sections are the default set of privilege
 * xref::access-control/built-in-roles.adoc#access-control-built-in-roles-architect[The `architect` role]
 * xref::access-control/built-in-roles.adoc#access-control-built-in-roles-admin[The `admin` role]
 
-
 [[access-control-built-in-roles-public]]
 == The `PUBLIC` role
 
 All users are granted the `PUBLIC` role, and it can not be revoked or dropped.
-By default, it gives access to the default database and allows executing all procedures and user defined functions.
+By default, it gives access to the default database and allows executing all procedures and user-defined functions.
 
 [IMPORTANT]
 ====
-The `PUBLIC` role cannot be dropped or revoked from any user, but the specific privileges for the role may be modified.
+The `PUBLIC` role cannot be dropped or revoked from any user, but the specific privileges for the role can be modified.
 In contrast to the `PUBLIC` role, the other built-in roles can be granted, revoked, dropped, and re-created.
 ====
 
 [[access-control-built-in-roles-public-list]]
 === Listing `PUBLIC` role privileges
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 SHOW ROLE PUBLIC PRIVILEGES AS COMMANDS
 ----
@@ -56,20 +54,21 @@ a|Rows: 3
 
 The `PUBLIC` role can not be dropped and thus there is no need to recreate the role itself.
 To restore the role to its original capabilities, two steps are needed.
-First, all `GRANT` or `DENY` privileges on this role should be revoked (see output of `SHOW ROLE PUBLIC PRIVILEGES AS REVOKE COMMANDS` on what to revoke).
-Secondly, the following queries must be run:
 
-[source, cypher, role=noplay, indent=0]
+First, all `GRANT` or `DENY` privileges on this role should be revoked (see output of `SHOW ROLE PUBLIC PRIVILEGES AS REVOKE COMMANDS` on what to revoke).
+Secondly, run these queries:
+
+[source, cypher, role=noplay]
 ----
 GRANT ACCESS ON HOME DATABASE TO PUBLIC
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT EXECUTE PROCEDURES * ON DBMS TO PUBLIC
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT EXECUTE USER DEFINED FUNCTIONS * ON DBMS TO PUBLIC
 ----
@@ -86,7 +85,7 @@ The `reader` role can perform read-only queries on all graphs except for the `sy
 [[access-control-built-in-roles-reader-list]]
 === Listing `reader` role privileges
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 SHOW ROLE reader PRIVILEGES AS COMMANDS
 ----
@@ -106,20 +105,20 @@ a|Rows: 3
 === Recreating the `reader` role
 
 To restore the role to its original capabilities two steps are needed.
-First, if not already done, execute `DROP ROLE reader`.
-Secondly, the following queries must be run:
+First, execute `DROP ROLE reader`.
+Secondly, run these queries:
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 CREATE ROLE reader
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT ACCESS ON DATABASE * TO reader
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT MATCH {*} ON GRAPH * TO reader
 ----
@@ -130,12 +129,12 @@ The resulting `reader` role now has the same privileges as the original built-in
 [[access-control-built-in-roles-editor]]
 == The `editor` role
 
-The `editor` role can perform read and write operations on all graphs except for the `system` database, but can not make new labels, property keys or relationship types.
+The `editor` role can perform read and write operations on all graphs except for the `system` database, but it cannot create new labels, property keys or relationship types.
 
 [[access-control-built-in-roles-editor-list]]
 === Listing `editor` role privileges
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 SHOW ROLE editor PRIVILEGES AS COMMANDS
 ----
@@ -156,25 +155,25 @@ a|Rows: 4
 === Recreating the `editor` role
 
 To restore the role to its original capabilities two steps are needed.
-First, if not already done, execute `DROP ROLE editor`.
-Secondly, the following queries must be run:
+First, execute `DROP ROLE editor`.
+Secondly, run these queries:
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 CREATE ROLE editor
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT ACCESS ON DATABASE * TO editor
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT MATCH {*} ON GRAPH * TO editor
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT WRITE ON GRAPH * TO editor
 ----
@@ -185,13 +184,13 @@ The resulting `editor` role now has the same privileges as the original built-in
 [[access-control-built-in-roles-publisher]]
 == The `publisher` role
 
-The `publisher` role can do the same as xref::access-control/built-in-roles.adoc#access-control-built-in-roles-editor[`editor`], but can also create new labels, property keys and relationship types.
+The `publisher` role can do the same as xref::access-control/built-in-roles.adoc#access-control-built-in-roles-editor[`editor`], as well as create new labels, property keys and relationship types.
 
 
 [[access-control-built-in-roles-publisher-list]]
 === Listing `publisher` role privileges
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 SHOW ROLE publisher PRIVILEGES AS COMMANDS
 ----
@@ -213,30 +212,30 @@ a|Rows: 5
 === Recreating the `publisher` role
 
 To restore the role to its original capabilities two steps are needed.
-First, if not already done, execute `DROP ROLE publisher`.
-Secondly, the following queries must be run:
+First, execute `DROP ROLE publisher`.
+Secondly, run these queries:
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 CREATE ROLE publisher
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT ACCESS ON DATABASE * TO publisher
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT MATCH {*} ON GRAPH * TO publisher
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT WRITE ON GRAPH * TO publisher
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT NAME MANAGEMENT ON DATABASE * TO publisher
 ----
@@ -253,7 +252,7 @@ The `architect` role can do the same as the xref::access-control/built-in-roles.
 [[access-control-built-in-roles-architect-list]]
 === Listing `architect` role privileges
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 SHOW ROLE architect PRIVILEGES AS COMMANDS
 ----
@@ -277,35 +276,35 @@ a|Rows: 7
 === Recreating the `architect` role
 
 To restore the role to its original capabilities two steps are needed.
-First, if not already done, execute `DROP ROLE architect`.
-Secondly, the following queries must be run:
+First, execute `DROP ROLE architect`.
+Secondly, run these queries:
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT ACCESS ON DATABASE * TO architect
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT MATCH {*} ON GRAPH * TO architect
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT WRITE ON GRAPH * TO architect
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT NAME MANAGEMENT ON DATABASE * TO architect
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT INDEX MANAGEMENT ON DATABASE * TO architect
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT CONSTRAINT MANAGEMENT ON DATABASE * TO architect
 ----
@@ -321,25 +320,25 @@ The `admin` role can do the same as the xref::access-control/built-in-roles.adoc
 The `admin` role has the ability to perform administrative tasks.
 These include the rights to perform the following classes of tasks:
 
-* Manage xref::access-control/database-administration.adoc[database security] for controlling the rights to perform actions on specific databases:
-** Manage access to a database and the right to start and stop a database
-** Manage xref::indexes-for-search-performance.adoc[indexes] and xref::constraints/index.adoc[constraints]
-** Allow the creation of labels, relationship types or property names
+* Manage xref::access-control/database-administration.adoc[database security] to control the rights to perform actions on specific databases:
+** Manage access to a database and the right to start and stop a database.
+** Manage xref::indexes-for-search-performance.adoc[indexes] and xref::constraints/index.adoc[constraints].
+** Allow the creation of labels, relationship types or property names.
 ** Manage transactions
-* Manage xref::access-control/dbms-administration.adoc[DBMS security] for controlling the rights to perform actions on the entire system:
-** Manage xref::databases.adoc[multiple databases]
-** Manage xref::access-control/manage-users.adoc[users] and xref::access-control/manage-roles.adoc[roles]
-** Change configuration parameters
-** Manage sub-graph privileges
-** Manage procedure security
+* Manage xref::access-control/dbms-administration.adoc[DBMS security] to control the rights to perform actions on the entire system:
+** Manage xref::databases.adoc[multiple databases].
+** Manage xref::access-control/manage-users.adoc[users] and xref::access-control/manage-roles.adoc[roles].
+** Change configuration parameters.
+** Manage sub-graph privileges.
+** Manage procedure security.
 
-These rights are conferred using privileges that can be managed using xref::access-control/manage-privileges.adoc#access-control-graph-privileges[`GRANT`, `DENY`, and `REVOKE` commands].
+These rights are conferred using privileges that can be managed through the xref::access-control/manage-privileges.adoc#access-control-graph-privileges[`GRANT`, `DENY` and `REVOKE` commands].
 
 
 [[access-control-built-in-roles-admin-list]]
 === Listing `admin` role privileges
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 SHOW ROLE admin PRIVILEGES AS COMMANDS
 ----
@@ -362,57 +361,57 @@ SHOW ROLE admin PRIVILEGES AS COMMANDS
 a|Rows: 11
 |===
 
-If the built-in admin role has been altered or dropped, and needs to be restored to its original state, see xref:5.0@operations-manual:ROOT:configuration/password-and-user-recovery/index.adoc[Operations Manual -> Password and user recovery].
+If the built-in `admin` role has been altered or dropped, and needs to be restored to its original state, see xref:5.0@operations-manual:ROOT:configuration/password-and-user-recovery/index.adoc[Operations Manual -> Password and user recovery].
 
 
 [[access-control-built-in-roles-admin-recreate]]
 === Recreating the `admin` role
 
 To restore the role to its original capabilities two steps are needed.
-First, if not already done, execute `DROP ROLE admin`.
-Secondly, the following queries must be run in order to set up the privileges:
+First, execute `DROP ROLE admin`.
+Secondly, run these queries:
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 CREATE ROLE admin
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT ALL DBMS PRIVILEGES ON DBMS TO admin
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT TRANSACTION MANAGEMENT ON DATABASE * TO admin
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT START ON DATABASE * TO admin
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT STOP ON DATABASE * TO admin
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT MATCH {*} ON GRAPH * TO admin
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT WRITE ON GRAPH * TO admin
 ----
 
-[source, cypher, role=noplay, indent=0]
+[source, cypher, role=noplay]
 ----
 GRANT ALL ON DATABASE * TO admin
 ----
 
 The resulting `admin` role now has the same privileges as the original built-in `admin` role.
 
-Additional information about restoring the admin role can be found in the xref:5.0@operations-manual:ROOT:configuration/password-and-user-recovery/index.adoc#recover-admin-role[Operations Manual -> Recover the admin role].
+Additional information about restoring the `admin` role can be found in the xref:5.0@operations-manual:ROOT:configuration/password-and-user-recovery/index.adoc#recover-admin-role[Operations Manual -> Recover the admin role].
 


### PR DESCRIPTION
Editorial improvements for the built in roles page in the access-control section.