### PR TITLE
Unaliased expression in RETURN subquery clause was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -301,6 +301,23 @@ label:syntax[]
 label:removed[]
 [source, cypher, role="noheader"]
 ----
+CALL { RETURN 1 }
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+CALL { RETURN 1 AS one }
+----
+
+Unaliased expressions are no longer supported in subquery `RETURN` clauses.
+
+
+a|
+label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
 SHOW INDEXES BRIEF
 ----
 a|


### PR DESCRIPTION
`CALL { RETURN 1 }` - syntax removed

Use `CALL { RETURN 1 AS example }` instead.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1533