### PR TITLE
Transaction procedures was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -277,6 +277,46 @@ SHOW [ALL \| BUILT IN \| USER DEFINED] FUNCTION[S]
 [RETURN ...]
 ----
 
+
+a|
+label:procedure[]
+label:removed[]
+
+[source, cypher, role="noheader"]
+----
+dbms.listTransactions
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW TRANSACTION[S] [transaction-id[,...]]
+[YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+[WHERE expression]
+[RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+----
+
+
+a|
+label:procedure[]
+label:removed[]
+
+[source, cypher, role="noheader"]
+----
+dbms.killTransaction
+----
+
+[source, cypher, role="noheader"]
+----
+dbms.killTransactions
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+TERMINATE TRANSACTION[S] transaction-id[,...]
+----
+
 |===
 
 // === Deprecated features


### PR DESCRIPTION
`dbms.listTransactions` -- removed

Use `SHOW TRANSACTIONS YIELD *` instead.

`dbms.killTransaction` -- removed
`dbms.killTransactions` -- removed

Use `TERMINATE TRANSACTION[S] transaction-id[,...]` instead.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1448