### PR TITLE
Update docs about round() function.

### DIFF
--- a/modules/ROOT/pages/functions/mathematical-numeric.adoc
+++ b/modules/ROOT/pages/functions/mathematical-numeric.adoc
@@ -423,7 +423,7 @@ Ties are rounded towards positive infinity, therfore `-1.0` is returned.
 
 [[functions-round2]]
 == round(), with precision
-`round()` returns the value of the given number rounded to the closest value of given precision, with ties always being rounded away from zero (rounding mode `HALF_UP`).
+`round()` returns the value of the given number rounded to the closest value of given precision, with ties always being rounded away from zero (using rounding mode `HALF_UP`).
 The exception is for precision 0, where ties are rounded towards positive infinity to align with <<functions-round>> without precision.
 
 *Syntax:*
@@ -601,7 +601,7 @@ round(expression, precision, mode)
 *Considerations:*
 |===
 
-| For the rounding modes, a tie refers to that the two closest values of the given precision are on the same distance from the given value.
+| For the rounding modes, a tie means that the two closest values of the given precision are at the same distance from the given value.
 E.g. for precision 1, 2.15 is a tie as it has equal distance to 2.1 and 2.2, while 2.151 is not a tie, as it is closer to 2.2.
 
 |===


### PR DESCRIPTION
We follow the behaviour of Java, i.e. rounding towards positive infinity for ties when we have no precision or mode or rounding according to https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/math/RoundingMode.html for rounding modes.

The current description was wrong in some cases and missleading in others. Also added more examples.

Fixes #https://github.com/neo4j/neo4j/issues/12972 and https://github.com/neo4j/neo4j/issues/12963