### PR TITLE
square function returns NaN when given a negative number  (#284)

### DIFF
--- a/modules/ROOT/pages/functions/mathematical-logarithmic.adoc
+++ b/modules/ROOT/pages/functions/mathematical-logarithmic.adoc
@@ -291,7 +291,7 @@ sqrt(expression)
 |===
 
 | `sqrt(null)` returns `null`.
-| `sqrt(<any negative number>)` returns `null`
+| `sqrt(<any negative number>)` returns `NaN`
 
 |===
 


### PR DESCRIPTION
The documentation did not match the implementation. The result of NaN has been accepted for now until we do an overarching analysis of all numeric functions.

Original PR: https://github.com/neo4j/docs-cypher/pull/284

