### PR TITLE
user-defined functions naming fix

### DIFF
--- a/modules/ROOT/pages/access-control/dbms-administration.adoc
+++ b/modules/ROOT/pages/access-control/dbms-administration.adoc
@@ -38,7 +38,7 @@ For more details, see the following sections:
 * xref::access-control/dbms-administration.adoc#access-control-dbms-administration-alias-management[Alias management]
 * xref::access-control/dbms-administration.adoc#access-control-dbms-administration-privilege-management[Privilege management]
 * xref::access-control/database-administration.adoc#access-control-database-administration-transaction[Transaction management]
-* xref::access-control/dbms-administration.adoc#access-control-dbms-administration-execute[Procedure and user defined function security]
+* xref::access-control/dbms-administration.adoc#access-control-dbms-administration-execute[Procedure and user-defined function security]
 
 It is possible to make a custom role with a subset of these privileges.
 
@@ -1253,7 +1253,7 @@ a|Rows: 1
 [[access-control-dbms-administration-execute]]
 == The DBMS `EXECUTE` privileges
 
-The DBMS privileges for procedure and user defined function execution are assignable using Cypher administrative commands.
+The DBMS privileges for procedure and user-defined function execution are assignable using Cypher administrative commands.
 They can be granted, denied and revoked like other privileges.
 
 .Execute privileges command syntax
@@ -1284,16 +1284,16 @@ GRANT EXECUTE ADMIN[ISTRATOR] PROCEDURES
 GRANT EXECUTE [USER [DEFINED]] FUNCTION[S] name-globbing[, ...]
   ON DBMS
   TO role[, ...]
-| Enable the specified roles to execute the given user defined functions.
+| Enable the specified roles to execute the given user-defined functions.
 
 | [source, cypher, role=noplay, indent=0]
 GRANT EXECUTE BOOSTED [USER [DEFINED]] FUNCTION[S] name-globbing[, ...]
   ON DBMS
   TO role[, ...]
-| Enable the specified roles to execute the given user defined functions with elevated privileges.
+| Enable the specified roles to execute the given user-defined functions with elevated privileges.
 |===
 
-The `EXECUTE BOOSTED` privileges replace the `dbms.security.procedures.default_allowed` and `dbms.security.procedures.roles` configuration parameters for procedures and user defined functions.
+The `EXECUTE BOOSTED` privileges replace the `dbms.security.procedures.default_allowed` and `dbms.security.procedures.roles` configuration parameters for procedures and user-defined functions.
 The configuration parameters are still honoured as a set of temporary privileges.
 These cannot be revoked, but will be updated on each restart with the current configuration values.
 
@@ -1602,7 +1602,7 @@ It does not matter whether `EXECUTE PROCEDURE`, `EXECUTE BOOSTED PROCEDURE` or `
 === The `EXECUTE USER DEFINED FUNCTION` privilege
 
 //EXECUTE [USER [DEFINED]] FUNCTION[S]
-The ability to execute a user defined function (UDF) can be granted via the `EXECUTE USER DEFINED FUNCTION` privilege.
+The ability to execute a user-defined function (UDF) can be granted via the `EXECUTE USER DEFINED FUNCTION` privilege.
 A user with this privilege is allowed to execute the UDFs matched by the xref::access-control/dbms-administration.adoc#access-control-name-globbing[name-globbing].
 
 [IMPORTANT]
@@ -1610,7 +1610,7 @@ A user with this privilege is allowed to execute the UDFs matched by the xref::a
 The `EXECUTE USER DEFINED FUNCTION` privilege does not apply to built-in functions, which are always executable.
 ====
 
-.Execute user defined function
+.Execute user-defined function
 ======
 The following query shows an example of how to grant this privilege:
 
@@ -1649,7 +1649,7 @@ a|Rows: 1
 
 If you want to allow executing all but a few UDFs, you can grant `+EXECUTE USER DEFINED FUNCTIONS *+` and deny the unwanted functions.
 
-.Execute user defined functions
+.Execute user-defined functions
 ======
 The following queries allow for executing all UDFs except those starting with `apoc.any.prop`:
 
@@ -1700,7 +1700,7 @@ The `apoc.any.property` and `apoc.any.properties` is blocked, as well as any oth
 === The `EXECUTE BOOSTED USER DEFINED FUNCTION` privilege
 
 //EXECUTE BOOSTED [USER [DEFINED]] FUNCTION[S]
-The ability to execute a user defined function (UDF) with elevated privileges can be granted via the `EXECUTE BOOSTED USER DEFINED FUNCTION` privilege.
+The ability to execute a user-defined function (UDF) with elevated privileges can be granted via the `EXECUTE BOOSTED USER DEFINED FUNCTION` privilege.
 A user with this privilege is allowed to execute the UDFs matched by the xref::access-control/dbms-administration.adoc#access-control-name-globbing[name-globbing] without the execution being restricted to their other privileges.
 There is no need to grant an individual `EXECUTE USER DEFINED FUNCTION` privilege for the functions either, as granting the `EXECUTE BOOSTED USER DEFINED FUNCTION` includes an implicit `EXECUTE USER DEFINED FUNCTION` grant for them.
 A denied `EXECUTE USER DEFINED FUNCTION` still denies executing the function.
@@ -1715,7 +1715,7 @@ A denied `EXECUTE BOOSTED USER DEFINED FUNCTION` on its own behaves slightly dif
 However, a role with only a granted `EXECUTE BOOSTED USER DEFINED FUNCTION` and a denied `EXECUTE BOOSTED USER DEFINED FUNCTION` denies the execution as well.
 This is the same behavior as for the xref::access-control/dbms-administration.adoc#access-control-execute-boosted-procedure[`EXECUTE BOOSTED PROCEDURE` privilege].
 
-.Execute boosted user defined function
+.Execute boosted user-defined function
 ======
 The following query shows an example of how to grant the `EXECUTE BOOSTED USER DEFINED FUNCTION` privilege:
 
@@ -1754,7 +1754,7 @@ a|Rows: 1
 [[access-control-name-globbing]]
 === Procedure and user-defined function name-globbing
 
-The name-globbing for procedure and user defined function names is a simplified version of globbing for filename expansions, only allowing two wildcard characters; `+*+` and `?`.
+The name-globbing for procedure and user-defined function names is a simplified version of globbing for filename expansions, only allowing two wildcard characters; `+*+` and `?`.
 They are used for multiple and single character matches, where `+*+` means 0 or more characters and `?` matches exactly one character.
 
 [NOTE]
@@ -1766,7 +1766,7 @@ Also good to keep in mind is that the wildcard characters behave as wildcards ev
 As an example, using `++`*`++` is equivalent to using `+*+`, and thus allows executing all functions or procedures and not only the procedure or function named `+*+`.
 ====
 
-The examples below only use procedures but the same rules apply to user defined function names.
+The examples below only use procedures but the same rules apply to user-defined function names.
 For the examples below, assume we have the following procedures:
 
 * `mine.public.exampleProcedure`
@@ -1849,7 +1849,7 @@ The right to perform the following privileges can be achieved with a single comm
 * assign privileges
 * remove privileges
 * execute all procedures with elevated privileges
-* execute all user defined functions with elevated privileges
+* execute all user-defined functions with elevated privileges
 
 [source, cypher, role=noplay, indent=0]
 ----

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -1471,7 +1471,7 @@ New privilege:
 EXECUTE
 ----
 a|
-New Cypher commands for administering privileges for executing procedures and user defined functions.
+New Cypher commands for administering privileges for executing procedures and user-defined functions.
 
 See xref::access-control/dbms-administration.adoc#access-control-dbms-administration-execute[The DBMS `EXECUTE` privileges].
 

--- a/modules/ROOT/pages/keyword-glossary.adoc
+++ b/modules/ROOT/pages/keyword-glossary.adoc
@@ -178,7 +178,8 @@ Also allows `WHERE` and `YIELD` clauses.
 | DBMS
 |
 List functions, either all or filtered.
-Available filters are executable by a user or function type (built-in or user defined). Also allows `WHERE` and `YIELD` clauses.
+Available filters are executable by a user or function type (built-in or user-defined).
+Also allows `WHERE` and `YIELD` clauses.
 
 | xref::clauses/listing-procedures.adoc[SHOW PROCEDURE[S\] [EXECUTABLE [BY {CURRENT USER\|username}\]\]]
 | DBMS


### PR DESCRIPTION
```
grep --exclude-dir=.git -rlZ "user defined" | xargs -0 sed -i 's/user defined/user-defined/g'
```