### PR TITLE
Removed syntax for referencing an introduced variable in the same pattern

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -290,6 +290,17 @@ label:syntax[]
 label:removed[]
 [source, cypher, role="noheader"]
 ----
+CREATE (a {prop:7})-[r:R]->(b {prop: a.prop})
+----
+a|
+It is no longer allowed to have `CREATE` clauses in which a variable introduced in the pattern is also referenced from the same pattern.
+
+
+a|
+label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
 SHOW INDEXES BRIEF
 ----
 a|


### PR DESCRIPTION
`CREATE (a {prop:7})-[r:R]->(b {prop: a.prop})` - syntax removed

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1533