### PR TITLE
Implicit EXECUTE PROCEDURE privilege was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -461,6 +461,21 @@ CREATE INDEX ...
 a|
 The default index type is changed from B-tree to range index.
 
+
+a|
+label:functionality[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+GRANT EXECUTE BOOSTED PROCEDURE ...
+----
+a|
+This is not a syntax change but a semantic one.
+
+The `EXECUTE BOOSTED PROCEDURE` privilege will no longer include an implicit `EXECUTE PROCEDURE` privilege when granted.
+
+For a role to be able to execute a procedure with boosted privileges both `EXECUTE PROCEDURE` and `EXECUTE BOOSTED PROCEDURE` are needed.
+
 |===
 
 


### PR DESCRIPTION
The `EXECUTE BOOSTED PROCEDURE` does not implicit grant the `EXECUTE PROCEDURE` privilege in Neo4j 5.0.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1470