### PR TITLE
Queries procedures was deprecated in 4.4

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -251,6 +251,11 @@ label:deprecated[]
 
 [source, cypher, role="noheader"]
 ----
+dbms.killQuery
+----
+
+[source, cypher, role="noheader"]
+----
 dbms.killQueries
 ----
 a|


### PR DESCRIPTION
`dbms.listQueries` -- deprecated

Use `SHOW TRANSACTIONS YIELD *` instead.

`dbms.killQuery` -- deprecated
`dbms.killQueries` -- deprecated

Use `TERMINATE TRANSACTION[S] transaction-id[,...]` instead.

This PR is based on:

1. https://github.com/neo-technology/neo4j-manual-modeling/pull/2618
2. https://github.com/neo4j/neo4j-documentation/pull/1448