### PR TITLE
PERIODIC COMMIT was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/clauses/call-subquery.adoc
+++ b/modules/ROOT/pages/clauses/call-subquery.adoc
@@ -411,9 +411,7 @@ This can come in handy when doing large write operations, like batch updates, im
 To execute a subquery in separate transactions, you add the modifier `IN TRANSACTIONS` after the subquery.
 
 The following example uses a CSV file and the `LOAD CSV` clause to import more data to the example graph.
-It creates nodes in separate transactions using `CALL {} IN TRANSACTIONS`:
-
-// neo4j-manual-modeling-antora/cypherManual/build/4.4/antora/modules/ROOT/examples/neo4j-cypher-docs/docs/dev/ql/csv-files/friends.csv
+It creates nodes in separate transactions using `+CALL { ... } IN TRANSACTIONS+`:
 
 .friends.csv
 [source, csv, role="noheader"]
@@ -450,7 +448,7 @@ As the size of the CSV file in this example is small, only a single separate tra
 
 [NOTE]
 ====
-`CALL { ... } IN TRANSACTIONS` is only allowed in xref::introduction/transactions.adoc[implicit transactions].
+`+CALL { ... } IN TRANSACTIONS+` is only allowed in xref::introduction/transactions.adoc[implicit transactions].
 ====
 
 
@@ -502,7 +500,7 @@ The query now starts and commits three separate transactions:
 . The last execution of the subquery (for the last input row) takes place in a third transaction.
 . The third transaction is committed.
 
-You can also use `+CALL { ... } IN TRANSACTIONS of n ROWS+` to delete all your data in batches in order to avoid a huge garbage collection or an `OutOfMemory` exception.
+You can also use `+CALL { ... } IN TRANSACTIONS OF n ROWS+` to delete all your data in batches in order to avoid a huge garbage collection or an `OutOfMemory` exception.
 For example:
 
 .Query
@@ -535,7 +533,7 @@ For larger data sets, you might want to use larger batch sizes, such as `10000 R
 
 === Errors
 
-If an error occurs in `CALL {} IN TRANSACTIONS` the entire query fails and
+If an error occurs in `+CALL { ... } IN TRANSACTIONS+` the entire query fails and
 both the current inner transaction and the outer transaction are rolled back.
 
 [IMPORTANT]

--- a/modules/ROOT/pages/clauses/index.adoc
+++ b/modules/ROOT/pages/clauses/index.adoc
@@ -43,8 +43,8 @@ m| xref::constraints/syntax.adoc[CREATE \| DROP CONSTRAINT]
 m| xref::clauses/load-csv.adoc[LOAD CSV]
 | Use when importing data from CSV files.
 
-m| --- xref::query-tuning/using.adoc#query-using-periodic-commit-hint[USING PERIODIC COMMIT]
-| This query hint may be used to prevent an out-of-memory error from occurring when importing large amounts of data using `LOAD CSV`.
+m| xref::clauses/call-subquery.adoc#subquery-call-in-transactions[`+CALL { ... } IN TRANSACTIONS+`]
+| This clause may be used to prevent an out-of-memory error from occurring when importing large amounts of data using `LOAD CSV`.
 
 |===
 

--- a/modules/ROOT/pages/clauses/load-csv.adoc
+++ b/modules/ROOT/pages/clauses/load-csv.adoc
@@ -15,7 +15,7 @@
 * xref::clauses/load-csv.adoc#load-csv-import-data-from-a-csv-file-containing-headers[Import data from a CSV file containing headers]
 * xref::clauses/load-csv.adoc#load-csv-import-data-from-a-csv-file-with-a-custom-field-delimiter[Import data from a CSV file with a custom field delimiter]
 * xref::clauses/load-csv.adoc#load-csv-importing-large-amounts-of-data[Importing large amounts of data]
-* xref::clauses/load-csv.adoc#load-csv-setting-the-rate-of-periodic-commits[Setting the rate of periodic commits]
+* xref::clauses/load-csv.adoc#load-csv-setting-the-rate-of-call-in-transactions[Setting the rate of +CALL { ... } IN TRANSACTIONS+]
 * xref::clauses/load-csv.adoc#load-csv-import-data-containing-escaped-characters[Import data containing escaped characters]
 * xref::clauses/load-csv.adoc#load-csv-using-linenumber-with-load-csv[Using linenumber() with LOAD CSV]
 * xref::clauses/load-csv.adoc#load-csv-using-file-with-load-csv[Using file() with LOAD CSV]
@@ -33,7 +33,8 @@
   Alternatively, `LOAD CSV` also supports accessing CSV files via _HTTPS_, _HTTP_, and _FTP_.
 * `LOAD CSV` supports resources compressed with _gzip_ and _Deflate_. Additionally `LOAD CSV` supports locally stored CSV files compressed with _ZIP_.
 * `LOAD CSV` will follow _HTTP_ redirects but for security reasons it will not follow redirects that changes the protocol, for example if the redirect is going from _HTTPS_ to _HTTP_.
-* `LOAD CSV` is often used in conjunction with the query hint `PERIODIC COMMIT`; more information on this may be found in xref::query-tuning/using.adoc#query-using-periodic-commit-hint[[deprecated\]#`PERIODIC COMMIT` query hint].
+* `LOAD CSV` is often used in conjunction with the query clause `+CALL { ... } IN TRANSACTIONS+`, see xref::clauses/call-subquery#subquery-call-in-transactions[].
+
 
 .Configuration settings for file URLs
 xref:5.0@operations-manual:ROOT:reference/configuration-settings/index.adoc#config_dbms.security.allow_csv_import_from_file_urls[dbms.security.allow_csv_import_from_file_urls]::
@@ -228,27 +229,33 @@ Labels added: 4
 
 [[load-csv-importing-large-amounts-of-data]]
 == Importing large amounts of data
-If the CSV file contains a significant number of rows (approaching hundreds of thousands or millions), `USING PERIODIC COMMIT` can be used to instruct Neo4j to perform a commit after a number of rows.
+
+If the CSV file contains a significant number of rows (approaching hundreds of thousands or millions), `+CALL { ... } IN TRANSACTIONS+` can be used to instruct Neo4j to commit a transaction after a number of rows.
 This reduces the memory overhead of the transaction state.
-By default, the commit happens every 1000 rows.
-Note that `PERIODIC COMMIT` is only allowed in xref::introduction/transactions.adoc[implicit (auto-commit or `:auto`) transactions].
-For more information, see xref::query-tuning/using.adoc#query-using-periodic-commit-hint[[deprecated\]#`PERIODIC COMMIT` query hint].
 
 [NOTE]
 ====
-The xref::clauses/use.adoc[`USE` clause] can not be used together with the `PERIODIC COMMIT` query hint.
+The query clause `+CALL { ... } IN TRANSACTIONS+` is only allowed in xref::introduction/transactions.adoc[implicit (auto-commit or `:auto`) transactions].
+For more information, see xref::clauses/call-subquery#subquery-call-in-transactions[].
 ====
 
-[NOTE]
-====
-Queries with the `PERIODIC COMMIT` query hint can not be routed by xref:5.0@operations-manual:ROOT:clustering/internals/index.adoc#causal-clustering-routing[Server-side routing].
-====
+.+artists.csv+
+[source, csv, role="noheader"]
+----
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+----
 
 .Query
-[source, cypher, subs=attributes+, indent=0]
+[source, cypher, subs=attributes+]
 ----
-USING PERIODIC COMMIT LOAD CSV FROM 'file:///artists.csv' AS line
-CREATE (:Artist {name: line[1], year: toInteger(line[2])})
+LOAD CSV FROM 'file:///artists.csv' AS line
+CALL {
+  WITH line
+  CREATE (:Artist {name: line[1], year: toInteger(line[2])})
+} IN TRANSACTIONS
 ----
 
 .Result
@@ -260,18 +267,33 @@ CREATE (:Artist {name: line[1], year: toInteger(line[2])})
 Nodes created: 4
 Properties set: 8
 Labels added: 4
+Transactions committed: 1
 ----
 
 
-[[load-csv-setting-the-rate-of-periodic-commits]]
-== Setting the rate of periodic commits
-You can set the number of rows as in the example, where it is set to 500 rows.
+[[load-csv-setting-the-rate-of-call-in-transactions]]
+== Setting the rate of CALL IN TRANSACTIONS
+
+You can set the number of rows as in the example, where it is set to `500` rows.
+
+
+.+artists.csv+
+[source, csv, role="noheader"]
+----
+1,ABBA,1992
+2,Roxette,1986
+3,Europe,1979
+4,The Cardigans,1992
+----
 
 .Query
-[source, cypher, subs=attributes+, indent=0]
+[source, cypher, subs=attributes+]
 ----
-USING PERIODIC COMMIT 500 LOAD CSV FROM 'file:///artists.csv' AS line
-CREATE (:Artist {name: line[1], year: toInteger(line[2])})
+LOAD CSV FROM 'file:///artists.csv' AS line
+CALL {
+  WITH line
+  CREATE (:Artist {name: line[1], year: toInteger(line[2])})
+} IN TRANSACTIONS OF 500 ROWS
 ----
 
 .Result
@@ -283,6 +305,7 @@ CREATE (:Artist {name: line[1], year: toInteger(line[2])})
 Nodes created: 4
 Properties set: 8
 Labels added: 4
+Transactions committed: 1
 ----
 
 

--- a/modules/ROOT/pages/clauses/use.adoc
+++ b/modules/ROOT/pages/clauses/use.adoc
@@ -11,11 +11,6 @@ The `USE` clause determines which graph a query, or query part, is executed agai
 The `USE` clause determines which graph a query, or query part, is executed against.
 It is supported for queries and schema commands.
 
-[NOTE]
-====
-The `USE` clause can not be used together with the xref::clauses/load-csv.adoc#load-csv-importing-large-amounts-of-data[`PERIODIC COMMIT` clause].
-====
-
 
 [[query-use-syntax]]
 == Syntax

--- a/modules/ROOT/pages/introduction/transactions.adoc
+++ b/modules/ROOT/pages/introduction/transactions.adoc
@@ -32,7 +32,7 @@ Transactions can be either _explicit_ or _implicit_.
   * Can execute a single Cypher query.
   * Are committed automatically when the query finishes successfully.
 
-Queries that start separate transactions themselves, such as queries using xref::clauses/call-subquery.adoc#subquery-call-in-transactions[`CALL { ... } IN TRANSACTIONS`] or xref::query-tuning/using.adoc#query-using-periodic-commit-hint[`PERIODIC COMMIT`] are only allowed in _implicit_ mode.
+Queries that start separate transactions themselves, such as queries using xref::clauses/call-subquery.adoc#subquery-call-in-transactions[`+CALL { ... } IN TRANSACTIONS+`], are only allowed in _implicit_ mode.
 
 For examples of the API's used to start and commit transactions, refer to the API specific documentation:
 

--- a/modules/ROOT/pages/keyword-glossary.adoc
+++ b/modules/ROOT/pages/keyword-glossary.adoc
@@ -28,9 +28,15 @@ This section comprises a glossary of all the keywords -- grouped by category and
 | Reading/Writing
 | Invoke a procedure deployed in the database.
 
-| xref::clauses/call-subquery.adoc[CALL {...}]
+| xref::clauses/call-subquery.adoc[+CALL {...}+]
 | Reading/Writing
 | Evaluates a subquery, typically used for post-union processing or aggregations.
+
+| xref::clauses/call-subquery.adoc#subquery-call-in-transactions[+CALL { ... } IN TRANSACTIONS+]
+| Reading/Writing
+a|
+Evaluates a subquery in separate transactions.
+Typically used when modifying or importing large amounts of data.
 
 | xref::clauses/create.adoc[CREATE]
 | Writing
@@ -247,10 +253,6 @@ Duplicates are retained.
 | xref::query-tuning/using.adoc#query-using-join-hint[USING JOIN ON variable]
 | Hint
 | Join hints are used to enforce a join operation at specified points.
-
-| xref::query-tuning/using.adoc#query-using-periodic-commit-hint[USING PERIODIC COMMIT]
-| Hint
-| This query hint may be used to prevent an out-of-memory error from occurring when importing large amounts of data using `LOAD CSV`.
 
 | xref::query-tuning/using.adoc#query-using-scan-hint[USING SCAN variable:Label]
 | Hint

--- a/modules/ROOT/pages/query-tuning/using.adoc
+++ b/modules/ROOT/pages/query-tuning/using.adoc
@@ -24,12 +24,11 @@ Moreover, in some circumstances (albeit rarely) it is better not to use an index
 Neo4j can be forced to use a specific starting point through the `USING` keyword.
 This is called giving a planner hint.
 
-There are four types of planner hints:
+There are three types of planner hints:
 
 * Index hints.
 * Scan hints.
 * Join hints.
-* `PERIODIC COMMIT` query hint. label:deprecated[]
 
 ////
 FOREACH(i IN range(1, 100) |
@@ -997,41 +996,4 @@ Runtime version 4.4
 
 Total database accesses: 403, total allocated memory: 4944
 ----
-
-
-[role="deprecated"]
-[[query-using-periodic-commit-hint]]
-== `PERIODIC COMMIT` query hint
-
-The `PERIODIC COMMIT` query hint will be removed in the next major release.
-It is recommended to use xref::clauses/call-subquery.adoc#subquery-call-in-transactions[`+CALL { ... } IN TRANSACTIONS+`] instead.
-
-Importing large amounts of data using xref::clauses/load-csv.adoc[`LOAD CSV`] with a single Cypher query may fail due to memory constraints.
-This will manifest itself as an `OutOfMemoryError`.
-
-For this situation _only,_ Cypher provides the global `USING PERIODIC COMMIT` query hint for updating queries using `LOAD CSV`.
-If required, the limit for the number of rows per commit may be set as follows: `USING PERIODIC COMMIT 500`.
-
-`PERIODIC COMMIT` will process the rows until the number of rows reaches a limit.
-Then the current transaction will be committed and replaced with a newly opened transaction.
-If no limit is set, a default value will be used.
-
-See xref::clauses/load-csv.adoc#load-csv-importing-large-amounts-of-data[Importing large amounts of data] in xref::clauses/load-csv.adoc[] for examples of `USING PERIODIC COMMIT` with and without setting the number of rows per commit.
-
-[IMPORTANT]
-====
-Using `PERIODIC COMMIT` will prevent running out of memory when importing large amounts of data.
-However, it will also break transactional isolation and thus it should only be used where needed.
-====
-
-[NOTE]
-====
-The xref::clauses/use.adoc[`USE` clause] can not be used together with the `PERIODIC COMMIT` query hint.
-====
-
-[NOTE]
-====
-Queries with the `PERIODIC COMMIT` query hint can not be routed by xref:5.0@operations-manual:ROOT:clustering/internals/index.adoc#causal-clustering-routing[Server-side routing].
-Such queries must rely on standard client-side routing, done by the Neo4j Driver.
-====
 

--- a/modules/ROOT/pages/syntax/reserved.adoc
+++ b/modules/ROOT/pages/syntax/reserved.adoc
@@ -97,8 +97,6 @@ If any reserved keyword is escaped -- i.e. is encapsulated by backticks ```, suc
 
 * `INDEX`
 * `JOIN`
-* `PERIODIC`
-* `COMMIT`
 * `SCAN`
 * `USING`
 


### PR DESCRIPTION
`PERIODIC COMMIT` - removed

Use `CALL { ... } IN TRANSACTIONS` instead.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1454