### PR TITLE
Queries procedures was deprecated in 4.4 (#54)

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -577,6 +577,46 @@ Replaced by:
 TERMINATE TRANSACTION[S] transaction-id[,...]
 ----
 
+
+a|
+label:procedure[]
+label:deprecated[]
+
+[source, cypher, role="noheader"]
+----
+dbms.listQueries
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW TRANSACTION[S] [transaction-id[,...]]
+[YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+[WHERE expression]
+[RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+----
+
+
+a|
+label:procedure[]
+label:deprecated[]
+
+[source, cypher, role="noheader"]
+----
+dbms.killQuery
+----
+
+[source, cypher, role="noheader"]
+----
+dbms.killQueries
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+TERMINATE TRANSACTION[S] transaction-id[,...]
+----
+
 |===
 
 


### PR DESCRIPTION
Queries procedures was deprecated in 4.4

`dbms.listQueries` -- deprecated

Use `SHOW TRANSACTIONS YIELD *` instead.

`dbms.killQuery` -- deprecated
`dbms.killQueries` -- deprecated

Use `TERMINATE TRANSACTION[S] transaction-id[,...]` instead.