### PR TITLE
Replaced the dbms.procedures() procedure with SHOW PROCEDURES command

### DIFF
--- a/modules/ROOT/pages/clauses/call.adoc
+++ b/modules/ROOT/pages/clauses/call.adoc
@@ -108,23 +108,31 @@ CALL db.labels
 [[call-view-the-signature-for-a-procedure]]
 == View the signature for a procedure
 
-To `CALL` a procedure, its input parameters need to be known, and to use `YIELD`, its output parameters need to be known.
-The built-in procedure `dbms.procedures` returns the name, signature and description for all procedures.
-The following query can be used to return the signature for a particular procedure:
+The `SHOW PROCEDURES` command can return the `name`, `signature`, and `description` for all procedures.
 
-////
-CREATE (a:User:Administrator {name: 'Adrian'})
-////
+The default outputs for `SHOW PROCEDURES` are `name`, `description`, `mode`, and `worksOnSystem`.
+To get the signature, make sure to use the `YIELD` clause.
+
+
+.+SHOW PROCEDURES+
+======
+
+The following query return the signature for a particular procedure:
 
 .Query
 [source, cypher, indent=0]
 ----
-CALL dbms.procedures() YIELD name, signature
-WHERE name='dbms.listConfig'
+SHOW PROCEDURES YIELD name, signature
+WHERE name = 'dbms.listConfig'
 RETURN signature
 ----
 
-We can see that the `dbms.listConfig` has one input parameter, `searchString`, and three output parameters, `name`, `description` and `value`.
+////
+The result shows that:
+
+ * The `dbms.listConfig` has one input parameter: `searchString`.
+ * The `dbms.listConfig` has three output parameters: `name`, `description`, and `value`.
+////
 
 .Result
 [role="queryresult",options="header,footer",cols="1*<m"]
@@ -133,6 +141,8 @@ We can see that the `dbms.listConfig` has one input parameter, `searchString`, a
 | +"dbms.listConfig(searchString =  :: STRING?) :: (name :: STRING?, description :: STRING?, value :: STRING?, dynamic :: BOOLEAN?)"+
 1+d|Rows: 1
 |===
+
+======
 
 
 [[call-call-a-procedure-using-a-quoted-namespace-and-name]]


### PR DESCRIPTION
`dbms.procedures()` -- deprecated in 4.3

`SHOW PROCEDURES` -- new in 4.3

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1441