### PR TITLE
Document ´Allow both plural and singular form in SHOW commands`

### DIFF
--- a/modules/ROOT/pages/access-control/manage-roles.adoc
+++ b/modules/ROOT/pages/access-control/manage-roles.adoc
@@ -27,7 +27,7 @@ m| SHOW ROLES
 a|
 [source, syntax, role="noheader"]
 ----
-SHOW [ALL\|POPULATED] ROLES
+SHOW [ALL\|POPULATED] ROLE[S]
   [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
   [WHERE expression]
   [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
@@ -63,7 +63,7 @@ m| SHOW ROLES WITH USERS
 a|
 [source, syntax, role="noheader"]
 ----
-SHOW [ALL\|POPULATED] ROLES WITH USERS
+SHOW [ALL\|POPULATED] ROLE[S] WITH USER[S]
   [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
   [WHERE expression]
   [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
@@ -84,7 +84,6 @@ a|
 GRANT SHOW ROLE
 ----
 
-[source, privilege, role="noheader"]
 (see xref::access-control/dbms-administration.adoc#access-control-dbms-administration-role-management[DBMS ROLE MANAGEMENT privileges])
 
 

--- a/modules/ROOT/pages/access-control/manage-servers.adoc
+++ b/modules/ROOT/pages/access-control/manage-servers.adoc
@@ -153,7 +153,7 @@ m| SHOW SERVERS
 a|
 [source, cyper, role=noplay]
 ----
-SHOW SERVERS
+SHOW SERVER[S]
   [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
   [WHERE expression]
   [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]

--- a/modules/ROOT/pages/access-control/manage-users.adoc
+++ b/modules/ROOT/pages/access-control/manage-users.adoc
@@ -55,7 +55,7 @@ m| SHOW USERS
 a|
 [source, syntax, role="noheader"]
 ----
-SHOW USERS
+SHOW USER[S]
   [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
   [WHERE expression]
   [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
@@ -477,7 +477,7 @@ This example shows how to:
 
 [source, cypher, role=noplay]
 ----
-SHOW USERS YIELD user, suspended, passwordChangeRequired, roles, home
+SHOW USER YIELD user, suspended, passwordChangeRequired, roles, home
 WHERE user = 'jake'
 ----
 ======

--- a/modules/ROOT/pages/databases.adoc
+++ b/modules/ROOT/pages/databases.adoc
@@ -24,13 +24,13 @@ The syntax of the database management commands is as follows:
 |
 [source, syntax, role="noheader"]
 ----
-SHOW { DATABASE name \| DATABASES \| DEFAULT DATABASE \| HOME DATABASE }
+SHOW { DATABASE[S] name \| DATABASE[S] \| DEFAULT DATABASE \| HOME DATABASE }
 [WHERE expression]
 ----
 
 [source, syntax, role="noheader"]
 ----
-SHOW { DATABASE name \| DATABASES \| DEFAULT DATABASE \| HOME DATABASE }
+SHOW { DATABASE[S] name \| DATABASE[S] \| DEFAULT DATABASE \| HOME DATABASE }
 YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]
 [WHERE expression]
 [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]


### PR DESCRIPTION
- `DATABASE` or `DATABASES` in show database commands (excluding show home/default database)
- `SERVER` or `SERVERS` in show sever command
- `USER` or `USERS` in show users command (excluding show current user)
- `ROLE` or `ROLES` in show role command
- `WITH USER` or `WITH USERS` in show role command

We still only allow singular form for:
`SHOW HOME DATABASE`
`SHOW DEFAULT DATABASE`
`SHOW CURRENT USER`
as those shouldn't be able to imply there could be more than one.