### PR TITLE
New privileges for built-in editor role

### DIFF
--- a/modules/ROOT/pages/access-control/built-in-roles.adoc
+++ b/modules/ROOT/pages/access-control/built-in-roles.adoc
@@ -99,7 +99,7 @@ SHOW ROLE reader PRIVILEGES AS COMMANDS
 |"GRANT MATCH {*} ON GRAPH * RELATIONSHIP * TO `reader`"
 |"GRANT SHOW CONSTRAINT ON DATABASE * TO `reader`"
 |"GRANT SHOW INDEX ON DATABASE * TO `reader`"
-a|Rows: 3
+a|Rows: 5
 |===
 
 
@@ -158,8 +158,10 @@ SHOW ROLE editor PRIVILEGES AS COMMANDS
 |"GRANT ACCESS ON DATABASE * TO `editor`"
 |"GRANT MATCH {*} ON GRAPH * NODE * TO `editor`"
 |"GRANT MATCH {*} ON GRAPH * RELATIONSHIP * TO `editor`"
+|"GRANT SHOW CONSTRAINT ON DATABASE * TO `editor`"
+|"GRANT SHOW INDEX ON DATABASE * TO `editor`"
 |"GRANT WRITE ON GRAPH * TO `editor`"
-a|Rows: 4
+a|Rows: 6
 |===
 
 
@@ -188,6 +190,16 @@ GRANT MATCH {*} ON GRAPH * TO editor
 [source, cypher, role=noplay]
 ----
 GRANT WRITE ON GRAPH * TO editor
+----
+
+[source, cypher, role=noplay]
+----
+GRANT SHOW CONSTRAINT ON DATABASE * TO editor
+----
+
+[source, cypher, role=noplay]
+----
+GRANT SHOW INDEX ON DATABASE * TO editor
 ----
 
 The resulting `editor` role now has the same privileges as the original built-in `editor` role.

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -993,6 +993,23 @@ The built-in `reader` role has two new privileges:
 "GRANT SHOW INDEX ON DATABASE * TO `reader`"
 ----
 
+
+a|
+label:role[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+SHOW ROLE editor PRIVILEGES AS COMMANDS
+----
+a|
+The built-in `editor` role has two new privileges:
+
+[source, result, role="noheader"]
+----
+"GRANT SHOW CONSTRAINT ON DATABASE * TO `editor`"
+"GRANT SHOW INDEX ON DATABASE * TO `editor`"
+----
+
 |===
 
 


### PR DESCRIPTION
The built-in `editor` role now has new privileges:

```
"GRANT SHOW CONSTRAINT ON DATABASE * TO `editor`"
"GRANT SHOW INDEX ON DATABASE * TO `editor`"
```

This PR is based on:

1. https://github.com/neo-technology/neo4j-manual-modeling/pull/2835