### PR TITLE
Property existence checking with the exists function was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/clauses/where.adoc
+++ b/modules/ROOT/pages/clauses/where.adoc
@@ -227,11 +227,6 @@ RETURN n.name, n.belt
 
 The name and belt for the *'Andy'* node are returned because he is the only one with a `belt` property.
 
-[IMPORTANT]
-====
-The `exists()` function has been deprecated for property existence checking and has been superseded by `IS NOT NULL`.
-====
-
 .Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -436,6 +436,39 @@ RETURN [ ()-[r]-()-[r]-() \| r ] AS rs
 a|
 Remaining support for repeated relationship variables is removed.
 
+
+a|
+label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+exists(prop)
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+prop IS NOT NULL
+----
+
+Check if a property is not `null`.
+
+a|
+label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+NOT exists(prop)
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+prop IS NULL
+----
+
+Check if a property is `null`.
+
 |===
 
 

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -62,7 +62,7 @@ These functions return either true or false for the given arguments.
 
 1.1+| xref::functions/predicate.adoc#functions-exists[`exists()`]
 | `exists(input :: ANY?) :: (BOOLEAN?)`
-| Returns true if a match for the pattern exists in the graph, or if the specified property exists in the node, relationship or map.
+| Returns `true` if a match for the pattern exists in the graph.
 
 1.3+| xref::functions/predicate.adoc#functions-isempty[`isEmpty()`]
 | `isEmpty(input :: LIST? OF ANY?) :: (BOOLEAN?)`

--- a/modules/ROOT/pages/functions/predicate.adoc
+++ b/modules/ROOT/pages/functions/predicate.adoc
@@ -180,14 +180,20 @@ The query returns nodes with the property `liked_colors` (as a list), where at l
 [[functions-exists]]
 == exists()
 
-The function `exists()` returns `true` if a match for the given pattern exists in the graph, or if the specified property exists in the node, relationship or map.
+The function `exists()` returns `true` if a match for the given pattern exists in the graph.
+
 `null` is returned if the input argument is `null`.
+
+[NOTE]
+====
+To check if a property is not `null` use the xref::syntax/operators.adoc#cypher-comparison[`IS NOT NULL` predicate].
+====
 
 *Syntax:*
 
 [source, syntax, role="noheader"]
 ----
-exists(pattern-or-property)
+exists(pattern)
 ----
 
 *Returns:*
@@ -204,8 +210,8 @@ exists(pattern-or-property)
 |===
 | Name | Description
 
-| `pattern-or-property`
-| A pattern or a property (in the form 'variable.prop').
+| `pattern`
+| A pattern.
 
 |===
 
@@ -241,49 +247,11 @@ The names of all nodes with the `name` property are returned, along with a boole
 
 ======
 
-
-.+exists()+
-======
-
-.Query
-[source, cypher, indent=0]
-----
-MATCH
-  (a),
-  (b)
-WHERE
-  exists(a.name)
-  AND NOT exists(b.name)
-OPTIONAL MATCH (c:DoesNotExist)
-RETURN
-  a.name AS a_name,
-  b.name AS b_name,
-  exists(b.name) AS b_has_name,
-  c.name AS c_name,
-  exists(c.name) AS c_has_name
-ORDER BY a_name, b_name, c_name
-LIMIT 1
-----
-
-Three nodes are returned: one with a property `name`, one without a property `name`, and one that does not exist (e.g., is `null`).
-This query exemplifies the behavior of `exists()` when operating on `null` nodes.
-
-.Result
-[role="queryresult",options="header,footer",cols="5*<m"]
-|===
-
-| +a_name+ | +b_name+ | +b_has_name+ | +c_name+ | +c_has_name+
-| +"Alice"+ | +<null>+ | +false+ | +<null>+ | +<null>+
-5+d|Rows: 1
-
-|===
-
-======
-
 [NOTE]
 ====
-Note that the `exists()` function is deprecated for property input.
-Please use the xref::syntax/operators.adoc#cypher-comparison[`IS NOT NULL` predicate] instead.
+The *function* `exists()` looks very similar to the *clause* `+EXISTS { ... }+`, but they are not related.
+
+See xref::clauses/where.adoc#existential-subqueries[Using existential subqueries in `WHERE`] for more information.
 ====
 
 

--- a/modules/ROOT/pages/keyword-glossary.adoc
+++ b/modules/ROOT/pages/keyword-glossary.adoc
@@ -626,7 +626,7 @@ xref::functions/temporal/index.adoc#functions-temporal-truncate-overview[Truncat
 
 | xref::functions/predicate.adoc#functions-exists[exists()]
 | Predicate
-| Returns true if a match for the pattern exists in the graph, or if the specified property exists in the node, relationship or map.
+| Returns `true` if a match for the pattern exists in the graph.
 
 | xref::functions/mathematical-logarithmic.adoc#functions-exp[exp()]
 | Logarithmic


### PR DESCRIPTION
`exists(property)` - removed

Use `property IS NOT NULL` instead.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1451