### PR TITLE
Automatic coercion of a list to a boolean was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -407,6 +407,23 @@ Only `+0x...+` (lowercase x) is supported.
 
 For example: `0x13af`, `0xFC3A9`, `-0x66eff`.
 
+
+a|
+label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+WHERE [1, 2, 3]
+----
+a|
+Automatic coercion of a list to a boolean is removed.
+
+Replaced by:
+[source, cypher, role="noheader"]
+----
+WHERE NOT isEmpty([1, 2, 3])
+----
+
 |===
 
 


### PR DESCRIPTION
`WHERE [1, 2, 3]` - removed

Use `WHERE NOT isEmpty([1, 2, 3])` instead.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1491