### PR TITLE
Fix small syntax error in clauses folder

### DIFF
--- a/modules/ROOT/pages/clauses/call-subquery.adoc
+++ b/modules/ROOT/pages/clauses/call-subquery.adoc
@@ -696,7 +696,7 @@ CALL {
 RETURN largeLists
 ----
 
-.Error message:
+.Error message
 [source, output, role="noheader", indent=0]
 ----
 Importing WITH should consist only of simple references to outside variables.

--- a/modules/ROOT/pages/clauses/match.adoc
+++ b/modules/ROOT/pages/clauses/match.adoc
@@ -674,11 +674,11 @@ CREATE
   (thePresident:Movie {title: 'The American President'}),
   (martin)-[:ACTED_IN {role: 'A.J. MacInerney'}]->(thePresident),
   (michael)-[:ACTED_IN {role: 'President Andrew Shepherd'}]->(thePresident),
-  (rob)-[:DIRECTED]->(thePresident)
+  (rob)-[:DIRECTED]->(thePresident);
 MATCH
   (charlie:Person {name: 'Charlie Sheen'}),
   (martin:Person {name: 'Martin Sheen'})
-CREATE (charlie)-[:X {blocked: false}]->(:UNBLOCKED)<-[:X {blocked: false}]-(martin)
+CREATE (charlie)-[:X {blocked: false}]->(:UNBLOCKED)<-[:X {blocked: false}]-(martin);
 CREATE (charlie)-[:X {blocked: true}]->(:BLOCKED)<-[:X {blocked: false}]-(martin)
 ////
 

--- a/modules/ROOT/pages/clauses/merge.adoc
+++ b/modules/ROOT/pages/clauses/merge.adoc
@@ -70,8 +70,8 @@ The following graph is used for the examples below:
 image:graph_merge_clause.svg[]
 
 ////
-CREATE CONSTRAINT FOR (person:Person) REQUIRE person.name IS UNIQUE
-CREATE CONSTRAINT FOR (movie:Movie) REQUIRE movie.title IS UNIQUE
+CREATE CONSTRAINT FOR (person:Person) REQUIRE person.name IS UNIQUE;
+CREATE CONSTRAINT FOR (movie:Movie) REQUIRE movie.title IS UNIQUE;
 CREATE
   (charlie:Person {name: 'Charlie Sheen', bornIn: 'New York', chauffeurName: 'John Brown'}),
   (martin:Person  {name: 'Martin Sheen', bornIn: 'Ohio', chauffeurName: 'Bob Brown'}),
@@ -171,9 +171,9 @@ In this example, the following would significantly improve the performance of th
 
 .Query
 [source, cypher, role="noheader"]
------
+----
 CREATE INDEX PersonIndex FOR (n:Person) ON (n.name)
------
+----
 
 
 [[merge-merge-single-node-derived-from-an-existing-node-property]]
@@ -565,7 +565,7 @@ Merge using unique constraints fails when finding partial matches.
 [source, cypher, indent=0]
 ----
 MERGE (michael:Person {name: 'Michael Douglas', role: 'Gordon Gekko'})
-#RETURN michael
+RETURN michael
 ----
 
 While there is a matching unique `'michael'` node with the name `'Michael Douglas'`, there is no unique node with the role of `'Gordon Gekko'` and `MERGE` fails to match.

--- a/modules/ROOT/pages/clauses/return.adoc
+++ b/modules/ROOT/pages/clauses/return.adoc
@@ -202,7 +202,7 @@ Any expression can be used as a return item -- literals, predicates, properties,
 [source, cypher, indent=0]
 ----
 MATCH (a {name: 'A'})
-RETURN a.age > 30, "I'm a literal", [p=(a)-->() | p] AS `(a)-->()` AS `(a)-->()`
+RETURN a.age > 30, "I'm a literal", [p=(a)-->() | p] AS `(a)-->()`
 ----
 
 Returns a predicate, a literal and function call with a pattern expression parameter.

--- a/modules/ROOT/pages/clauses/use.adoc
+++ b/modules/ROOT/pages/clauses/use.adoc
@@ -61,7 +61,7 @@ When executing queries against a composite database, the `USE` clause must only 
 
 In this example it is assumed that the DBMS contains a database named `myDatabase`:
 
-.Query.
+.Query
 [source, cypher, indent=0]
 ----
 USE myDatabase
@@ -74,7 +74,7 @@ MATCH (n) RETURN n
 
 In this example it is assumed that the DBMS contains a composite database named `myComposite`, which includes an alias named `myConstituent`:
 
-.Query.
+.Query
 [source, cypher, indent=0]
 ----
 USE myComposite.myConstituent
@@ -89,7 +89,7 @@ The built-in function `graph.byName()` can be used in the `USE` clause to resolv
 
 This example uses a composite database named `myComposite` that includes an alias named `myConstituent`:
 
-.Query.
+.Query
 [source, cypher, indent=0]
 ----
 USE graph.byName('myComposite.myConstituent')
@@ -98,7 +98,7 @@ MATCH (n) RETURN n
 
 The argument can be any expression that evaluates to the name of a constituent graph - for example a parameter:
 
-.Query.
+.Query
 [source, cypher]
 ----
 USE graph.byName($graphName)


### PR DESCRIPTION
Here are some small mistype we notice during the work for test the cypher query under /clauses/*adoc

We put some issue we notice in here:
https://docs.google.com/document/d/1YzMD5kkfDnMS9WEhk4PaAxZTVqIsZVteS_Heye_c8G4/edit

Some of they we are trying to fix in this PR