### PR TITLE
Pattern expressions producing lists of paths was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -318,6 +318,23 @@ label:syntax[]
 label:removed[]
 [source, cypher, role="noheader"]
 ----
+MATCH (a) RETURN (a)--()
+----
+a|
+Pattern expressions producing lists of paths are no longer supported, but they can still be used as existence predicates, for example in `WHERE` clauses.
+
+Instead, use a pattern comprehension:
+[source, cypher, role="noheader"]
+----
+MATCH (a) RETURN [p=(a)--() \| p]
+----
+
+
+a|
+label:syntax[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
 SHOW INDEXES BRIEF
 ----
 a|


### PR DESCRIPTION
`MATCH (a) RETURN (a)--()` - syntax removed

Instead use pattern comprehension.

`MATCH (a) RETURN [p=(a)--() | p]`

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1533