### PR TITLE
Add missing seeding options (#285)

### DIFF
--- a/modules/ROOT/pages/databases.adoc
+++ b/modules/ROOT/pages/databases.adoc
@@ -551,7 +551,7 @@ CREATE DATABASE `topology-example` TOPOLOGY 1 PRIMARY 0 SECONDARIES
 ----
 
 // TODO: Add result
-For more details on primary and secondary server roles, see link:{neo4j-docs-base-uri}/operations-manual{page-version}/clustering#clustering-introduction-operational[Cluster overview].
+For more details on primary and secondary server roles, see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/clustering#clustering-introduction-operational[Cluster overview].
 
 [NOTE]
 ====
@@ -687,12 +687,28 @@ Currently this is only supported with `existingDataSeedInstance` and must be set
 Defines which instance is used for seeding the data of the created database.
 The instance id can be taken from the id column of the `dbms.cluster.overview()` procedure. Can only be used in clusters.
 
+| `seedURI`
+| URI to a backup or a dump from an existing database.
+|
+Defines an identical seed from an external source which will be used to seed all servers.
+
+| `seedConfig`
+| comma separated list of configuration values.
+|
+Defines additional configuration specified by comma separated `name=value` pairs that might be required by certain seed providers.
+
+| `seedCredentials`
+| credentials
+|
+Defines credentials that needs to be passed into certain seed providers.
+
 |===
 
 
 [NOTE]
 ====
-The `existingData` and `existingDataSeedInstance` options cannot be combined with the `OR REPLACE` part of this command.
+The `existingData`, `existingDataSeedInstance`, `seedURI`, `seedConfig` and `seedCredentials` options cannot be combined with the `OR REPLACE` part of this command.
+For details about the use of these seeding options, see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/clustering/databases/#cluster-seed[Operations Manual -> Seed a cluster].
 ====
 
 
@@ -707,7 +723,7 @@ Standard databases can be modified using the command `ALTER DATABASE`.
 
 By default, a database has read-write access mode on creation.
 The database can be limited to read-only mode on creation using the configuration parameters `dbms.databases.default_to_read_only`, `dbms.databases.read_only`, and `dbms.database.writable`.
-For details, see link:{neo4j-docs-base-uri}/operations-manual{page-version}/manage-databases/configuration#manage_database_parameters[Configuration parameters].
+For details, see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/manage-databases/configuration#manage_database_parameters[Configuration parameters].
 
 A database that was created with read-write access mode can be changed to read-only.
 To change it to read-only, you can use the `ALTER DATABASE` command with the sub-clause `SET ACCESS READ ONLY`.

--- a/modules/ROOT/pages/query-tuning/query-options.adoc
+++ b/modules/ROOT/pages/query-tuning/query-options.adoc
@@ -256,7 +256,7 @@ Cypher replanning occurs in the following circumstances:
 
 * When the query is not in the cache.
 This can either be when the server is first started or restarted, if the cache has recently been cleared, or if link:{neo4j-docs-base-uri}/operations-manual/{page-version}/reference/configuration-settings#config_server.db.query_cache_size[server.db.query_cache_size] was exceeded.
-* When the time has past the link:{neo4j-docs-base-uri}/operations-manual{page-version}/reference/configuration-settings#config_dbms.cypher.min_replan_interval[dbms.cypher.min_replan_interval] value, and the database statistics have changed more than the link:{neo4j-docs-base-uri}/operations-manual/{page-version}/reference/configuration-settings#config_dbms.cypher.statistics_divergence_threshold[dbms.cypher.statistics_divergence_threshold] value.
+* When the time has past the link:{neo4j-docs-base-uri}/operations-manual/{page-version}/reference/configuration-settings#config_dbms.cypher.min_replan_interval[dbms.cypher.min_replan_interval] value, and the database statistics have changed more than the link:{neo4j-docs-base-uri}/operations-manual/{page-version}/reference/configuration-settings#config_dbms.cypher.statistics_divergence_threshold[dbms.cypher.statistics_divergence_threshold] value.
 
 There may be situations where xref::execution-plans/index.adoc[Cypher query planning] can occur at a non-ideal time.
 For example, when a query must be as fast as possible and a valid plan is already in place.


### PR DESCRIPTION
Add missing seeding options for `CREATE DATABASE`, also fixes a couple of broken links.

Original PR:  https://github.com/neo4j/docs-cypher/pull/285