### PR TITLE
USING BTREE INDEX was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -220,6 +220,23 @@ The `ownedIndexId` output has been removed and replaced by the new `ownedIndex` 
 
 
 a|
+label:functionality[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+USING BTREE INDEX
+----
+a|
+B-tree index (`BTREE INDEX`) has been removed.
+
+Replaced by:
+[source, cypher, role="noheader"]
+----
+USING {POINT \| RANGE \| TEXT} INDEX
+----
+
+
+a|
 label:syntax[]
 label:removed[]
 [source, cypher, role="noheader"]


### PR DESCRIPTION
The `BTREE INDEX` was removed in 5.0.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1533