### PR TITLE
Add deprecation for duplicated var length relationships in 5.2 (#212)

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -13,6 +13,33 @@ Replacement syntax for deprecated and removed features are also indicated.
 [[cypher-deprecations-additions-removals-5.2]]
 == Version 5.2
 
+=== Deprecated features
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:syntax[]
+label:deprecated[]
+[source, cypher, role="noheader"]
+----
+MATCH ()-[r*]-()-[r*]-()
+----
+----
+MATCH p = ()-[r*]-(), q = ()-[r*]-()
+----
+
+----
+MATCH ()-[r*]-() MATCH ()-[r*]-()
+----
+a|
+
+The use of the same relationship variable for multiple variable length relationships is deprecated.
+
+|===
+
 === Updated features
 
 [cols="2", options="header"]
@@ -73,7 +100,7 @@ CREATE TEXT INDEX ... OPTIONS {indexProvider: `text-2.0`}
 ----
 a|
 
-A new text index provider is available, `text-2.0`. 
+A new text index provider is available, `text-2.0`.
 This is also the default provider if none is given.
 
 |===


### PR DESCRIPTION
Adds the deprecation from
https://github.com/neo4j/neo4j-documentation/pull/1625