### PR TITLE
Remaining support for repeated relationship variables was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -424,6 +424,18 @@ Replaced by:
 WHERE NOT isEmpty([1, 2, 3])
 ----
 
+
+a|
+label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+MATCH ()-[r]-()
+RETURN [ ()-[r]-()-[r]-() \| r ] AS rs
+----
+a|
+Remaining support for repeated relationship variables is removed.
+
 |===
 
 


### PR DESCRIPTION
The syntax:

```
MATCH ()-[r]-()
RETURN [ ()-[r]-()-[r]-() | r ] AS rs
```

is not valid in Neo4j 5.0.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1491