### PR TITLE
Deprecated syntax SET with a value of a node or relationship.

### DIFF
--- a/modules/ROOT/pages/clauses/set.adoc
+++ b/modules/ROOT/pages/clauses/set.adoc
@@ -8,7 +8,7 @@
 The `SET` clause is used to update labels on nodes and properties on nodes and relationships.
 --
 
-`SET` can be used with a map -- provided as a literal, a parameter, or a node or relationship -- to set properties.
+The `SET` clause can be used with a map -- provided as a literal or a parameter -- to set properties.
 
 [NOTE]
 ====
@@ -153,7 +153,7 @@ Properties set: 1
 [[set-copying-properties-between-nodes-and-relationships]]
 == Copy properties between nodes and relationships
 
-`SET` can be used to copy all properties from one node or relationship to another.
+`SET` can be used to copy all properties from one node or relationship to another using the `properties()` function.
 This will remove _all_ other properties on the node or relationship being copied to.
 
 .Query
@@ -162,7 +162,7 @@ This will remove _all_ other properties on the node or relationship being copied
 MATCH
   (at {name: 'Andy'}),
   (pn {name: 'Peter'})
-SET at = pn
+SET at = properties(pn)
 RETURN at.name, at.age, at.hungry, pn.name, pn.age
 ----
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -439,7 +439,33 @@ Remaining support for repeated relationship variables is removed.
 |===
 
 
-// === Deprecated features
+=== Deprecated features
+
+[cols="2", options="header"]
+|===
+| Feature | Details
+
+a|
+label:syntax[]
+label:deprecated[]
+[source, cypher, role="noheader"]
+----
+MATCH (n)-[r:REL]->(m)
+SET n = r
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+MATCH (n)-[r:REL]->(m)
+SET n = properties(r)
+----
+
+The `SET` clause can be used with a map -- provided as a literal or a parameter -- to set properties.
+
+Use the `properties()` function instead to get the map of properties of nodes/relationships that can then be used in a `SET` clause.
+
+|===
 
 
 // === Restricted features


### PR DESCRIPTION
The set value for setting all properties of a node or relationship must be a map.

`SET my_node = other_node` - deprecated in Neo4j 5.0.

Use `SET my_node = properties(other_node)` instead.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1532