### PR TITLE
Moved regex operator to string-specific comparison (#121)

### DIFF
--- a/modules/ROOT/pages/syntax/operators.adoc
+++ b/modules/ROOT/pages/syntax/operators.adoc
@@ -9,39 +9,40 @@ This section contains an overview of operators.
 
 * xref::syntax/operators.adoc#query-operators-summary[Operators at a glance]
 * xref::syntax/operators.adoc#query-operators-aggregation[Aggregation operators]
- ** xref::syntax/operators.adoc#syntax-using-the-distinct-operator[Using the `DISTINCT` operator]
+** xref::syntax/operators.adoc#syntax-using-the-distinct-operator[Using the `DISTINCT` operator]
 * xref::syntax/operators.adoc#query-operators-property[Property operators]
- ** xref::syntax/operators.adoc#syntax-accessing-the-property-of-a-node-or-relationship[Statically accessing a property of a node or relationship using the `.` operator]
- ** xref::syntax/operators.adoc#syntax-filtering-on-a-dynamically-computed-property-key[Filtering on a dynamically-computed property key using the `[\]` operator]
- ** xref::syntax/operators.adoc#syntax-property-replacement-operator[Replacing all properties of a node or relationship using the `=` operator]
- ** xref::syntax/operators.adoc#syntax-property-mutation-operator[Mutating specific properties of a node or relationship using the `+=` operator]
+** xref::syntax/operators.adoc#syntax-accessing-the-property-of-a-node-or-relationship[Statically accessing a property of a node or relationship using the `.` operator]
+** xref::syntax/operators.adoc#syntax-filtering-on-a-dynamically-computed-property-key[Filtering on a dynamically-computed property key using the `[\]` operator]
+** xref::syntax/operators.adoc#syntax-property-replacement-operator[Replacing all properties of a node or relationship using the `=` operator]
+** xref::syntax/operators.adoc#syntax-property-mutation-operator[Mutating specific properties of a node or relationship using the `+=` operator]
 * xref::syntax/operators.adoc#query-operators-mathematical[Mathematical operators]
- ** xref::syntax/operators.adoc#syntax-using-the-exponentiation-operator[Using the exponentiation operator `^`]
- ** xref::syntax/operators.adoc#syntax-using-the-unary-minus-operator[Using the unary minus operator `-`]
+** xref::syntax/operators.adoc#syntax-using-the-exponentiation-operator[Using the exponentiation operator `^`]
+** xref::syntax/operators.adoc#syntax-using-the-unary-minus-operator[Using the unary minus operator `-`]
 * xref::syntax/operators.adoc#query-operators-comparison[Comparison operators]
- ** xref::syntax/operators.adoc#syntax-comparing-two-numbers[Comparing two numbers]
- ** xref::syntax/operators.adoc#syntax-using-starts-with-to-filter-names[Using `STARTS WITH` to filter names]
- ** xref::syntax/operators.adoc#cypher-comparison[Equality and comparison of values]
- ** xref::syntax/operators.adoc#cypher-ordering[Ordering and comparison of values]
- ** xref::syntax/operators.adoc#cypher-operations-chaining[Chaining comparison operations]
+** xref::syntax/operators.adoc#syntax-comparing-two-numbers[Comparing two numbers]
+** xref::syntax/operators.adoc#syntax-using-starts-with-to-filter-names[Using `STARTS WITH` to filter names]
+** xref::syntax/operators.adoc#cypher-comparison[Equality and comparison of values]
+** xref::syntax/operators.adoc#cypher-ordering[Ordering and comparison of values]
+** xref::syntax/operators.adoc#cypher-operations-chaining[Chaining comparison operations]
+** xref::syntax/operators.adoc#syntax-using-a-regular-expression-to-filter-words[Using a regular expression with `=~` to filter words]
 * xref::syntax/operators.adoc#query-operators-boolean[Boolean operators]
- ** xref::syntax/operators.adoc#syntax-using-boolean-operators-to-filter-numbers[Using boolean operators to filter numbers]
+** xref::syntax/operators.adoc#syntax-using-boolean-operators-to-filter-numbers[Using boolean operators to filter numbers]
 * xref::syntax/operators.adoc#query-operators-string[String operators]
- ** xref::syntax/operators.adoc#syntax-using-a-regular-expression-to-filter-words[Using a regular expression with `=~` to filter words]
+** xref::syntax/operators.adoc#syntax-concatenating-two-strings[Concatenating two strings using `+`]
 * xref::syntax/operators.adoc#query-operators-temporal[Temporal operators]
- ** xref::syntax/operators.adoc#syntax-add-subtract-duration-to-temporal-instant[Adding and subtracting a _Duration_ to or from a temporal instant]
- ** xref::syntax/operators.adoc#syntax-add-subtract-duration-to-duration[Adding and subtracting a _Duration_ to or from another _Duration_]
- ** xref::syntax/operators.adoc#syntax-multiply-divide-duration-number[Multiplying and dividing a _Duration_ with or by a number]
+** xref::syntax/operators.adoc#syntax-add-subtract-duration-to-temporal-instant[Adding and subtracting a _Duration_ to or from a temporal instant]
+** xref::syntax/operators.adoc#syntax-add-subtract-duration-to-duration[Adding and subtracting a _Duration_ to or from another _Duration_]
+** xref::syntax/operators.adoc#syntax-multiply-divide-duration-number[Multiplying and dividing a _Duration_ with or by a number]
 * xref::syntax/operators.adoc#query-operators-map[Map operators]
- ** xref::syntax/operators.adoc#syntax-accessing-the-value-of-a-nested-map[Statically accessing the value of a nested map by key using the `.` operator"]
- ** xref::syntax/operators.adoc#syntax-accessing-dynamic-map-parameter[Dynamically accessing the value of a map by key using the `[\]` operator and a parameter]
+** xref::syntax/operators.adoc#syntax-accessing-the-value-of-a-nested-map[Statically accessing the value of a nested map by key using the `.` operator"]
+** xref::syntax/operators.adoc#syntax-accessing-dynamic-map-parameter[Dynamically accessing the value of a map by key using the `[\]` operator and a parameter]
 * xref::syntax/operators.adoc#query-operators-list[List operators]
- ** xref::syntax/operators.adoc#syntax-concatenating-two-lists[Concatenating two lists using `+`]
- ** xref::syntax/operators.adoc#syntax-using-in-to-check-if-a-number-is-in-a-list[Using `IN` to check if a number is in a list]
- ** xref::syntax/operators.adoc#syntax-using-in-for-more-complex-list-membership-operations[Using `IN` for more complex list membership operations]
- ** xref::syntax/operators.adoc#syntax-accessing-elements-in-a-list[Accessing elements in a list using the `[\]` operator]
- ** xref::syntax/operators.adoc#syntax-accessing-element-in-a-list-parameter[Dynamically accessing an element in a list using the `[\]` operator and a parameter]
- ** xref::syntax/operators.adoc#syntax-using-in-with-nested-list-subscripting[Using `IN` with `[\]` on a nested list]
+** xref::syntax/operators.adoc#syntax-concatenating-two-lists[Concatenating two lists using `+`]
+** xref::syntax/operators.adoc#syntax-using-in-to-check-if-a-number-is-in-a-list[Using `IN` to check if a number is in a list]
+** xref::syntax/operators.adoc#syntax-using-in-for-more-complex-list-membership-operations[Using `IN` for more complex list membership operations]
+** xref::syntax/operators.adoc#syntax-accessing-elements-in-a-list[Accessing elements in a list using the `[\]` operator]
+** xref::syntax/operators.adoc#syntax-accessing-element-in-a-list-parameter[Dynamically accessing an element in a list using the `[\]` operator and a parameter]
+** xref::syntax/operators.adoc#syntax-using-in-with-nested-list-subscripting[Using `IN` with `[\]` on a nested list]
 
 
 [[query-operators-summary]]
@@ -54,12 +55,12 @@ This section contains an overview of operators.
 | xref::syntax/operators.adoc#query-operators-property[Property operators] | `.` for static property access, `[]` for dynamic property access, `=` for replacing all properties, `+=` for mutating specific properties
 | xref::syntax/operators.adoc#query-operators-mathematical[Mathematical operators] | `+`, `-`, `*`, `/`, `%`, `^`
 | xref::syntax/operators.adoc#query-operators-comparison[Comparison operators]     | `+=+`, `+<>+`, `+<+`, `+>+`, `+<=+`, `+>=+`, `IS NULL`, `IS NOT NULL`
-| xref::syntax/operators.adoc#query-operators-comparison[String-specific comparison operators] | `STARTS WITH`, `ENDS WITH`, `CONTAINS`
+| xref::syntax/operators.adoc#query-operators-comparison[String-specific comparison operators] | `STARTS WITH`, `ENDS WITH`, `CONTAINS`, `=~` (regex matching)
 | xref::syntax/operators.adoc#query-operators-boolean[Boolean operators] | `AND`, `OR`, `XOR`, `NOT`
-| xref::syntax/operators.adoc#query-operators-string[String operators]   | `+` for concatenation, `=~` for regex matching
+| xref::syntax/operators.adoc#query-operators-string[String operators]   | `+` (string concatenation)
 | xref::syntax/operators.adoc#query-operators-temporal[Temporal operators]   | `+` and `-` for operations between durations and temporal instants/durations, `*` and `/` for operations between durations and numbers
 | xref::syntax/operators.adoc#query-operators-map[Map operators]       |  `.` for static value access by key, `[]` for dynamic value access by key
-| xref::syntax/operators.adoc#query-operators-list[List operators]       | `+` for concatenation, `IN` to check existence of an element in a list, `[]` for accessing element(s) dynamically
+| xref::syntax/operators.adoc#query-operators-list[List operators]       | `+` (list concatenation), `IN` to check existence of an element in a list, `[]` for accessing element(s) dynamically
 |===
 
 
@@ -308,7 +309,7 @@ The comparison operators comprise:
 * `STARTS WITH`: perform case-sensitive prefix searching on strings
 * `ENDS WITH`: perform case-sensitive suffix searching on strings
 * `CONTAINS`: perform case-sensitive inclusion searching in strings
-
+* `=~`: regular expression for matching a pattern
 
 [[syntax-comparing-two-numbers]]
 === Comparing two numbers
@@ -355,7 +356,6 @@ RETURN candidate
 
 xref::clauses/where.adoc#query-where-string[String matching] contains more information regarding the string-specific comparison operators as well as additional examples illustrating the usage thereof.
 
-// neo4j-manual-modeling-antora/cypherManual/build/4.4/antora/modules/ROOT/partials/neo4j-cypher-docs/docs/dev/syntax/comparison.adoc
 
 [[cypher-comparison]]
 === Equality and comparison of values
@@ -495,6 +495,31 @@ a < b AND b = c AND c <= d AND d <> e
 ----
 
 
+[[syntax-using-a-regular-expression-to-filter-words]]
+=== Using a regular expression with `=~` to filter words
+
+.Query
+[source, cypher, indent=0]
+----
+WITH ['mouse', 'chair', 'door', 'house'] AS wordlist
+UNWIND wordlist AS word
+WITH word
+WHERE word =~ '.*ous.*'
+RETURN word
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+| +word+
+| +"mouse"+
+| +"house"+
+1+d|Rows: 2
+|===
+
+Further information and examples regarding the use of regular expressions in filtering can be found in xref::clauses/where.adoc#query-where-regex[Regular expressions].
+
+
 [[query-operators-boolean]]
 == Boolean operators
 
@@ -552,33 +577,24 @@ RETURN number
 The string operators comprise:
 
 * concatenating strings: `+`
-* matching a regular expression: `=~`
 
 
-[[syntax-using-a-regular-expression-to-filter-words]]
-=== Using a regular expression with `=~` to filter words
+[[syntax-concatenating-two-strings]]
+=== Concatenating two strings with `+`
 
 .Query
-[source, cypher, indent=0]
+[source, cypher]
 ----
-WITH ['mouse', 'chair', 'door', 'house'] AS wordlist
-UNWIND wordlist AS word
-WITH word
-WHERE word =~ '.*ous.*'
-RETURN word
+RETURN 'neo' + '4j' AS result
 ----
 
 .Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
-| +word+
-| +"mouse"+
-| +"house"+
-1+d|Rows: 2
+| +result+
+| +"neo4j"+
+1+d|Rows: 1
 |===
-
-Further information and examples regarding the use of regular expressions in filtering can be found in xref::clauses/where.adoc#query-where-regex[Regular expressions].
-In addition, refer to xref::syntax/operators.adoc#query-operator-comparison-string-specific[String-specific comparison operators comprise:] for details on string-specific comparison operators.
 
 
 [[query-operators-temporal]]


### PR DESCRIPTION
Moved the operator: `=~`

From string operators to string-specific comparison operators.

Moved and created examples also.

This PR is based on:

1. https://github.com/neo4j/neo4j-documentation/pull/1578