### PR TITLE
The dbms.procedures was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -237,6 +237,26 @@ Replaced by:
 ON HOME GRAPH
 ----
 
+
+a|
+label:procedure[]
+label:removed[]
+
+[source, cypher, role="noheader"]
+----
+dbms.procedures
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW PROCEDURE[S]
+[EXECUTABLE [BY {CURRENT USER \| username}]]
+[YIELD ...]
+[WHERE ...]
+[RETURN ...]
+----
+
 |===
 
 // === Deprecated features


### PR DESCRIPTION
`dbms.procedures() :: (name :: STRING?, signature :: STRING?, description :: STRING?, mode :: STRING?, defaultBuiltInRoles :: LIST? OF STRING?, worksOnSystem :: BOOLEAN?)`

Use `SHOW PROCEDURES YIELD *` instead.

Based on the PR:

1. https://github.com/neo-technology/neo4j-manual-modeling/pull/2679