### PR TITLE
The distance function was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -237,6 +237,21 @@ USING {POINT \| RANGE \| TEXT} INDEX
 
 
 a|
+label:functionality[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+distance(n.prop, point({x:0, y:0})
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+point.distance(n.prop, point({x:0, y:0})
+----
+
+
+a|
 label:syntax[]
 label:removed[]
 [source, cypher, role="noheader"]


### PR DESCRIPTION
`distance()` - removed

Use the `point.distance()` function instead.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1533