### PR TITLE
dbms.functions was deprecated in 4.3

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -697,6 +697,26 @@ SHOW PROCEDURE[S]
 [RETURN ...]
 ----
 
+
+a|
+label:procedure[]
+label:deprecated[]
+
+[source, cypher, role="noheader"]
+----
+dbms.functions
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW [ALL \| BUILT IN \| USER DEFINED] FUNCTION[S]
+[EXECUTABLE [BY {CURRENT USER \| username}]]
+[YIELD ...]
+[WHERE ...]
+[RETURN ...]
+----
+
 |===
 
 


### PR DESCRIPTION
The procedure `dmbs.functions` is deprecated in 4.3.

Use the new `SHOW FUNCTIONS` command instead.

This PR is based on:

1. https://github.com/neo-technology/neo4j-manual-modeling/pull/2679