### PR TITLE
Specifying a cypher version has been removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -28,6 +28,21 @@ label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
 ----
+CYPHER 3.5
+...
+----
+a|
+The ability to specify a cypher version has been removed.
+
+* Prepending a query with a cypher version option (for example `CYPHER 3.5`) has been removed.
+* The configuration `cypher.default_language_version` has been removed.
+
+
+a|
+label:functionality[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
 DROP INDEX ON :Label(prop)
 ----
 a|
@@ -2626,7 +2641,7 @@ label:removed[]
 CREATE UNIQUE
 ----
 a|
-Running queries with this clause will cause a syntax error. Running with `CYPHER 3.5` will cause a runtime error due to the removal of the rule planner.
+Running queries with this clause will cause a syntax error.
 
 
 a|
@@ -2637,7 +2652,7 @@ label:removed[]
 START
 ----
 a|
-Running queries with this clause will cause a syntax error. Running with `CYPHER 3.5` will cause a runtime error due to the removal of the rule planner.
+Running queries with this clause will cause a syntax error.
 
 
 a|
@@ -3408,65 +3423,3 @@ a| See xref::functions/spatial.adoc#functions-distance[`distance()`].
 
 |===
 
-
-[[cypher-compatibility]]
-== Compatibility
-
-[NOTE]
-====
-Neo4j’s ability to support multiple older versions of the Cypher language has changed over time.
-In versions prior to Neo4j 3.4, the backwards compatibility layer included the Cypher language parser, planner, and runtime.
-All supported versions of Cypher ran on the same Neo4j kernel.
-However, this changed in Neo4j 3.4 when the runtime was excluded from the compatibility layer.
-When you run, e.g. a `CYPHER 3.1` query in Neo4j 3.5, the query is planned with the 3.1 planner, but run with 3.5 runtime and kernel.
-The compatibility layer changed again in Neo4j 4.0 and it now includes only the Cypher language parser.
-When you run a `CYPHER 3.5` query, e.g., in Neo4j 4.4, Neo4j parses the older language features, but uses the 4.4 planner, runtime, and kernel to plan and run the query.
-The primary reason for these changes is the optimizations in the Cypher runtime to allow Cypher queries to perform better.
-====
-
-Older versions of the language can still be accessed if required.
-There are two ways to select which version to use in queries.
-
-. Setting a version for all queries:
-You can configure your database with the configuration parameter `cypher.default_language_version`, and enter which version you'd like to use (see xref::deprecations-additions-removals-compatibility.adoc#cypher-versions[]).
-Every Cypher query will use this version, provided the query hasn't explicitly been configured as described in the next item below.
-
-. Setting a version on a query by query basis:
-The other method is to set the version for a particular query.
-Prepending a query with `CYPHER 3.5` will execute the query with the version of Cypher included in Neo4j 3.5.
-
-Below is an example using the older parameter syntax `+{param}+`:
-
-[source, cypher, role="nocopy,norun"]
-----
-CYPHER 3.5
-MATCH (n:Person)
-WHERE n.age > {agelimit}
-RETURN n.name, n.age
-----
-
-Without the `CYPHER 3.5` prefix this query would fail with a syntax error. With `CYPHER 3.5` however, it will only generate a warning and still work.
-
-[WARNING]
-====
-In Neo4j {neo4j-version} the Cypher parser understands some older language features, even if they are no longer supported by the Neo4j kernel.
-These features result in runtime errors.
-See the table at xref::deprecations-additions-removals-compatibility.adoc#cypher-deprecations-additions-removals-4.0[Cypher Version 4.0] for the list of affected features.
-====
-
-
-[[cypher-versions]]
-== Supported language versions
-
-Neo4j {neo4j-version} supports the following versions of the Cypher language:
-
-* Neo4j Cypher 3.5
-* Neo4j Cypher 4.3
-* Neo4j Cypher 4.4
-
-[TIP]
-====
-Each release of Neo4j supports a limited number of old Cypher Language Versions.
-When you upgrade to a new release of Neo4j, please make sure that it supports the Cypher language version you need.
-If not, you may need to modify your queries to work with a newer Cypher language version.
-====

--- a/modules/ROOT/pages/query-tuning/query-options.adoc
+++ b/modules/ROOT/pages/query-tuning/query-options.adoc
@@ -9,52 +9,13 @@ This section describes the query options available in Cypher.
 --
 
 Query execution can be fine-tuned through the use of query options.
-In order to use one or more of these options, the query must be prepended with `CYPHER`, followed by the query option(s), as exemplified thus: `CYPHER query-option [further-query-options] query`.
 
+In order to use one or more of these options, the query must be prepended with `CYPHER`, followed by the query option(s), as exemplified thus:
 
-[[cypher-version]]
-== Cypher version
-
-Occasionally, there is a requirement to use a previous version of the Cypher compiler when running a query.
-
-Here we detail the available versions:
-
-[options="header",cols="1m,3a,^1a"]
-|===
-| Query option | Description | Default
-
-| 3.5
-| This will force the query to use Neo4j Cypher 3.5.
-|
-
-| 4.2
-| This will force the query to use Neo4j Cypher 4.2.
-|
-
-| 4.3
-| This will force the query to use Neo4j Cypher 4.3.
-|
-
-| 4.4
-| This will force the query to use Neo4j Cypher 4.4.
-|
-
-| 5.0
-a|
-This will force the query to use Neo4j Cypher 5.0.
-As this is the default version, it is not necessary to use this option explicitly.
-a| {check-mark}
-
-|===
-
-
-[WARNING]
-====
-In Neo4j {neo4j-version}, the support for Cypher 3.5 is provided only at the parser level.
-The consequence is that some underlying features available in Neo4j 3.5 are no longer available and will result in runtime errors.
-
-Please refer to the discussion in xref::deprecations-additions-removals-compatibility.adoc#cypher-compatibility[Cypher Compatibility] for more information on which features are affected.
-====
+[source, syntax, role="noheader"]
+----
+CYPHER query-option [further-query-options] query
+----
 
 
 [[cypher-runtime]]

--- a/modules/ROOT/pages/syntax/parameters.adoc
+++ b/modules/ROOT/pages/syntax/parameters.adoc
@@ -42,14 +42,6 @@ For example:
 We provide below a comprehensive list of examples of parameter usage.
 In these examples, parameters are given in JSON; the exact manner in which they are to be submitted depends upon the driver being used.
 
-[NOTE]
-====
-The old parameter syntax `+{param}+` was deprecated in Neo4j 3.0 and removed entirely in Neo4j 4.0.
-Using it will result in a syntax error.
-However, it is still possible to use it, with warnings, if you prefix the query with `CYPHER 3.5`.
-See xref::deprecations-additions-removals-compatibility.adoc#cypher-compatibility[Cypher Compatibility] for further information.
-====
-
 
 [[cypher-parameters-auto-parameterization]]
 == Auto-parameterization
@@ -69,8 +61,6 @@ This means that any remaining literals will not be turned into parameters.
 [[cypher-parameters-string-literal]]
 == String literal
 
-// neo4j-manual-modeling-antora/cypherManual/build/4.4/antora/modules/ROOT/partials/neo4j-cypher-docs/docs/dev/syntax/includes/exampleWithStringLiteralAsParameter.adoc
-
 .Parameters
 [source,javascript, indent=0]
 ----
@@ -88,8 +78,6 @@ RETURN n
 ----
 
 You can use parameters in this syntax as well:
-
-// neo4j-manual-modeling-antora/cypherManual/build/4.4/antora/modules/ROOT/partials/neo4j-cypher-docs/docs/dev/syntax/includes/exampleWithShortSyntaxStringLiteralAsParameter.adoc
 
 .Parameters
 [source,javascript, indent=0]
@@ -110,8 +98,6 @@ RETURN n
 [[cypher-parameters-regular-expression]]
 == Regular expression
 
-// neo4j-manual-modeling-antora/cypherManual/build/4.4/antora/modules/ROOT/partials/neo4j-cypher-docs/docs/dev/syntax/includes/exampleWithParameterRegularExpression.adoc
-
 .Parameters
 [source,javascript, indent=0]
 ----
@@ -131,8 +117,6 @@ RETURN n.name
 
 [[cypher-parameters-case-sensitive-pattern-matching]]
 == Case-sensitive string pattern matching
-
-// neo4j-manual-modeling-antora/cypherManual/build/4.4/antora/modules/ROOT/partials/neo4j-cypher-docs/docs/dev/syntax/includes/exampleWithParameterCSCIStringPatternMatching.adoc
 
 .Parameters
 [source,javascript, indent=0]
@@ -175,8 +159,6 @@ CREATE ($props)
 [[cypher-parameters-create-multiple-nodes-with-properties]]
 == Create multiple nodes with properties
 
-// neo4j-manual-modeling-antora/cypherManual/build/4.4/antora/modules/ROOT/partials/neo4j-cypher-docs/docs/dev/syntax/includes/create_multiple_nodes_from_map.adoc
-
 .Parameters
 [source,javascript, indent=0]
 ----
@@ -208,8 +190,6 @@ RETURN n
 
 Note that this will replace all the current properties.
 
-// neo4j-manual-modeling-antora/cypherManual/build/4.4/antora/modules/ROOT/partials/neo4j-cypher-docs/docs/dev/syntax/includes/set_properties_on_a_node_from_a_map.adoc
-
 .Parameters
 [source,javascript, indent=0]
 ----
@@ -233,8 +213,6 @@ SET n = $props
 [[cypher-parameters-skip-and-limit]]
 == `SKIP` and `LIMIT`
 
-// neo4j-manual-modeling-antora/cypherManual/build/4.4/antora/modules/ROOT/partials/neo4j-cypher-docs/docs/dev/syntax/includes/exampleWithParameterForSkipLimit.adoc
-
 .Parameters
 [source,javascript, indent=0]
 ----
@@ -256,8 +234,6 @@ LIMIT $l
 
 [[cypher-parameters-node-id]]
 == Node id
-
-// neo4j-manual-modeling-antora/cypherManual/build/4.4/antora/modules/ROOT/partials/neo4j-cypher-docs/docs/dev/syntax/includes/exampleWithParameterForNodeId.adoc
 
 .Parameters
 [source,javascript, indent=0]


### PR DESCRIPTION
In Neo4j 5.0 the ability to change Cypher Versions by prepending queries with `CYPHER X.Y` or using the config setting `cypher.default_language_version` has been removed.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1503