### PR TITLE
Implied grouping keys was deprecated in 4.4

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -30,17 +30,19 @@ MATCH (n) RETURN n.propertyName_1, n.propertyName_2 + count(*)
 ----
 a|
 Implied grouping keys are deprecated.
-Only expressions that do _not_ contain aggregations are grouping keys.
-In expressions that contain aggregations, the leaves of expressions must be one of:
+Only expressions that do _not_ contain aggregations are still considered grouping keys.
 
-- An aggregation
-- A literal
-- A Parameter
-- A variable - *ONLY IF* that variable is also one of: +
-1) A projection expression on its own (e.g. the `n` in `RETURN n AS myNode, n.value + count(*)`) +
-2) A local variable in the expression (e.g the `x` in `RETURN n, n.prop + size([ x IN range(1, 10) \| x ]`)
-- Property access - *ONLY IF* that property access is also a projection expression on its own (e.g. the `n.prop` in `RETURN n.prop, n.prop + count(*)`) +
-- Map access - *ONLY IF* that map access is also a projection expression on its own (e.g. the `map.prop` in `WITH {prop: 2} AS map RETURN map.prop, map.prop + count(*)`)
+In expressions that contain aggregations, the leaves must be either:
+
+- An aggregation.
+- A literal.
+- A parameter.
+- A variable, *ONLY IF* it is either: +
+1) A projection expression on its own (e.g. the `n` in `RETURN n AS myNode, n.value + count(*)`). +
+2) A local variable in the expression (e.g the `x` in `RETURN n, n.prop + size([ x IN range(1, 10) \| x ]`).
+- Property access, *ONLY IF* it is also a projection expression on its own (e.g. the `n.prop` in `RETURN n.prop, n.prop + count(*)`).
+- Map access, *ONLY IF* it is also a projection expression on its own (e.g. the `map.prop` in `WITH {prop: 2} AS map RETURN map.prop, map.prop + count(*)`).
+
 
 a|
 label:syntax[]


### PR DESCRIPTION
This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1533