### PR TITLE
New privileges for built-in reader role

### DIFF
--- a/modules/ROOT/pages/access-control/built-in-roles.adoc
+++ b/modules/ROOT/pages/access-control/built-in-roles.adoc
@@ -97,6 +97,8 @@ SHOW ROLE reader PRIVILEGES AS COMMANDS
 |"GRANT ACCESS ON DATABASE * TO `reader`"
 |"GRANT MATCH {*} ON GRAPH * NODE * TO `reader`"
 |"GRANT MATCH {*} ON GRAPH * RELATIONSHIP * TO `reader`"
+|"GRANT SHOW CONSTRAINT ON DATABASE * TO `reader`"
+|"GRANT SHOW INDEX ON DATABASE * TO `reader`"
 a|Rows: 3
 |===
 
@@ -121,6 +123,16 @@ GRANT ACCESS ON DATABASE * TO reader
 [source, cypher, role=noplay]
 ----
 GRANT MATCH {*} ON GRAPH * TO reader
+----
+
+[source, cypher, role=noplay]
+----
+GRANT SHOW CONSTRAINT ON DATABASE * TO reader
+----
+
+[source, cypher, role=noplay]
+----
+GRANT SHOW INDEX ON DATABASE * TO reader
 ----
 
 The resulting `reader` role now has the same privileges as the original built-in `reader` role.

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -976,6 +976,22 @@ New outputs has been added.
 
 These outputs are returned in the full result set (`+YIELD *+`) and not by default.
 
+a|
+label:role[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+SHOW ROLE reader PRIVILEGES AS COMMANDS
+----
+a|
+The built-in `reader` role has two new privileges:
+
+[source, result, role="noheader"]
+----
+"GRANT SHOW CONSTRAINT ON DATABASE * TO `reader`"
+"GRANT SHOW INDEX ON DATABASE * TO `reader`"
+----
+
 |===
 
 


### PR DESCRIPTION
The built-in `reader` role now has new privileges:

```
"GRANT SHOW CONSTRAINT ON DATABASE * TO `reader`"
"GRANT SHOW INDEX ON DATABASE * TO `reader`"
```

This PR is based on:

1. https://github.com/neo-technology/neo4j-manual-modeling/pull/2835