### PR TITLE
Bump version to fix logging bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@antora/cli": "^3.1.1",
     "@antora/site-generator-default": "^3.1.1",
     "@neo4j-antora/antora-add-notes": "^0.1.6",
-    "@neo4j-antora/antora-modify-sitemaps": "^0.4.3",
+    "@neo4j-antora/antora-modify-sitemaps": "^0.4.4",
     "@neo4j-antora/antora-page-roles": "^0.3.1",
     "@neo4j-antora/antora-table-footnotes": "^0.3.2",
     "@neo4j-documentation/macros": "^1.0.2",


### PR DESCRIPTION
Updates the `antora-modify-sitemaps` version to fix a bug where the logger was incorrectly invoked, which could sometimes result in errors and warnings not being correctly logged.