### PR TITLE
Use case null in a CASE expression.

### DIFF
--- a/modules/ROOT/pages/syntax/expressions.adoc
+++ b/modules/ROOT/pages/syntax/expressions.adoc
@@ -407,8 +407,7 @@ CASE n.age
 END AS age_10_years_ago
 ----
 
-However, as `null = null` does not yield true, the `WHEN null THEN -1` branch is never taken,
-resulting in the `ELSE n.age - 10` branch being taken instead, returning `null`.
+However, as `null = null` does not yield `true`, the `WHEN null THEN -1` branch is never taken, resulting in the `ELSE n.age - 10` branch being taken instead, returning `null`.
 
 .Result
 [role="queryresult",options="header,footer",cols="2*<m"]


### PR DESCRIPTION
New example that explains how `null` works in a `CASE` expression.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1524