### PR TITLE
Add a warning about ALTER DATABASE and single primaries (#289)

### DIFF
--- a/modules/ROOT/pages/databases.adoc
+++ b/modules/ROOT/pages/databases.adoc
@@ -834,6 +834,12 @@ SET TOPOLOGY 3 PRIMARY 0 SECONDARIES
 
 ======
 
+[NOTE]
+====
+It is not possible to automatically transition to or from a topology with a single primary host.
+See the link:{neo4j-docs-base-uri}/operations-manual/{page-version}/clustering/databases#_alter_topology[Operations Manual -> Alter topology] for more information.
+====
+
 
 .+SHOW DATABASE+
 ======
@@ -846,7 +852,7 @@ SHOW DATABASES yield name, currentPrimariesCount, currentSecondariesCount, reque
 
 ======
 
-For more details on primary and secondary server roles, see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/clustering/inroduction#clustering-introduction-operational[Cluster overview].
+For more details on primary and secondary server roles, see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/clustering/introduction#clustering-introduction-operational[Operations Manual -> Clustering overview].
 
 [NOTE]
 ====


### PR DESCRIPTION
We cannot currently move from one primary to more than one, or from more than one primary to one primary. This limitation is noted elsewhere, but worth adding here too.

Original PR: https://github.com/neo4j/docs-cypher/pull/289
