### PR TITLE
fix broken links to operations manual 

### DIFF
--- a/modules/ROOT/pages/indexes-for-full-text-search.adoc
+++ b/modules/ROOT/pages/indexes-for-full-text-search.adoc
@@ -43,7 +43,7 @@ In contrast to xref::indexes-for-search-performance.adoc[other indexes], a full-
 * applied to more than one property at a time (similar to a xref::indexes-for-search-performance.adoc#administration-indexes-create-a-composite-range-index-for-nodes[_composite index_]) but with an important difference:
 While a composite index applies only to entities that match the indexed label and _all_ of the indexed properties, full-text index will index entities that have at least one of the indexed labels or relationship types, and at least one of the indexed properties.
 
-For information on how to configure full-text indexes, refer to link:{neo4j-docs-base-uri}/operations-manual/{page-version}/performance/index-configuration#index-configuration-fulltext[Operations Manual -> Indexes to support full-text search].
+For information on how to configure full-text indexes, refer to link:{neo4j-docs-base-uri}/operations-manual/current/performance/index-configuration#index-configuration-fulltext[Operations Manual -> Indexes to support full-text search].
 
 
 [[administration-indexes-fulltext-search-manage]]

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -12,7 +12,7 @@ For query performance purposes, it is important to also understand how the index
 Refer to xref::query-tuning/index.adoc[] for examples and in-depth discussions on how query plans result from different index and query scenarios.
 See specifically xref::query-tuning/indexes.adoc[The use of indexes] for examples of how various index scenarios result in different query plans.
 
-For information on index configuration and limitations, refer to link:{neo4j-docs-base-uri}/operations-manual/{page-version}/performance/index-configuration[Operations Manual -> Index configuration].
+For information on index configuration and limitations, refer to link:{neo4j-docs-base-uri}/operations-manual/current/performance/index-configuration[Operations Manual -> Index configuration].
 
 
 [[administration-indexes-types]]

--- a/modules/ROOT/pages/query-tuning/advanced-example.adoc
+++ b/modules/ROOT/pages/query-tuning/advanced-example.adoc
@@ -20,7 +20,7 @@ Let's explain how to use these features with a more advanced query tuning exampl
 [NOTE]
 ====
 If you are upgrading an existing store to {neo4j-version-exact}, it may be necessary to drop and re-create existing indexes.
-For information on native index support and upgrade considerations regarding indexes, see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/performance/index-configuration#index-configuration-btree[Operations Manual -> Indexes].
+For information on native index support and upgrade considerations regarding indexes, see link:{neo4j-docs-base-uri}/operations-manual/current/performance/index-configuration#index-configuration[Operations Manual -> Indexes].
 ====
 
 


### PR DESCRIPTION
Fix links on the following pages:
- indexes for full text search
- indexes for search performance
- query tuning/advanced examples 