### PR TITLE
New outputs for show transactions

### DIFF
--- a/modules/ROOT/pages/clauses/transaction-clauses.adoc
+++ b/modules/ROOT/pages/clauses/transaction-clauses.adoc
@@ -97,9 +97,9 @@ a| The indexes utilised by the query currently executing in this transaction, or
 m| LIST OF MAP
 
 // New in 5.0
-// m| currentQueryStartTime
-// a| The time at which the query currently executing in this transaction was started, or an empty string if no query is currently executing.
-// m| STRING
+m| currentQueryStartTime
+a| The time at which the query currently executing in this transaction was started, or an empty string if no query is currently executing.
+m| STRING
 
 m| protocol
 a|
@@ -113,9 +113,9 @@ a| The request URI used by the client connection issuing the transaction, or `nu
 m| STRING
 
 // New in 5.0
-// m| currentQueryStatus
-// a| The current status of the query currently executing in this transaction (`parsing`, `planning`, `planned`, `running`, or `waiting`), or an empty string if no query is currently executing.
-// m| STRING
+m| currentQueryStatus
+a| The current status of the query currently executing in this transaction (`parsing`, `planning`, `planned`, `running`, or `waiting`), or an empty string if no query is currently executing.
+m| STRING
 
 m| statusDetails
 a| Provide additional status details from the underlying transaction or an empty string if none is available.
@@ -127,6 +127,11 @@ m| MAP
 
 m| activeLockCount
 a| Count of active locks held by the transaction.
+m| LONG
+
+// New in 5.0
+m| currentQueryActiveLockCount
+a| Count of active locks held by the query currently executing in this transaction.
 m| LONG
 
 m| cpuTime
@@ -142,29 +147,29 @@ a| Idle time for this transaction, or `null` if unavailable.
 m| DURATION
 
 // New in 5.0
-// m| currentQueryElapsedTime
-// a| The time that has elapsed since the query currently executing in this transaction was started, or `null` if no query is currently executing.
-// m| DURATION
+m| currentQueryElapsedTime
+a| The time that has elapsed since the query currently executing in this transaction was started, or `null` if no query is currently executing.
+m| DURATION
 
 // New in 5.0
-// m| currentQueryCpuTime
-// a| CPU time that has been actively spent executing the query currently executing in this transaction, or `null` if unavailable or no query is currently executing.
-// m| DURATION
+m| currentQueryCpuTime
+a| CPU time that has been actively spent executing the query currently executing in this transaction, or `null` if unavailable or no query is currently executing.
+m| DURATION
 
 // New in 5.0
-// m| currentQueryWaitTime
-// a| Wait time that has been spent waiting to acquire locks for the query currently executing in this transaction, or `null` if no query is currently executing.
-// m| DURATION
+m| currentQueryWaitTime
+a| Wait time that has been spent waiting to acquire locks for the query currently executing in this transaction, or `null` if no query is currently executing.
+m| DURATION
 
 // New in 5.0
-// m| currentQueryIdleTime
-// a| Idle time for the query currently executing in this transaction, or `null` if unavailable or no query is currently executing.
-// m| LONG
+m| currentQueryIdleTime
+a| Idle time for the query currently executing in this transaction, or `null` if unavailable or no query is currently executing.
+m| LONG
 
 // New in 5.0
-// m| currentQueryAllocatedBytes
-// a| The number of bytes allocated on the heap so far by the query currently executing in this transaction, or `null` if unavailable or no query is currently executing.
-// m| LONG
+m| currentQueryAllocatedBytes
+a| The number of bytes allocated on the heap so far by the query currently executing in this transaction, or `null` if unavailable or no query is currently executing.
+m| LONG
 
 m| allocatedDirectBytes
 a| Amount of off-heap (native) memory allocated by the transaction in bytes or `null` if unavailable.
@@ -183,14 +188,14 @@ a| The total number of page cache faults that the transaction performed.
 m| LONG
 
 // New in 5.0
-// m| currentQueryPageHits
-// a| The total number of page cache hits that the query currently executing in this transaction performed.
-// m| LONG
+m| currentQueryPageHits
+a| The total number of page cache hits that the query currently executing in this transaction performed.
+m| LONG
 
 // New in 5.0
-// m| currentQueryPageFaults
-// a| The total number of page cache faults that the query currently executing in this transaction performed.
-// m| LONG
+m| currentQueryPageFaults
+a| The total number of page cache faults that the query currently executing in this transaction performed.
+m| LONG
 
 m| initializationStackTrace
 a| The initialization stacktrace for this transaction, or an empty string if unavailable.
@@ -271,28 +276,31 @@ Several of the output columns have the `duration` type, which can be hard to rea
 They can instead be returned in a more readable format:
 
 .Query
-[source, cypher, indent=0]
+[source, cypher]
 ----
 SHOW TRANSACTIONS
-YIELD transactionId, elapsedTime, cpuTime, waitTime, idleTime
+YIELD transactionId, elapsedTime, cpuTime, waitTime, idleTime,
+  currentQueryElapsedTime, currentQueryCpuTime, currentQueryWaitTime, currentQueryIdleTime
 RETURN
   transactionId AS txId,
   elapsedTime.milliseconds AS elapsedTimeMillis,
   cpuTime.milliseconds AS cpuTimeMillis,
   waitTime.milliseconds AS waitTimeMillis,
-  idleTime.seconds AS idleTimeSeconds
+  idleTime.seconds AS idleTimeSeconds,
+  currentQueryElapsedTime.milliseconds AS currentQueryElapsedTimeMillis,
+  currentQueryCpuTime.milliseconds AS currentQueryCpuTimeMillis,
+  currentQueryWaitTime.microseconds AS currentQueryWaitTimeMicros,
+  currentQueryIdleTime.seconds AS currentQueryIdleTimeSeconds
 ----
 
 .Result
-[role="queryresult",options="header,footer",cols="5*<m"]
+[role="queryresult",options="header,footer",cols="9*<m"]
 |===
-| +txId+ | +elapsedTimeMillis+ | +cpuTimeMillis+ | +waitTimeMillis+ | +idleTimeSeconds+
-
-| +"neo4j-transaction-5"+ | +692+ | +19+ | +0+ | +0+
-| +"neo4j-transaction-4"+ | +700+ | +577+ | +0+ | +0+
-| +"neo4j-transaction-9"+ | +113+ | +110+ | +0+ | +0+
-
-5+d|Rows: 3
+| +txId+ | +elapsedTimeMillis+ | +cpuTimeMillis+ | +waitTimeMillis+ | +idleTimeSeconds+ | +currentQueryElapsedTimeMillis+ | +currentQueryCpuTimeMillis+ | +currentQueryWaitTimeMicros+ | +currentQueryIdleTimeSeconds+
+| +"neo4j-transaction-5"+ | +1055+ | +767+ | +0+ | +0+ | +1012+ | +767+ | +0+ | +0+
+| +"neo4j-transaction-9"+ | +156+ | +155+ | +0+ | +0+ | +97+ | +97+ | +0+ | +0+
+| +"neo4j-transaction-4"+ | +1082+ | +17+ | +0+ | +1+ | +1013+ | +17+ | +0+ | +0+
+9+d|Rows: 3
 |===
 
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -543,6 +543,28 @@ label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
 ----
+SHOW TRANSACTIONS YIELD *
+----
+a|
+New outputs for the `SHOW TRANSACTIONS YIELD *` command.
+
+* `currentQueryStartTime`
+* `currentQueryStatus`
+* `currentQueryActiveLockCount`
+* `currentQueryElapsedTime`
+* `currentQueryCpuTime`
+* `currentQueryWaitTime`
+* `currentQueryIdleTime`
+* `currentQueryAllocatedBytes`
+* `currentQueryPageHits`
+* `currentQueryPageFaults`
+
+
+a|
+label:functionality[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
 GRANT EXECUTE BOOSTED PROCEDURE ...
 ----
 a|


### PR DESCRIPTION
`SHOW TRANSACTIONS YIELD *` has new outputs in 5.0

* `currentQueryStartTime`
* `currentQueryStatus`
* `currentQueryActiveLockCount`
* `currentQueryElapsedTime`
* `currentQueryCpuTime`
* `currentQueryWaitTime`
* `currentQueryIdleTime`
* `currentQueryAllocatedBytes`
* `currentQueryPageHits`
* `currentQueryPageFaults`

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1461 