### PR TITLE
ShortestPath without varlength relationship was deprecated in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -620,6 +620,26 @@ Use the `properties()` function instead to get the map of properties of nodes/re
 
 
 a|
+label:syntax[]
+label:deprecated[]
+[source, cypher, role="noheader"]
+----
+MATCH (a), (b), allShortestPaths((a)-[r]->(b)) RETURN b
+
+MATCH (a), (b), shortestPath((a)-[r]->(b)) RETURN b
+----
+a|
+The `shortestPath` and `allShortestPaths` functions without xref::syntax/patterns.adoc#cypher-pattern-varlength[variable-length relationship] are deprecated.
+
+Instead, use a `MATCH` with a `LIMIT` of `1` or:
+
+[source, cypher, role="noheader"]
+----
+MATCH (a), (b), shortestPath((a)-[r*1..1]->(b)) RETURN b
+----
+
+
+a|
 label:functionality[]
 label:deprecated[]
 [source, cypher, role="noheader"]


### PR DESCRIPTION
`shortestPath`

`MATCH (a), (b), shortestPath((a)-[r]->(b)) RETURN b` - deprecated

`allShortestPaths`

`MATCH (a), (b), allShortestPaths((a)-[r]->(b)) RETURN b` - deprecated

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1561