### PR TITLE
TERMINATE TRANSACTIONS YIELD was added in 5.0

### DIFF
--- a/modules/ROOT/pages/clauses/transaction-clauses.adoc
+++ b/modules/ROOT/pages/clauses/transaction-clauses.adoc
@@ -21,7 +21,7 @@ The command `SHOW TRANSACTIONS` returns only the default output. For a full outp
 Full output: `SHOW TRANSACTIONS YIELD *`.
 ====
 
-This command will produce a table with the following columns:
+This command returns the following outputs:
 
 .List transactions output
 [options="header", cols="4,6,2"]
@@ -229,8 +229,8 @@ All users may view all of their own currently executing transactions.
 
 === Listing all transactions
 
-To list all available transactions with the default output columns, use the `SHOW TRANSACTIONS` command.
-If all columns are required, use `SHOW TRANSACTIONS YIELD *`.
+To list all available transactions with the default outputs, use the `SHOW TRANSACTIONS` command.
+If all outputs are required, use `SHOW TRANSACTIONS YIELD *`.
 
 .Query
 [source, cypher, indent=0]
@@ -250,7 +250,7 @@ SHOW TRANSACTIONS
 |===
 
 
-=== Listing transactions with filtering on output columns
+=== Listing transactions with filtering on output
 
 The listed transactions can be filtered by using the `WHERE` clause.
 For example, getting the databases for all transactions where the currently executing query contains `'Mark'`:
@@ -272,7 +272,7 @@ SHOW TRANSACTIONS YIELD database, currentQuery WHERE currentQuery contains 'Mark
 2+d|Rows: 2
 |===
 
-Several of the output columns have the `duration` type, which can be hard to read.
+Several of the outputs have the `duration` type, which can be hard to read.
 They can instead be returned in a more readable format:
 
 .Query
@@ -330,24 +330,30 @@ SHOW TRANSACTIONS "neo4j-transaction-3"
 
 The `TERMINATE TRANSACTIONS` command is used to terminate running transactions by their IDs.
 
-This command will produce a table with the following columns:
+[NOTE]
+====
+The outputs for the `TERMINATE TRANSACTIONS` command there is no difference between the default output and full output (`YIELD *`), all outputs are default.
+====
+
+This command returns the following outputs:
 
 .Terminate transactions output
 [options="header", cols="4,6,2"]
 |===
 | Column | Description | Type
 
-m|transactionId
-a|The transaction ID.
-m|STRING
+m| transactionId
+a| The transaction ID.
+m| STRING
 
-m|username
-a|The username of the user executing the transaction.
-m|STRING
+m| username
+a| The username of the user executing the transaction.
+m| STRING
 
-m|message
-a|The result of the `TERMINATE TRANSACTION` command as applied to this transaction.
-m|STRING
+m| message
+a| The result of the `TERMINATE TRANSACTION` command as applied to this transaction.
+m| STRING
+
 |===
 
 
@@ -358,9 +364,21 @@ Terminate transactions by ID on the current server::
 [source, cypher, role="noheader", indent=0]
 ----
 TERMINATE TRANSACTION[S] transaction_id[, ...]
+[YIELD { * \| field[, ...] }
+  [ORDER BY field[, ...]]
+  [SKIP n]
+  [LIMIT n]
+  [WHERE expression]
+  [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+]
 ----
 
 The format of `transaction-id` is `<databaseName>-transaction-<id>`. Transaction IDs must be supplied as a comma-separated list of one or more quoted strings, a string parameter, or a list parameter.
+
+[NOTE]
+====
+When using the `WHERE` or `RETURN` clauses, the `YIELD` clause is mandatory and must not be omitted.
+====
 
 A user with the xref::access-control/database-administration.adoc#access-control-database-administration-transaction[`TERMINATE TRANSACTION`] privilege can terminate transactions in accordance with the privilege grants.
 All users may terminate their own currently executing transactions.
@@ -386,4 +404,54 @@ TERMINATE TRANSACTIONS "neo4j-transaction-1","neo4j-transaction-2"
 
 3+d|Rows: 2
 |===
+
+
+=== Terminate transactions with filtering on output
+
+The output from the `TERMINATE TRANSACTIONS` command can be filtered using the `YIELD` and `WHERE` clauses.
+
+
+.+TERMINATE TRANSACTION YIELD+
+======
+For example, returning the transaction IDs and message for the transactions that did not terminate.
+
+.Query
+[source, cypher]
+----
+TERMINATE TRANSACTIONS "neo4j-transaction-1","neo4j-transaction-2"
+YIELD transactionId, message
+WHERE message <> "Transaction terminated."
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="2*<m"]
+|===
+| +transactionId+ | +message+
+| +"neo4j-transaction-2"+ | +"Transaction not found."+
+2+d|Rows: 1
+|===
+
+======
+
+
+.+TERMINATE TRANSACTION error+
+======
+
+In difference to `SHOW TRANSACTIONS`; the `TERMINATE TRANSACTIONS` does not allow `WHERE` without `YIELD`.
+
+.Query
+[source, cypher]
+----
+TERMINATE TRANSACTIONS "neo4j-transaction-1","neo4j-transaction-2"
+WHERE message <> "Transaction terminated."
+----
+
+[source, error, role="noheader"]
+----
+`WHERE` is not allowed by itself, please use `TERMINATE TRANSACTION ... YIELD ... WHERE ...` instead (line 2, column 1 (offset: 67)) +
+"WHERE message <> "Transaction terminated."" +
+ ^
+----
+
+======
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -565,6 +565,25 @@ label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
 ----
+TERMINATE TRANSACTION[S] transaction-id[,...]
+YIELD { * \| field[, ...] }
+[ORDER BY field[, ...]]
+[SKIP n]
+[LIMIT n]
+[WHERE expression]
+[RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+----
+a|
+The `TERMINATE TRANSACTIONS` command now allows yielding (`YIELD`) outputs.
+
+Note for the `TERMINATE TRANSACTIONS` command; when using the `WHERE` or `RETURN` clauses, the `YIELD` clause is mandatory and must not be omitted.
+
+
+a|
+label:functionality[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
 GRANT EXECUTE BOOSTED PROCEDURE ...
 ----
 a|


### PR DESCRIPTION
It is now possible to `YIELD` outputs for the `TERMINATE TRANSACTIONS` command.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1461