### PR TITLE
dbms.procedures was deprecated in 4.3

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -677,6 +677,26 @@ Replaced by:
 ON HOME GRAPH
 ----
 
+
+a|
+label:procedure[]
+label:deprecated[]
+
+[source, cypher, role="noheader"]
+----
+dbms.procedures
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW PROCEDURE[S]
+[EXECUTABLE [BY {CURRENT USER \| username}]]
+[YIELD ...]
+[WHERE ...]
+[RETURN ...]
+----
+
 |===
 
 


### PR DESCRIPTION
The procedure `dmbs.procedures` is deprecated in 4.3.

Use the new `SHOW PROCEDURES` command instead.

This PR is based on:

1. https://github.com/neo-technology/neo4j-manual-modeling/pull/2679