### PR TITLE
Implied grouping keys was removed in 5.0

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -346,10 +346,10 @@ In expressions that contain aggregations, the leaves must be either:
 - An aggregation.
 - A literal.
 - A parameter.
-- A variable, *ONLY IF* it is either:
+- A variable, *ONLY IF* it is either: +
 1) A projection expression on its own (e.g. the `n` in `RETURN n AS myNode, n.value + count(*)`). +
 2) A local variable in the expression (e.g the `x` in `RETURN n, n.prop + size([ x IN range(1, 10) \| x ]`).
-- Property access, *ONLY IF* it is also a projection expression on its own (e.g. the `n.prop` in `RETURN n.prop, n.prop + count(*)`). +
+- Property access, *ONLY IF* it is also a projection expression on its own (e.g. the `n.prop` in `RETURN n.prop, n.prop + count(*)`).
 - Map access, *ONLY IF* it is also a projection expression on its own (e.g. the `map.prop` in `WITH {prop: 2} AS map RETURN map.prop, map.prop + count(*)`).
 
 


### PR DESCRIPTION
Implied grouping keys are no longer supported.

Only expressions that do not contain aggregations are still considered grouping keys.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1533