### PR TITLE
The dbms.functions was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -257,6 +257,26 @@ SHOW PROCEDURE[S]
 [RETURN ...]
 ----
 
+
+a|
+label:procedure[]
+label:removed[]
+
+[source, cypher, role="noheader"]
+----
+dbms.functions
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW [ALL \| BUILT IN \| USER DEFINED] FUNCTION[S]
+[EXECUTABLE [BY {CURRENT USER \| username}]]
+[YIELD ...]
+[WHERE ...]
+[RETURN ...]
+----
+
 |===
 
 // === Deprecated features


### PR DESCRIPTION
`dbms.functions() :: (name :: STRING?, signature :: STRING?, category :: STRING?, description :: STRING?, aggregating :: BOOLEAN?, defaultBuiltInRoles :: LIST? OF STRING?)`

Use `SHOW FUNCTIONS YIELD *` instead.

This PR is based on:

1. https://github.com/neo-technology/neo4j-manual-modeling/pull/2679