### PR TITLE
Remove old note about variable length pattern matching in versions 2.x

### DIFF
--- a/modules/ROOT/pages/syntax/patterns.adoc
+++ b/modules/ROOT/pages/syntax/patterns.adoc
@@ -202,15 +202,6 @@ You can specify additional constraints by introducing a xref::clauses/where.adoc
 [[cypher-pattern-varlength]]
 == Variable-length pattern matching
 
-[CAUTION]
-====
-Variable length pattern matching in versions 2.1.x and earlier does not enforce relationship uniqueness for patterns described within a single `MATCH` clause.
-This means that a query such as the following: `MATCH (a)-[r]\->(b), p = (a)-[\*]\->(c) RETURN *, relationships(p) AS rs` may include `r` as part of the `rs` set.
-This behavior has changed in versions 2.2.0 and later, in such a way that `r` will be excluded from the result set, as this better adheres to the rules of relationship uniqueness as documented here xref::introduction/uniqueness.adoc[].
-If you have a query pattern that needs to retrace relationships rather than ignoring them as the relationship uniqueness rules normally dictate, you can accomplish this using multiple match clauses, as follows: `MATCH (a)-[r]\->(b) MATCH p = (a)-[*]\->(c) RETURN *, relationships(p)`.
-This will work in all versions of Neo4j that support the `MATCH` clause, namely 2.0.0 and later.
-====
-
 Rather than describing a long path using a sequence of many node and relationship descriptions in a pattern, many relationships (and the intermediate nodes) can be described by specifying a length in the relationship description of a pattern.
 For example:
 


### PR DESCRIPTION
Currently only removing note, pending restructuring of the page on patterns in collaboration with the Langstar team (set for q1 of 2023). 