### PR TITLE
Queries procedures was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -317,6 +317,46 @@ Replaced by:
 TERMINATE TRANSACTION[S] transaction-id[,...]
 ----
 
+
+a|
+label:procedure[]
+label:removed[]
+
+[source, cypher, role="noheader"]
+----
+dbms.listQueries
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+SHOW TRANSACTION[S] [transaction-id[,...]]
+[YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+[WHERE expression]
+[RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+----
+
+
+a|
+label:procedure[]
+label:removed[]
+
+[source, cypher, role="noheader"]
+----
+dbms.killQuery
+----
+
+[source, cypher, role="noheader"]
+----
+dbms.killQueries
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+TERMINATE TRANSACTION[S] transaction-id[,...]
+----
+
 |===
 
 // === Deprecated features


### PR DESCRIPTION
`dbms.listQueries` -- removed

Use `SHOW TRANSACTIONS YIELD *` instead.

`dbms.killQuery` -- removed
`dbms.killQueries` -- removed

Use `TERMINATE TRANSACTION[S] transaction-id[,...]` instead.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1448