### PR TITLE
Transaction procedures was deprecated in 4.4 (#51)

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -497,6 +497,46 @@ Please instead use:
 point.withinBBox(point({x:1, y:1}), point({x:0, y:0}), point({x:2, y:2}))
 ----
 
+
+a|
+label:procedure[]
+label:deprecated[]
+
+[source, cypher, role="noheader"]
+----
+dbms.listTransactions
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW TRANSACTION[S] [transaction-id[,...]]
+[YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+[WHERE expression]
+[RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+----
+
+
+a|
+label:procedure[]
+label:deprecated[]
+
+[source, cypher, role="noheader"]
+----
+dbms.killTransaction
+----
+
+[source, cypher, role="noheader"]
+----
+dbms.killTransactions
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+TERMINATE TRANSACTION[S] transaction-id[,...]
+----
+
 |===
 
 


### PR DESCRIPTION
Transaction procedures was deprecated in 4.4

`dbms.listTransactions` -- deprecated

Use `SHOW TRANSACTIONS YIELD *` instead.

`dbms.killTransaction` -- deprecated
`dbms.killTransactions` -- deprecated

Use `TERMINATE TRANSACTION[S] transaction-id[,...]` instead.