### PR TITLE
Operators for spatial points was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -252,6 +252,23 @@ point.distance(n.prop, point({x:0, y:0})
 
 
 a|
+label:functionality[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+point({x:0, y:0}) <= point({x:1, y:1}) <= point({x:2, y:2})
+----
+a|
+The ability to use operators `+<+`, `+<=+`, `+>+`, and `+>=+` on spatial points is removed.
+
+Instead, use:
+[source, cypher, role="noheader"]
+----
+point.withinBBox(point({x:1, y:1}), point({x:0, y:0}), point({x:2, y:2}))
+----
+
+
+a|
 label:syntax[]
 label:removed[]
 [source, cypher, role="noheader"]


### PR DESCRIPTION
The ability to use operators `<`, `<=`, `>`, and `>=` on spatial points was removed in 5.0.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1533