### PR TITLE
New privileges for built-in admin role

### DIFF
--- a/modules/ROOT/pages/access-control/built-in-roles.adoc
+++ b/modules/ROOT/pages/access-control/built-in-roles.adoc
@@ -402,11 +402,13 @@ SHOW ROLE admin PRIVILEGES AS COMMANDS
 |"GRANT MATCH {*} ON GRAPH * NODE * TO `admin`"
 |"GRANT MATCH {*} ON GRAPH * RELATIONSHIP * TO `admin`"
 |"GRANT NAME MANAGEMENT ON DATABASE * TO `admin`"
+|"GRANT SHOW CONSTRAINT ON DATABASE * TO `admin`"
+|"GRANT SHOW INDEX ON DATABASE * TO `admin`"
 |"GRANT START ON DATABASE * TO `admin`"
 |"GRANT STOP ON DATABASE * TO `admin`"
 |"GRANT TRANSACTION MANAGEMENT (*) ON DATABASE * TO `admin`"
 |"GRANT WRITE ON GRAPH * TO `admin`"
-a|Rows: 11
+a|Rows: 13
 |===
 
 If the built-in `admin` role has been altered or dropped, and needs to be restored to its original state, see xref:5.0@operations-manual:ROOT:configuration/password-and-user-recovery/index.adoc[Operations Manual -> Password and user recovery].
@@ -459,7 +461,7 @@ GRANT WRITE ON GRAPH * TO admin
 GRANT ALL ON DATABASE * TO admin
 ----
 
-The resulting `admin` role now has the same privileges as the original built-in `admin` role.
+The resulting `admin` role now has the same effective privileges as the original built-in `admin` role.
 
 Additional information about restoring the `admin` role can be found in the xref:5.0@operations-manual:ROOT:configuration/password-and-user-recovery/index.adoc#recover-admin-role[Operations Manual -> Recover the admin role].
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -1044,6 +1044,23 @@ The built-in `architect` role has two new privileges:
 "GRANT SHOW INDEX ON DATABASE * TO `architect`"
 ----
 
+
+a|
+label:role[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+SHOW ROLE admin PRIVILEGES AS COMMANDS
+----
+a|
+The built-in `admin` role has two new privileges:
+
+[source, result, role="noheader"]
+----
+"GRANT SHOW CONSTRAINT ON DATABASE * TO `admin`"
+"GRANT SHOW INDEX ON DATABASE * TO `admin`"
+----
+
 |===
 
 


### PR DESCRIPTION
The built-in `admin` role now has new privileges:

```
"GRANT SHOW CONSTRAINT ON DATABASE * TO `admin`"
"GRANT SHOW INDEX ON DATABASE * TO `admin`"
```

This PR is based on:

1. https://github.com/neo-technology/neo4j-manual-modeling/pull/2835