### PR TITLE
New function isNaN(numeric_value) was introduced in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -401,6 +401,16 @@ label:added[]
 a|
 Cypher now supports number literals with underscores between digits.
 
+a|
+label:functionality[]
+label:added[]
+[source, cypher, role="noheader"]
+----
+isNaN(value)
+----
+a|
+The new function `isNaN` returns `true` if the given numeric value is `NaN` (Not a Number).
+
 |===
 
 

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -342,6 +342,12 @@ These functions all operate on numerical expressions only, and will return an er
 | `floor(input :: FLOAT?) :: (FLOAT?)`
 | Returns the largest floating point number that is less than or equal to a number and equal to a mathematical integer.
 
+1.2+| xref::functions/mathematical-numeric.adoc#functions-isnan[`isNaN()`]
+| `isNaN(input :: FLOAT?) :: (BOOLEAN?)`
+| Returns `true` if the floating point number is `NaN`.
+| `isNaN(input :: INTEGER?) :: (BOOLEAN?)`
+| Returns `true` if the integer number is `NaN`.
+
 1.1+| xref::functions/mathematical-numeric.adoc#functions-rand[`rand()`]
 | `rand() :: (FLOAT?)`
 | Returns a random floating point number in the range from 0 (inclusive) to 1 (exclusive); i.e. [0,1).

--- a/modules/ROOT/pages/functions/mathematical-numeric.adoc
+++ b/modules/ROOT/pages/functions/mathematical-numeric.adoc
@@ -14,6 +14,7 @@ Functions:
 * xref::functions/mathematical-numeric.adoc#functions-abs[abs()]
 * xref::functions/mathematical-numeric.adoc#functions-ceil[ceil()]
 * xref::functions/mathematical-numeric.adoc#functions-floor[floor()]
+* xref::functions/mathematical-numeric.adoc#functions-isnan[isNaN()]
 * xref::functions/mathematical-numeric.adoc#functions-rand[rand()]
 * xref::functions/mathematical-numeric.adoc#functions-round[round()]
 * xref::functions/mathematical-numeric.adoc#functions-round2[round(), with precision]
@@ -224,6 +225,70 @@ The floor of `0.9` is returned.
 | +floor(0.9)+
 | +0.0+
 1+d|Rows: 1
+|===
+
+======
+
+
+[[functions-isnan]]
+== isNaN()
+
+`isNaN()` returns `true` if the given numeric value is `NaN` (Not a Number).
+
+*Syntax:*
+
+[source, syntax, role="noheader"]
+----
+isNaN(expression)
+----
+
+*Returns:*
+
+|===
+
+| A Boolean.
+
+|===
+
+*Arguments:*
+
+[options="header"]
+|===
+| Name | Description
+
+| `expression`
+| A numeric expression.
+
+|===
+
+*Considerations:*
+
+|===
+
+| `isNaN(null)` returns `null`.
+
+|===
+
+
+.+isNaN()+
+======
+
+.Query
+[source, cypher]
+----
+RETURN isNaN(0/0.0)
+----
+
+`true` is returned since the value is `NaN`.
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| +isNaN(0/0.0)+
+| +true+
+1+d|Rows: 1
+
 |===
 
 ======

--- a/modules/ROOT/pages/keyword-glossary.adoc
+++ b/modules/ROOT/pages/keyword-glossary.adoc
@@ -650,6 +650,10 @@ xref::functions/temporal/index.adoc#functions-temporal-truncate-overview[Truncat
 | Predicate
 | Returns true if the given list or map contains no elements or if the given string contains no characters.
 
+| xref::functions/mathematical-numeric.adoc#functions-isnan[isNaN()]
+| Numeric
+| Returns `true` if the given numeric value is `NaN` (Not a Number).
+
 | xref::functions/list.adoc#functions-keys[keys()]
 | List
 | Returns a list containing the string representations for all the property names of a node, relationship, or map.


### PR DESCRIPTION
The `isNaN` function check if the given numeric value is `NaN` (Not a Number).

A numeric expression can result in a `NaN` value in certain circumstances.
For example: `0.0` divided by `0.0` is undefined.

`isNaN(2.0)` returns `false`

`isNaN(0.0/0.0)` returns `true`

`isNaN(null)` returns `null`

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1477