### PR TITLE
New privileges for built-in publisher role

### DIFF
--- a/modules/ROOT/pages/access-control/built-in-roles.adoc
+++ b/modules/ROOT/pages/access-control/built-in-roles.adoc
@@ -227,8 +227,10 @@ SHOW ROLE publisher PRIVILEGES AS COMMANDS
 |"GRANT MATCH {*} ON GRAPH * NODE * TO `publisher`"
 |"GRANT MATCH {*} ON GRAPH * RELATIONSHIP * TO `publisher`"
 |"GRANT NAME MANAGEMENT ON DATABASE * TO `publisher`"
+|"GRANT SHOW CONSTRAINT ON DATABASE * TO `publisher`"
+|"GRANT SHOW INDEX ON DATABASE * TO `publisher`"
 |"GRANT WRITE ON GRAPH * TO `publisher`"
-a|Rows: 5
+a|Rows: 7
 |===
 
 
@@ -262,6 +264,16 @@ GRANT WRITE ON GRAPH * TO publisher
 [source, cypher, role=noplay]
 ----
 GRANT NAME MANAGEMENT ON DATABASE * TO publisher
+----
+
+[source, cypher, role=noplay]
+----
+GRANT SHOW CONSTRAINT ON DATABASE * TO publisher
+----
+
+[source, cypher, role=noplay]
+----
+GRANT SHOW INDEX ON DATABASE * TO publisher
 ----
 
 The resulting `publisher` role now has the same privileges as the original built-in `publisher` role.

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -1010,6 +1010,23 @@ The built-in `editor` role has two new privileges:
 "GRANT SHOW INDEX ON DATABASE * TO `editor`"
 ----
 
+
+a|
+label:role[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+SHOW ROLE publisher PRIVILEGES AS COMMANDS
+----
+a|
+The built-in `publisher` role has two new privileges:
+
+[source, result, role="noheader"]
+----
+"GRANT SHOW CONSTRAINT ON DATABASE * TO `publisher`"
+"GRANT SHOW INDEX ON DATABASE * TO `publisher`"
+----
+
 |===
 
 


### PR DESCRIPTION
The built-in `publisher` role now has new privileges:

```
"GRANT SHOW CONSTRAINT ON DATABASE * TO `publisher`"
"GRANT SHOW INDEX ON DATABASE * TO `publisher`"
```

This PR is based on:

1. https://github.com/neo-technology/neo4j-manual-modeling/pull/2835