### PR TITLE
Fixed broken cypher syntax - or on types (#119)

### DIFF
--- a/modules/ROOT/pages/clauses/match.adoc
+++ b/modules/ROOT/pages/clauses/match.adoc
@@ -320,7 +320,7 @@ To match on one of multiple types, you can specify this by chaining them togethe
 .Query
 [source, cypher, indent=0]
 ----
-MATCH (wallstreet {title: 'Wall Street'})<-[:ACTED_IN|:DIRECTED]-(person)
+MATCH (wallstreet {title: 'Wall Street'})<-[:ACTED_IN|DIRECTED]-(person)
 RETURN person.name
 ----
 


### PR DESCRIPTION
`[:ACTED_IN|:DIRECTED]` - wrong syntax

`[:ACTED_IN|DIRECTED]` - correct syntax