### PR TITLE
USING BTREE INDEX was deprecated in 4.4

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -151,6 +151,23 @@ label:functionality[]
 label:deprecated[]
 [source, cypher, role="noheader"]
 ----
+USING BTREE INDEX
+----
+a|
+B-tree indexes are deprecated.
+
+Replaced by:
+[source, cypher, role="noheader"]
+----
+USING {POINT \| RANGE \| TEXT} INDEX
+----
+
+
+a|
+label:functionality[]
+label:deprecated[]
+[source, cypher, role="noheader"]
+----
 CREATE CONSTRAINT
 ...
 OPTIONS "{" btree-option: btree-value[, ...] "}"


### PR DESCRIPTION
`USING BTREE INDEX` - deprecated

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1533