### PR TITLE
Moved regex operator to string-specific comparison

### DIFF
--- a/modules/ROOT/pages/syntax/operators.adoc
+++ b/modules/ROOT/pages/syntax/operators.adoc
@@ -60,7 +60,7 @@ This section contains an overview of operators.
 | xref::syntax/operators.adoc#query-operators-string[String operators]   | `+` (string concatenation)
 | xref::syntax/operators.adoc#query-operators-temporal[Temporal operators]   | `+` and `-` for operations between durations and temporal instants/durations, `*` and `/` for operations between durations and numbers
 | xref::syntax/operators.adoc#query-operators-map[Map operators]       |  `.` for static value access by key, `[]` for dynamic value access by key
-| xref::syntax/operators.adoc#query-operators-list[List operators]       | `+` for concatenation, `IN` to check existence of an element in a list, `[]` for accessing element(s) dynamically
+| xref::syntax/operators.adoc#query-operators-list[List operators]       | `+` (list concatenation), `IN` to check existence of an element in a list, `[]` for accessing element(s) dynamically
 |===
 
 


### PR DESCRIPTION
Moved the operator: `=~`

From string operators to string-specific comparison operators.

Moved and created examples also.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1572