### PR TITLE
Syntax for referencing an introduced variable in the same pattern was deprecated in 4.4

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -60,6 +60,18 @@ CALL {
 } IN TRANSACTIONS
 ----
 
+
+a|
+label:syntax[]
+label:deprecated[]
+[source, cypher, role="noheader"]
+----
+CREATE (a {prop:7})-[r:R]->(b {prop: a.prop})
+----
+a|
+`CREATE` clauses in which a variable introduced in the pattern is also referenced from the same pattern are deprecated.
+
+
 a|
 label:syntax[]
 label:deprecated[]


### PR DESCRIPTION
`CREATE (a {prop:7})-[r:R]->(b {prop: a.prop})` - syntax deprecated

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1533