### PR TITLE
New privileges for built-in architect role

### DIFF
--- a/modules/ROOT/pages/access-control/built-in-roles.adoc
+++ b/modules/ROOT/pages/access-control/built-in-roles.adoc
@@ -303,8 +303,10 @@ SHOW ROLE architect PRIVILEGES AS COMMANDS
 |"GRANT MATCH {*} ON GRAPH * NODE * TO `architect`"
 |"GRANT MATCH {*} ON GRAPH * RELATIONSHIP * TO `architect`"
 |"GRANT NAME MANAGEMENT ON DATABASE * TO `architect`"
+|"GRANT SHOW CONSTRAINT ON DATABASE * TO `architect`"
+|"GRANT SHOW INDEX ON DATABASE * TO `architect`"
 |"GRANT WRITE ON GRAPH * TO `architect`"
-a|Rows: 7
+a|Rows: 9
 |===
 
 
@@ -337,12 +339,22 @@ GRANT NAME MANAGEMENT ON DATABASE * TO architect
 
 [source, cypher, role=noplay]
 ----
-GRANT INDEX MANAGEMENT ON DATABASE * TO architect
+GRANT SHOW CONSTRAINT ON DATABASE * TO architect
 ----
 
 [source, cypher, role=noplay]
 ----
 GRANT CONSTRAINT MANAGEMENT ON DATABASE * TO architect
+----
+
+[source, cypher, role=noplay]
+----
+GRANT SHOW INDEX ON DATABASE * TO architect
+----
+
+[source, cypher, role=noplay]
+----
+GRANT INDEX MANAGEMENT ON DATABASE * TO architect
 ----
 
 The resulting `architect` role now has the same privileges as the original built-in `architect` role.

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -1027,6 +1027,23 @@ The built-in `publisher` role has two new privileges:
 "GRANT SHOW INDEX ON DATABASE * TO `publisher`"
 ----
 
+
+a|
+label:role[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+SHOW ROLE architect PRIVILEGES AS COMMANDS
+----
+a|
+The built-in `architect` role has two new privileges:
+
+[source, result, role="noheader"]
+----
+"GRANT SHOW CONSTRAINT ON DATABASE * TO `architect`"
+"GRANT SHOW INDEX ON DATABASE * TO `architect`"
+----
+
 |===
 
 


### PR DESCRIPTION
The built-in `architect` role now has new privileges:

```
"GRANT SHOW CONSTRAINT ON DATABASE * TO `architect`"
"GRANT SHOW INDEX ON DATABASE * TO `architect`"
```

This PR is based on:

1. https://github.com/neo-technology/neo4j-manual-modeling/pull/2835