### PR TITLE
Execution plan UnionNodeByLabelsScan was introduced in 5.0

### DIFF
--- a/modules/ROOT/pages/execution-plans/operators.adoc
+++ b/modules/ROOT/pages/execution-plans/operators.adoc
@@ -588,6 +588,47 @@ Total database accesses: 61, total allocated memory: 176
 ======
 
 
+[[query-plan-union-node-by-labels-scan]]
+== Union Node By Labels Scan
+// UnionNodeByLabelsScan
+// New in 5.0
+
+The `UnionNodeByLabelsScan` operator fetches all nodes that have at least one of the provided labels from the node label index.
+
+////
+CREATE LOOKUP INDEX lookup_index_name FOR (n) ON EACH labels(n)
+////
+
+.Query
+[source,cypher]
+----
+MATCH (countryOrLocation:Country|Location)
+RETURN countryOrLocation
+----
+
+.Query Plan
+[source]
+----
+Planner COST
+
+Runtime PIPELINED
+
+Runtime version 5.0
+
+Batch size 128
+
++------------------------+------------------------------------+----------------+------+---------+----------------+------------------------+-----------+-----------------------+---------------------+
+| Operator               | Details                            | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Ordered by            | Pipeline            |
++------------------------+------------------------------------+----------------+------+---------+----------------+------------------------+-----------+-----------------------+---------------------+
+| +ProduceResults        | countryOrLocation                  |             17 |   11 |       0 |                |                        |           |                       |                     |
+| |                      +------------------------------------+----------------+------+---------+----------------+                        |           |                       |                     |
+| +UnionNodeByLabelsScan | countryOrLocation:Country|Location |             17 |   11 |      13 |            120 |                    3/1 |     0.660 | countryOrLocation ASC | Fused in Pipeline 0 |
++------------------------+------------------------------------+----------------+------+---------+----------------+------------------------+-----------+-----------------------+---------------------+
+
+Total database accesses: 13, total allocated memory: 184
+----
+
+
 [[query-plan-directed-relationship-type-scan]]
 == Directed Relationship Type Scan
 // DirectedRelationshipTypeScan

--- a/modules/ROOT/pages/query-tuning/using.adoc
+++ b/modules/ROOT/pages/query-tuning/using.adoc
@@ -720,7 +720,7 @@ Total database accesses: 405, total allocated memory: 200
 === Query using multiple scan hints with a disjunction
 
 Supplying multiple scan hints can also be useful if the query contains a disjunction (`OR`) in the `WHERE` clause.
-This makes sure that all involved label predicates are solved by a `NodeByLabelScan` and the results are joined together with a `Union` and a `Distinct` afterwards.
+This makes sure that all involved label predicates are solved by a `UnionNodeByLabelsScan`.
 
 ////
 FOREACH(i IN range(1, 100) |


### PR DESCRIPTION
`UnionNodeByLabelsScan`

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1496