### PR TITLE
Transaction procedures was deprecated in 4.4

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -211,12 +211,12 @@ label:deprecated[]
 
 [source, cypher, role="noheader"]
 ----
-dbms.listTransaction
+dbms.killTransaction
 ----
 
 [source, cypher, role="noheader"]
 ----
-dbms.listTransactions
+dbms.killTransactions
 ----
 a|
 Replaced by:


### PR DESCRIPTION
`dbms.listTransactions` -- deprecated

Use `SHOW TRANSACTIONS YIELD *` instead.

`dbms.killTransaction` -- deprecated
`dbms.killTransactions` -- deprecated

Use `TERMINATE TRANSACTION[S] transaction-id[,...]` instead.

This PR is based on:

1. https://github.com/neo-technology/neo4j-manual-modeling/pull/2618
2. https://github.com/neo4j/neo4j-documentation/pull/1448