### PR TITLE
Fixed broken cypher syntax - or on types

### DIFF
--- a/modules/ROOT/pages/clauses/match.adoc
+++ b/modules/ROOT/pages/clauses/match.adoc
@@ -274,7 +274,7 @@ To match on one of multiple types, you can specify this by chaining them togethe
 .Query
 [source, cypher, indent=0]
 ----
-MATCH (wallstreet {title: 'Wall Street'})<-[:ACTED_IN|:DIRECTED]-(person)
+MATCH (wallstreet {title: 'Wall Street'})<-[:ACTED_IN|DIRECTED]-(person)
 RETURN person.name
 ----
 


### PR DESCRIPTION
`[:ACTED_IN|:DIRECTED]` - wrong syntax

`[:ACTED_IN|DIRECTED]` - correct syntax

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1542