### PR TITLE
Some 4.2 and 4.3 deprecations (#114)

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -1217,8 +1217,9 @@ label:deprecated[]
 point({x:0, y:0}) <= point({x:1, y:1}) <= point({x:2, y:2})
 ----
 a|
-Using inequality operators `<`, `+<=+`, `>`, and `+>=+` on spatial points is deprecated.
-Please instead use:
+The ability to use the `+<+`, `+<=+`, `+>+`, and `+>=+` on spatial points is deprecated.
+
+Instead use:
 [source, cypher, role="noheader"]
 ----
 point.withinBBox(point({x:1, y:1}), point({x:0, y:0}), point({x:2, y:2}))
@@ -1800,6 +1801,23 @@ ON HOME GRAPH
 
 
 a|
+label:syntax[]
+label:deprecated[]
+[source, cypher, role="noheader"]
+----
+MATCH (a) RETURN (a)--()
+----
+a|
+Pattern expressions producing lists of paths are deprecated, but they can still be used as existence predicates, for example in `WHERE` clauses.
+
+Instead, use a pattern comprehension:
+[source, cypher, role="noheader"]
+----
+MATCH (a) RETURN [p=(a)--() \| p]
+----
+
+
+a|
 label:procedure[]
 label:deprecated[]
 
@@ -2326,6 +2344,23 @@ SHOW INDEXES YIELD *
 ----
 SHOW CONSTRAINTS YIELD *
 ----
+
+
+a|
+label:syntax[]
+label:deprecated[]
+[source, cypher, role="noheader"]
+----
+CALL { RETURN 1 }
+----
+a|
+Replaced by:
+[source, cypher, role="noheader"]
+----
+CALL { RETURN 1 AS one }
+----
+
+Unaliased expressions are deprecated in subquery `RETURN` clauses.
 
 |===
 


### PR DESCRIPTION
Unaliased expressions are deprecated in subquery `RETURN` clauses. - deprecated 4.2

Pattern expressions producing lists of paths are deprecated. - deprecated 4.3