### PR TITLE
Fixing examples with the deprecated id() operator

### DIFF
--- a/modules/ROOT/pages/clauses/match.adoc
+++ b/modules/ROOT/pages/clauses/match.adoc
@@ -798,7 +798,7 @@ When your pattern contains a bound relationship, and that relationship pattern d
 [source, cypher, indent=0]
 ----
 MATCH (a)-[r]-(b)
-WHERE id(r) = 0
+WHERE elementId(r) = 0
 RETURN a, b
 ----
 
@@ -907,7 +907,7 @@ Finds the two shortest paths between *'Martin Sheen'* and *'Michael Douglas'*.
 [[match-node-by-id]]
 === Node by ID
 
-Searching for nodes by ID can be done with the `id()` function in a predicate.
+Searching for nodes by ID can be done with the `elementId()` function in a predicate.
 
 [NOTE]
 ====
@@ -920,7 +920,7 @@ It is therefore recommended to rather use application-generated IDs.
 [source, cypher, indent=0]
 ----
 MATCH (n)
-WHERE id(n) = 0
+WHERE elementId(n) = 0
 RETURN n
 ----
 
@@ -938,7 +938,7 @@ The corresponding node is returned.
 [[match-rel-by-id]]
 === Relationship by ID
 
-Search for relationships by ID can be done with the `id()` function in a predicate.
+Search for relationships by ID can be done with the `elementId()` function in a predicate.
 
 This is not the recommended practice.
 See xref::clauses/match.adoc#match-node-by-id[Node by ID] for more information on the use of Neo4j IDs.
@@ -947,7 +947,7 @@ See xref::clauses/match.adoc#match-node-by-id[Node by ID] for more information o
 [source, cypher, indent=0]
 ----
 MATCH ()-[r]->()
-WHERE id(r) = 0
+WHERE elementId(r) = 0
 RETURN r
 ----
 
@@ -971,7 +971,7 @@ Multiple nodes are selected by specifying them in an `IN`-clause.
 [source, cypher, indent=0]
 ----
 MATCH (n)
-WHERE id(n) IN [0, 3, 5]
+WHERE elementId(n) IN [0, 3, 5]
 RETURN n
 ----
 

--- a/modules/ROOT/pages/clauses/order-by.adoc
+++ b/modules/ROOT/pages/clauses/order-by.adoc
@@ -106,7 +106,7 @@ This returns the nodes, sorted first by their age, and then by their name.
 ----
 MATCH (n)
 RETURN n.name, n.age
-ORDER BY id(n)
+ORDER BY elementId(n)
 ----
 
 The nodes are returned, sorted by their internal ID.

--- a/modules/ROOT/pages/execution-plans/operators.adoc
+++ b/modules/ROOT/pages/execution-plans/operators.adoc
@@ -267,7 +267,7 @@ Batch size 128
 +-------------------------------+---------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
 | +ProduceResults               | r, n1                                       |              1 |    1 |       0 |                |                        |           |                     |
 | |                             +---------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +DirectedRelationshipByIdSeek | (n1)-[r]->(anon_0) WHERE id(r) = $autoint_0 |              1 |    1 |       1 |            120 |                    4/0 |     0.459 | Fused in Pipeline 0 |
+| +DirectedRelationshipByIdSeek | (n1)-[r]->(anon_0) WHERE elementId(r) = $autoint_0 |              1 |    1 |       1 |            120 |                    4/0 |     0.459 | Fused in Pipeline 0 |
 +-------------------------------+---------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
 
 Total database accesses: 1, total allocated memory: 184
@@ -291,7 +291,7 @@ As the direction is unspecified, two rows are produced for each relationship as 
 [source, cypher, role="noplay"]
 ----
 MATCH (n1)-[r]-()
-WHERE id(r) = 1
+WHERE elementId(r) = 1
 RETURN r, n1
 ----
 
@@ -311,7 +311,7 @@ Batch size 128
 +---------------------------------+--------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
 | +ProduceResults                 | r, n1                                      |              2 |    2 |       0 |                |                        |           |                     |
 | |                               +--------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +UndirectedRelationshipByIdSeek | (n1)-[r]-(anon_0) WHERE id(r) = $autoint_0 |              2 |    2 |       1 |            120 |                    4/0 |     0.332 | Fused in Pipeline 0 |
+| +UndirectedRelationshipByIdSeek | (n1)-[r]-(anon_0) WHERE elementId(r) = $autoint_0 |              2 |    2 |       1 |            120 |                    4/0 |     0.332 | Fused in Pipeline 0 |
 +---------------------------------+--------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
 
 Total database accesses: 1, total allocated memory: 184
@@ -809,7 +809,7 @@ The `NodeByIdSeek` operator reads one or more nodes by id from the node store.
 [source, cypher, role="noplay"]
 ----
 MATCH (n)
-WHERE id(n) = 0
+WHERE elementId(n) = 0
 RETURN n
 ----
 
@@ -829,7 +829,7 @@ Batch size 128
 +-----------------+----------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
 | +ProduceResults | n                          |              1 |    1 |       0 |                |                        |           |                     |
 | |               +----------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +NodeByIdSeek   | n WHERE id(n) = $autoint_0 |              1 |    1 |       1 |            120 |                    3/0 |     2.108 | Fused in Pipeline 0 |
+| +NodeByIdSeek   | n WHERE elementId(n) = $autoint_0 |              1 |    1 |       1 |            120 |                    3/0 |     2.108 | Fused in Pipeline 0 |
 +-----------------+----------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
 
 Total database accesses: 1, total allocated memory: 184

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -106,9 +106,9 @@ These functions return a single value.
 
 1.2+| xref::functions/scalar.adoc#functions-id[`id()`]
 | `id(input :: NODE?) :: (INTEGER?)`
-| Returns the id of a node.
+| label:deprecated[] Returns the id of a node. Replaced by `elementId()`
 | `id(input :: RELATIONSHIP?) :: (INTEGER?)`
-| Returns the id of a relationship.
+| label:deprecated[] Returns the id of a relationship. Replaced by `elementId()`.
 
 1.1+| xref::functions/scalar.adoc#functions-last[`last()`]
 | `last(list :: LIST? OF ANY?) :: (ANY?)`

--- a/modules/ROOT/pages/styleguide.adoc
+++ b/modules/ROOT/pages/styleguide.adoc
@@ -376,7 +376,7 @@ RETURN count(vehicle)
 ----
 CREATE (a:End {prop: 42}),
        (b:End {prop: 3}),
-       (c:Begin {prop: id(a)})
+       (c:Begin {prop: elementId(a)})
 ----
 +
 .Good
@@ -384,7 +384,7 @@ CREATE (a:End {prop: 42}),
 ----
 CREATE (a:End {prop: 42}),
        (:End {prop: 3}),
-       (:Begin {prop: id(a)})
+       (:Begin {prop: elementId(a)})
 ----
 
 * Chain patterns together to avoid repeating variables.

--- a/modules/ROOT/pages/syntax/parameters.adoc
+++ b/modules/ROOT/pages/syntax/parameters.adoc
@@ -247,7 +247,7 @@ LIMIT $l
 [source,cypher, indent=0]
 ----
 MATCH (n)
-WHERE id(n) = $id
+WHERE elementId(n) = $id
 RETURN n.name
 ----
 
@@ -269,7 +269,7 @@ RETURN n.name
 [source,cypher, indent=0]
 ----
 MATCH (n)
-WHERE id(n) IN $ids
+WHERE elementId(n) IN $ids
 RETURN n.name
 ----
 


### PR DESCRIPTION
Updated now with `elementId()` where suitable. 