### PR TITLE
Temporary remove the new relationship constraint docs again as it is re-hidden by feature flag

### DIFF
--- a/modules/ROOT/pages/constraints/examples.adoc
+++ b/modules/ROOT/pages/constraints/examples.adoc
@@ -50,10 +50,13 @@ FOR (book:Book) REQUIRE book.isbn IS UNIQUE
 Unique constraints added: 1
 ----
 
+////
+TODO: Re-add this part when adding back relationship key and uniqueness constraints
 [NOTE]
 ====
 The statistics will be updated to say `Node uniqueness constraints` in Neo4j version 6.0.
 ====
+////
 
 ======
 
@@ -87,10 +90,13 @@ Assuming no constraint with the given name or other node property uniqueness con
 Unique constraints added: 1
 ----
 
+////
+TODO: Re-add this part when adding back relationship key and uniqueness constraints
 [NOTE]
 ====
 The statistics will be updated to say `Node uniqueness constraints` in Neo4j version 6.0.
 ====
+////
 
 ======
 
@@ -132,10 +138,13 @@ OPTIONS {
 Unique constraints added: 1
 ----
 
+////
+TODO: Re-add this part when adding back relationship key and uniqueness constraints
 [NOTE]
 ====
 The statistics will be updated to say `Node uniqueness constraints` in Neo4j version 6.0.
 ====
+////
 
 ======
 
@@ -172,10 +181,13 @@ Constraint already exists:
 Constraint( id=4, name='preExistingUnique', type='UNIQUENESS', schema=(:Book {title}), ownedIndex=3 )
 ----
 
+////
+TODO: Re-add this part when adding back relationship key and uniqueness constraints
 [NOTE]
 ====
 The constraint type will be updated to say `NODE_UNIQUENESS` in Neo4j version 6.0.
 ====
+////
 
 ======
 
@@ -313,14 +325,18 @@ Unable to create Constraint( name='constraint_62365a16', type='UNIQUENESS', sche
 Both Node(0) and Node(1) have the label `Book` and property `isbn` = '1449356265'
 ----
 
+////
+TODO: Re-add this part when adding back relationship key and uniqueness constraints
 [NOTE]
 ====
 The constraint type will be updated to say `NODE_UNIQUENESS` in Neo4j version 6.0.
 ====
+////
 
 ======
 
-
+////
+TODO: Re-add this part when adding back relationship key and uniqueness constraints
 [[constraints-examples-relationship-uniqueness]]
 == Relationship property uniqueness constraints
 
@@ -450,10 +466,8 @@ There are no valid index configuration values for the constraint-backing range i
 
 Create a property uniqueness constraint on the property `nickname` on relationships with the `FRIENDS_WITH` relationship type, when that constraint already exists.
 
-////
-Set-up to get expected behavior:
-CREATE CONSTRAINT preExistingUnique FOR ()-[friend:FRIENDS_WITH]-() REQUIRE friend.nickname IS UNIQUE
-////
+// Set-up to get expected behavior:
+// CREATE CONSTRAINT preExistingUnique FOR ()-[friend:FRIENDS_WITH]-() REQUIRE friend.nickname IS UNIQUE
 
 .Query
 [source, cypher, indent=0]
@@ -483,10 +497,8 @@ Constraint( id=4, name='preExistingUnique', type='RELATIONSHIP_UNIQUENESS', sche
 
 Create a property uniqueness constraint on the property `nickname` on relationships with the `FRIENDS_WITH` relationship type, when an index already exists on that relationship type and property combination.
 
-////
-Set-up to get expected behavior:
-CREATE INDEX FOR ()-[friend:FRIENDS_WITH]-() ON (friend.nickname)
-////
+// Set-up to get expected behavior:
+// CREATE INDEX FOR ()-[friend:FRIENDS_WITH]-() ON (friend.nickname)
 
 .Query
 [source, cypher, indent=0]
@@ -516,10 +528,8 @@ A constraint cannot be created until the index has been dropped.
 
 Create a `FRIENDS_WITH` relationship with an `nickname` that is not already in the database.
 
-////
-Set-up to get expected behavior:
-CREATE CONSTRAINT FOR ()-[friend:FRIENDS_WITH]-() REQUIRE friend.nickname IS UNIQUE
-////
+// Set-up to get expected behavior:
+// CREATE CONSTRAINT FOR ()-[friend:FRIENDS_WITH]-() REQUIRE friend.nickname IS UNIQUE
 
 .Query
 [source, cypher, indent=0]
@@ -552,11 +562,9 @@ Labels added: 2
 
 Create a `FRIENDS_WITH` relationship with an `nickname` that is already used in the database.
 
-////
-Set-up to get expected behavior:
-CREATE CONSTRAINT FOR ()-[friend:FRIENDS_WITH]-() REQUIRE friend.nickname IS UNIQUE
-CREATE (:Person {name: 'Emma'}), (:Person {name: 'Josefin'})-[:FRIENDS_WITH {nickname: 'Mimi'}]->(:Person {name: 'Emilia'})
-////
+// Set-up to get expected behavior:
+// CREATE CONSTRAINT FOR ()-[friend:FRIENDS_WITH]-() REQUIRE friend.nickname IS UNIQUE
+// CREATE (:Person {name: 'Emma'}), (:Person {name: 'Josefin'})-[:FRIENDS_WITH {nickname: 'Mimi'}]->(:Person {name: 'Emilia'})
 
 .Query
 [source, cypher, indent=0]
@@ -586,11 +594,9 @@ Relationship(0) already exists with type `FRIENDS_WITH` and property `nickname` 
 
 Create a property uniqueness constraint on the property `nickname` on relationships with the `FRIENDS_WITH` relationship type when there are two relationships with the same `nickname`.
 
-////
-Set-up to get expected behavior:
-CREATE (emma:Person {name: 'Emma'}), (josefin:Person {name: 'Josefin'}), (emilia:Person {name: 'Emilia'})
-CREATE (josefin)-[:FRIENDS_WITH {nickname: 'Mimi'}]->(emilia), (emma)-[:FRIENDS_WITH {nickname: 'Mimi'}]->(emilia)
-////
+// Set-up to get expected behavior:
+// CREATE (emma:Person {name: 'Emma'}), (josefin:Person {name: 'Josefin'}), (emilia:Person {name: 'Emilia'})
+// CREATE (josefin)-[:FRIENDS_WITH {nickname: 'Mimi'}]->(emilia), (emma)-[:FRIENDS_WITH {nickname: 'Mimi'}]->(emilia)
 
 .Query
 [source, cypher, indent=0]
@@ -609,7 +615,7 @@ Both Relationship(0) and Relationship(1) have the type `FRIENDS_WITH` and proper
 ----
 
 ======
-
+////
 
 [role=enterprise-edition]
 [[constraints-examples-node-property-existence]]
@@ -652,11 +658,14 @@ FOR (book:Book) REQUIRE book.isbn IS NOT NULL
 Property existence constraints added: 1
 ----
 
+////
+TODO: Re-add this part when adding back relationship key and uniqueness constraints
 [NOTE]
 ====
 The statistics for property existence constraints will be split between nodes and relationships in Neo4j version 6.0.
 For the node property existence constraints, they will say `Node property existence constraints`.
 ====
+////
 
 ======
 
@@ -908,11 +917,14 @@ FOR ()-[like:LIKED]-() REQUIRE like.day IS NOT NULL
 Property existence constraints added: 1
 ----
 
+////
+TODO: Re-add this part when adding back relationship key and uniqueness constraints
 [NOTE]
 ====
 The statistics for property existence constraints will be split between nodes and relationships in Neo4j version 6.0.
 For the relationship property existence constraints, they will say `Relationship property existence constraints`.
 ====
+////
 
 ======
 
@@ -1444,7 +1456,8 @@ Node(0) with label `Person` must have the properties (`firstname`, `surname`)
 
 ======
 
-
+////
+TODO: Re-add this part when adding back relationship key and uniqueness constraints
 [role=enterprise-edition]
 [[constraints-examples-relationship-key]]
 == Relationship key constraints
@@ -1504,10 +1517,8 @@ This will ensure that no error is thrown and no constraint is created if any oth
 .+CREATE CONSTRAINT+
 ======
 
-////
-Set-up to get expected behavior:
-CREATE CONSTRAINT FOR ()-[r:ROAD]-() REQUIRE (r.startPoint, r.endPoint) IS RELATIONSHIP KEY
-////
+// Set-up to get expected behavior:
+// CREATE CONSTRAINT FOR ()-[r:ROAD]-() REQUIRE (r.startPoint, r.endPoint) IS RELATIONSHIP KEY
 
 .Query
 [source, cypher, indent=0]
@@ -1579,10 +1590,8 @@ There is no valid index configuration values for the constraint-backing range in
 
 Create a relationship key constraint on the properties `startPoint` and `endPoint` on relationships with the `ROAD` relationship type, when a property uniqueness constraint already exists on the same relationship type and property combination.
 
-////
-Set-up to get expected behavior:
-CREATE CONSTRAINT preExistingUnique FOR ()-[r:ROAD]-() REQUIRE (r.startPoint, r.endPoint) IS UNIQUE
-////
+// Set-up to get expected behavior:
+// CREATE CONSTRAINT preExistingUnique FOR ()-[r:ROAD]-() REQUIRE (r.startPoint, r.endPoint) IS UNIQUE
 
 .Query
 [source, cypher, indent=0]
@@ -1612,10 +1621,8 @@ Constraint( id=4, name='preExistingUnique', type='RELATIONSHIP_UNIQUENESS', sche
 
 Create a named relationship key constraint on the property `coordinates` on relationships with the `INTERSECTION` relationship type, when an index already exists with the given name.
 
-////
-Set-up to get expected behavior:
-CREATE INDEX intersections FOR ()-[intersect:Roundabout]-() ON (intersect.coordinates)
-////
+// Set-up to get expected behavior:
+// CREATE INDEX intersections FOR ()-[intersect:Roundabout]-() ON (intersect.coordinates)
 
 .Query
 [source, cypher, indent=0]
@@ -1645,11 +1652,9 @@ There already exists an index called 'intersections'.
 
 Create a `ROAD` relationship with both a `startPoint` and `endPoint` property.
 
-////
-Set-up to get expected behavior:
-CREATE CONSTRAINT FOR ()-[r:ROAD]-() REQUIRE (r.startPoint, r.endPoint) IS REL KEY
-CREATE (:Intersection {name: 'a', coordinates: point({x: 1, y:2})}), (:Intersection {name: 'b', coordinates: point({x: 2, y:5})})
-////
+// Set-up to get expected behavior:
+// CREATE CONSTRAINT FOR ()-[r:ROAD]-() REQUIRE (r.startPoint, r.endPoint) IS REL KEY
+// CREATE (:Intersection {name: 'a', coordinates: point({x: 1, y:2})}), (:Intersection {name: 'b', coordinates: point({x: 2, y:5})})
 
 .Query
 [source, cypher, indent=0]
@@ -1681,11 +1686,9 @@ Properties set: 2
 
 Trying to create a `INTERSECTION` relationship without a `coordinates` property, given a relationship key constraint on `:INTERSECTION(coordinates)`, will fail.
 
-////
-Set-up to get expected behavior:
-CREATE CONSTRAINT FOR ()-[r:INTERSECTION]-() REQUIRE (r.coordinates) IS REL KEY
-CREATE (:Road {name: 'a'}), (:Road {name: 'b'})
-////
+// Set-up to get expected behavior:
+// CREATE CONSTRAINT FOR ()-[r:INTERSECTION]-() REQUIRE (r.coordinates) IS REL KEY
+// CREATE (:Road {name: 'a'}), (:Road {name: 'b'})
 
 .Query
 [source, cypher, indent=0]
@@ -1715,12 +1718,10 @@ Relationship(0) with type `INTERSECTION` must have the property `coordinates`
 
 Trying to remove the `endPoint` property from an existing relationship `ROAD`, given a `RELATIONSHIP KEY` constraint on `:ROAD(startPoint, endPoint)`.
 
-////
-Set-up to get expected behavior:
-CREATE CONSTRAINT FOR ()-[r:ROAD]-() REQUIRE (r.startPoint, r.endPoint) IS REL KEY
-CREATE (a:Intersection {name: 'a', coordinates: point({x: 1, y:2})}), (b:Intersection {name: 'b', coordinates: point({x: 2, y:5})})
-CREATE (a)-[:ROAD {startPoint: a.coordinates, endPoint: b.coordinates}]->(b)
-////
+// Set-up to get expected behavior:
+// CREATE CONSTRAINT FOR ()-[r:ROAD]-() REQUIRE (r.startPoint, r.endPoint) IS REL KEY
+// CREATE (a:Intersection {name: 'a', coordinates: point({x: 1, y:2})}), (b:Intersection {name: 'b', coordinates: point({x: 2, y:5})})
+// CREATE (a)-[:ROAD {startPoint: a.coordinates, endPoint: b.coordinates}]->(b)
 
 .Query
 [source, cypher, indent=0]
@@ -1749,12 +1750,10 @@ Relationship(0) with type `ROAD` must have the properties (`startPoint`, `endPoi
 
 Trying to create a relationship key constraint on the property `coordinates` on relationships with the `INTERSECTION` relationship type will fail when two relationships with identical `coordinates` already exists in the database.
 
-////
-Set-up to get expected behavior:
-CREATE (a:Road {name: 'a'}), (b:Road {name: 'b'})
-CREATE (a)-[:INTERSECTION {coordinates: point({x:1, y:2})}]->(b)
-CREATE (a)<-[:INTERSECTION {coordinates: point({x:1, y:2})}]-(b)
-////
+// Set-up to get expected behavior:
+// CREATE (a:Road {name: 'a'}), (b:Road {name: 'b'})
+// CREATE (a)-[:INTERSECTION {coordinates: point({x:1, y:2})}]->(b)
+// CREATE (a)<-[:INTERSECTION {coordinates: point({x:1, y:2})}]-(b)
 
 .Query
 [source, cypher, indent=0]
@@ -1773,7 +1772,7 @@ Both Relationship(0) and Relationship(1) have the type `INTERSECTION` and proper
 ----
 
 ======
-
+////
 
 [[constraints-examples-drop-constraint]]
 == Drop a constraint by name
@@ -1787,7 +1786,9 @@ Both Relationship(0) and Relationship(1) have the type `INTERSECTION` and proper
 === Drop a constraint
 
 A constraint can be dropped using the name with the `DROP CONSTRAINT constraint_name` command.
-It is the same command for uniqueness, property existence, and node/relationship key constraints.
+It is the same command for uniqueness, property existence, and node key constraints.
+// TODO: Switch the row above to the one below when adding back relationship key and uniqueness constraints
+//It is the same command for uniqueness, property existence, and node/relationship key constraints.
 The name of the constraint can be found using the xref::constraints/syntax.adoc#constraints-syntax-list[`SHOW CONSTRAINTS` command], given in the output column `name`.
 
 
@@ -1822,7 +1823,9 @@ Named constraints removed: 1
 === Drop a non-existing constraint
 
 If it is uncertain if any constraint with a given name exists and you want to drop it if it does but not get an error should it not, use `IF EXISTS`.
-It is the same command for uniqueness, property existence, and node/relationship key constraints.
+It is the same command for uniqueness, property existence, and node constraints.
+// TODO: Switch the row above to the one below when adding back relationship key and uniqueness constraints
+//It is the same command for uniqueness, property existence, and node/relationship key constraints.
 
 .+DROP CONSTRAINT+
 ======
@@ -1871,7 +1874,7 @@ This can be used to drop the constraint with the xref::constraints/syntax.adoc#c
 ////
 Set-up to get expected behavior:
 CREATE CONSTRAINT isbnConstraint FOR (n:Book) REQUIRE (n.isbn) IS UNIQUE
-CREATE CONSTRAINT roadConstraint FOR ()-[r:ROAD]-() REQUIRE (r.startPoint, r.endPoint) IS UNIQUE
+(TODO: not relevant until the constraint is re-added) CREATE CONSTRAINT roadConstraint FOR ()-[r:ROAD]-() REQUIRE (r.startPoint, r.endPoint) IS UNIQUE
 ////
 
 .Query
@@ -1882,6 +1885,18 @@ SHOW CONSTRAINTS
 
 [queryresult]
 ----
++---------------------------------------------------------------------------------------------------+
+| id | name             | type         | entityType | labelsOrTypes | properties | ownedIndex       |
++---------------------------------------------------------------------------------------------------+
+| 4  | "isbnConstraint" | "UNIQUENESS" | "NODE"     | ["Book"]      | ["isbn"]   | "isbnConstraint" |
++---------------------------------------------------------------------------------------------------+
+2 rows
+----
+
+////
+TODO: Switch the result above to the one below when adding back relationship key and uniqueness constraints
+[queryresult]
+----
 +------------------------------------------------------------------------------------------------------------------------------------+
 | id | name             | type                      | entityType     | labelsOrTypes | properties                 | ownedIndex       |
 +------------------------------------------------------------------------------------------------------------------------------------+
@@ -1890,12 +1905,16 @@ SHOW CONSTRAINTS
 +------------------------------------------------------------------------------------------------------------------------------------+
 2 rows
 ----
+////
 
+////
+TODO: Re-add this part when adding back relationship key and uniqueness constraints
 [NOTE]
 ====
 The `type` column returns `UNIQUENESS` for the node property uniqueness constraint and `RELATIONSHIP_UNIQUENESS` for the relationship property uniqueness constraint.
 The `type` for node property uniqueness constraint will be updated to `NODE_UNIQUENESS` in Neo4j version 6.0.
 ====
+////
 
 ======
 

--- a/modules/ROOT/pages/constraints/index.adoc
+++ b/modules/ROOT/pages/constraints/index.adoc
@@ -18,10 +18,13 @@ Unique node property constraints, or node property uniqueness constraints, ensur
 For property uniqueness constraints on multiple properties, the combination of the property values is unique.
 Node property uniqueness constraints do not require all nodes to have a unique value for the properties listed (nodes without all properties are not subject to this rule).
 
+// TODO: Re-add this part when adding back relationship key and uniqueness constraints
+////
 *Unique relationship property constraints*::
 Unique relationship property constraints, or relationship property uniqueness constraints, ensure that property values are unique for all relationships with a specific type.
 For property uniqueness constraints on multiple properties, the combination of the property values is unique.
 Relationship property uniqueness constraints do not require all relationships to have a unique value for the properties listed (relationships without all properties are not subject to this rule).
+////
 
 *Node property existence constraints* label:enterprise-edition[]::
 Node property existence constraints ensure that a property exists for all nodes with a specific label.
@@ -47,6 +50,8 @@ Queries attempting to do any of the following will fail:
 * Remove one of the mandatory properties.
 * Update the properties so that the combination of property values is no longer unique.
 
+// TODO: Re-add this part when adding back relationship key and uniqueness constraints
+////
 *Relationship key constraints* label:enterprise-edition[]::
 Relationship key constraints ensure that, for a given type and set of properties:
 +
@@ -60,11 +65,14 @@ Queries attempting to do any of the following will fail:
 * Create new relationships without all the properties or where the combination of property values is not unique.
 * Remove one of the mandatory properties.
 * Update the properties so that the combination of property values is no longer unique.
+////
 
 
 [NOTE]
 ====
-Node key constraints, relationship key constraints, node property existence constraints, and relationship property existence constraints are only available in Neo4j Enterprise Edition.
+Node key constraints, node property existence constraints, and relationship property existence constraints are only available in Neo4j Enterprise Edition.
+// TODO: Switch the row above to the one below when adding back relationship key and uniqueness constraints
+//Node key constraints, relationship key constraints, node property existence constraints, and relationship property existence constraints are only available in Neo4j Enterprise Edition.
 Databases containing one of these constraint types cannot be opened using Neo4j Community Edition.
 ====
 
@@ -73,15 +81,26 @@ Databases containing one of these constraint types cannot be opened using Neo4j 
 
 Creating a constraint has the following implications on indexes:
 
+* Adding a node key or property uniqueness constraint on a single property also adds an index on that property, and therefore, an index of the same index type, label, and property combination cannot be added separately.
+* Adding a node key or property uniqueness constraint for a set of properties also adds an index on those properties, and therefore, an index of the same index type, label, and properties combination cannot be added separately.
+* Cypher will use these indexes for lookups just like other indexes.
+  Refer to xref::indexes-for-search-performance.adoc[] for more details on indexes.
+* If a node key or property uniqueness constraint is dropped and the backing index is still required, the index need to be created explicitly.
+
+////
+TODO: Switch the part above to the one below when adding back relationship key and uniqueness constraints
 * Adding a node key, relationship key, or property uniqueness constraint on a single property also adds an index on that property, and therefore, an index of the same index type, label/relationship type, and property combination cannot be added separately.
 * Adding a node key, relationship key, or property uniqueness constraint for a set of properties also adds an index on those properties, and therefore, an index of the same index type, label/relationship type, and properties combination cannot be added separately.
 * Cypher will use these indexes for lookups just like other indexes.
   Refer to xref::indexes-for-search-performance.adoc[] for more details on indexes.
 * If a node key, relationship key, or property uniqueness constraint is dropped and the backing index is still required, the index need to be created explicitly.
+////
 
 Additionally, the following is true for constraints:
 
-* A given label or relationship type can have multiple constraints, and uniqueness and property existence constraints can be combined on the same property.
+* A given label can have multiple constraints, and uniqueness and property existence constraints can be combined on the same property.
+// TODO: Switch the row above to the one below when adding back relationship key and uniqueness constraints
+//* A given label or relationship type can have multiple constraints, and uniqueness and property existence constraints can be combined on the same property.
 * Adding constraints is an atomic operation that can take a while -- all existing data has to be scanned before Neo4j DBMS can turn the constraint 'on'.
 * Best practice is to give the constraint a name when it is created.
 If the constraint is not explicitly named, it will get an auto-generated name.

--- a/modules/ROOT/pages/constraints/syntax.adoc
+++ b/modules/ROOT/pages/constraints/syntax.adoc
@@ -56,6 +56,8 @@ REQUIRE (n.propertyName_1, ..., n.propertyName_n) IS [NODE] UNIQUE
 Index provider can be specified using the `OPTIONS` clause.
 
 
+////
+TODO: Re-add this part when adding back relationship key and uniqueness constraints
 [[constraints-syntax-create-rel-unique]]
 [discrete]
 === Create a relationship property uniqueness constraint
@@ -79,6 +81,7 @@ REQUIRE (r.propertyName_1, ..., r.propertyName_n) IS [REL[ATIONSHIP]] UNIQUE
 ----
 
 Index provider can be specified using the `OPTIONS` clause.
+////
 
 
 [[constraints-syntax-create-node-exists]]
@@ -146,6 +149,8 @@ REQUIRE (n.propertyName_1, ..., n.propertyName_n) IS [NODE] KEY
 Index provider can be specified using the `OPTIONS` clause.
 
 
+////
+TODO: Re-add this part when adding back relationship key and uniqueness constraints
 [[constraints-syntax-create-rel-key]]
 [discrete]
 === Create a relationship key constraint label:enterprise-edition[]
@@ -169,6 +174,7 @@ REQUIRE (r.propertyName_1, ..., r.propertyName_n) IS [REL[ATIONSHIP]] KEY
 ----
 
 Index provider can be specified using the `OPTIONS` clause.
+////
 
 
 [[constraints-syntax-drop]]
@@ -206,6 +212,21 @@ The simple version of the command allows for a `WHERE` clause and will give back
 ----
 SHOW [
       ALL
+     |UNIQUE[NESS]
+     |NODE [PROPERTY] EXIST[ENCE]
+     |REL[ATIONSHIP] [PROPERTY] EXIST[ENCE]
+     |[PROPERTY] EXIST[ENCE]
+     |NODE KEY
+] CONSTRAINT[S]
+  [WHERE expression]
+----
+
+////
+TODO: Switch the syntax above to the one below when adding back relationship key and uniqueness constraints
+[source, syntax, role="noheader", indent=0]
+----
+SHOW [
+      ALL
      |NODE UNIQUE[NESS]
      |REL[ATIONSHIP] UNIQUE[NESS]
      |UNIQUE[NESS]
@@ -218,9 +239,27 @@ SHOW [
 ] CONSTRAINT[S]
   [WHERE expression]
 ----
+////
 
 To get the full set of output columns, a yield clause is needed:
 
+[source, syntax, role="noheader", indent=0]
+----
+SHOW [
+      ALL
+     |UNIQUE[NESS]
+     |NODE [PROPERTY] EXIST[ENCE]
+     |REL[ATIONSHIP] [PROPERTY] EXIST[ENCE]
+     |[PROPERTY] EXIST[ENCE]
+     |NODE KEY
+] CONSTRAINT[S]
+YIELD { * | field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]
+  [WHERE expression]
+  [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+----
+
+////
+TODO: Switch the syntax above to the one below when adding back relationship key and uniqueness constraints
 [source, syntax, role="noheader", indent=0]
 ----
 SHOW [
@@ -239,6 +278,7 @@ YIELD { * | field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]
   [WHERE expression]
   [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
 ----
+////
 
 
 The type filtering keywords filters the returned constraints on constraint type:
@@ -253,14 +293,18 @@ The type filtering keywords filters the returned constraints on constraint type:
 | Returns all constraints, no filtering on constraint type.
 This is the default if none is given.
 
-|NODE UNIQUE[NESS]
-| Returns the node property uniqueness constraints.
+// TODO: Re-add these parts when adding back relationship key and uniqueness constraints
+//|NODE UNIQUE[NESS]
+//| Returns the node property uniqueness constraints.
 
-|REL[ATIONSHIP] UNIQUE[NESS]
-| Returns the relationship property uniqueness constraints.
+//|REL[ATIONSHIP] UNIQUE[NESS]
+//| Returns the relationship property uniqueness constraints.
 
 |UNIQUE[NESS]
-| Returns all property uniqueness constraints, for both nodes and relationships.
+| Returns all property uniqueness constraints.
+// TODO: Switch the part above to the one below when adding back relationship key and uniqueness constraints
+//|UNIQUE[NESS]
+//| Returns all property uniqueness constraints, for both nodes and relationships.
 
 |NODE [PROPERTY] EXIST[ENCE]
 | Returns the node property existence constraints.
@@ -274,11 +318,12 @@ This is the default if none is given.
 |NODE KEY
 | Returns the node key constraints.
 
-|REL[ATIONSHIP] KEY
-| Returns the relationship key constraints.
+// TODO: Re-add these parts when adding back relationship key and uniqueness constraints
+//|REL[ATIONSHIP] KEY
+//| Returns the relationship key constraints.
 
-|KEY
-| Returns all node and relationship key constraints.
+//|KEY
+//| Returns all node and relationship key constraints.
 
 |===
 
@@ -297,7 +342,9 @@ The returned columns from the show command is:
 | Name of the constraint (explicitly set by the user or automatically assigned). label:default-output[]
 
 | type
-| The ConstraintType of this constraint (`UNIQUENESS` (node uniqueness), `RELATIONSHIP_UNIQUENESS`, `NODE_PROPERTY_EXISTENCE`, `RELATIONSHIP_PROPERTY_EXISTENCE`, `NODE_KEY`, or `RELATIONSHIP_KEY`). label:default-output[]
+| The ConstraintType of this constraint (`UNIQUENESS`, `NODE_PROPERTY_EXISTENCE`, `RELATIONSHIP_PROPERTY_EXISTENCE`, or `NODE_KEY`). label:default-output[]
+// TODO: Switch the row above to the one below when adding back relationship key and uniqueness constraints
+//| The ConstraintType of this constraint (`UNIQUENESS` (node uniqueness), `RELATIONSHIP_UNIQUENESS`, `NODE_PROPERTY_EXISTENCE`, `RELATIONSHIP_PROPERTY_EXISTENCE`, `NODE_KEY`, or `RELATIONSHIP_KEY`). label:default-output[]
 
 | entityType
 | Type of entities this constraint represents (nodes or relationship). label:default-output[]

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -12,6 +12,8 @@ Replacement syntax for deprecated and removed features are also indicated.
 [[cypher-deprecations-additions-removals-5.3]]
 == Version 5.3
 
+// TODO: Re-add this part in whatever version (not 5.3...) the relationship key and uniqueness constraints are added back in
+////
 === Deprecated features
 
 [cols="2", options="header"]
@@ -34,6 +36,7 @@ The current constraint type for node property uniqueness constraints, `UNIQUENES
 This will also be reflected in updates to some error messages and query statistics.
 
 |===
+////
 
 === Updated features
 
@@ -85,8 +88,20 @@ a|
 
 A `COUNT` subquery now supports any non-writing query. For example, it now supports `UNION` and `CALL` clauses.
 
+a|
+label:syntax[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+SHOW UNIQUE[NESS] CONSTRAINTS
+----
+a|
+The property uniqueness constraint type filter now allow both `UNIQUE` and `UNIQUENESS` keywords.
+
 |===
 
+// TODO: Re-add this part in whatever version (not 5.3...) the relationship key and uniqueness constraints are added back in
+////
 === New features
 
 [cols="2", options="header"]
@@ -127,11 +142,10 @@ a|
 Added filtering for the new constraint types to `SHOW CONSTRAINTS`.
 Includes filtering for the node part, relationship part, or both parts of each type (`NODE KEY` filtering already exists previously).
 
-The existing `UNIQUE` filter will now return both node and relationship property uniqueness constraints.
-All property uniqueness constraint type filters now allow both `UNIQUE` and `UNIQUENESS` keywords.
-
+The existing `UNIQUENESS` filter will now return both node and relationship property uniqueness constraints.
 
 |===
+////
 
 [[cypher-deprecations-additions-removals-5.2]]
 == Version 5.2

--- a/modules/ROOT/pages/execution-plans/operators.adoc
+++ b/modules/ROOT/pages/execution-plans/operators.adoc
@@ -4890,7 +4890,9 @@ This constraint can have any of the available constraint types:
 
 * Property uniqueness constraints
 * Property existence constraints label:enterprise-edition[]
-* Node or relationship key constraints label:enterprise-edition[]
+* Node key constraints label:enterprise-edition[]
+// TODO: Switch the row above to the one below when adding back relationship key and uniqueness constraints
+//* Node or relationship key constraints label:enterprise-edition[]
 
 The following query will create a property uniqueness constraint with the name `uniqueness` on the `name` property of nodes with the `Country` label.
 

--- a/modules/ROOT/pages/introduction/neo4j-databases-graphs.adoc
+++ b/modules/ROOT/pages/introduction/neo4j-databases-graphs.adoc
@@ -78,12 +78,22 @@ a|
 All constraints:
 xref::constraints/examples.adoc#constraints-examples-node-property-existence[node existence constraints],
 xref::constraints/examples.adoc#constraints-examples-relationship-property-existence[relationship existence constraints],
+xref::constraints/examples.adoc#constraints-examples-node-uniqueness[node property uniqueness constraints], and
+xref::constraints/examples.adoc#constraints-examples-node-key[node key constraints].
+////
+TODO: Switch the part above to the one below when adding back relationship key and uniqueness constraints
+All constraints:
+xref::constraints/examples.adoc#constraints-examples-node-property-existence[node existence constraints],
+xref::constraints/examples.adoc#constraints-examples-relationship-property-existence[relationship existence constraints],
 xref::constraints/examples.adoc#constraints-examples-node-uniqueness[node property uniqueness constraints],
 xref::constraints/examples.adoc#constraints-examples-relationship-uniqueness[relationship property uniqueness constraints],
 xref::constraints/examples.adoc#constraints-examples-node-key[node key constraints], and
 xref::constraints/examples.adoc#constraints-examples-relationship-key[relationship key constraints].
+////
 a|
-Only xref::constraints/examples.adoc#constraints-examples-node-uniqueness[node] and xref::constraints/examples.adoc#constraints-examples-relationship-uniqueness[relationship] property uniqueness constraints.
+Only xref::constraints/examples.adoc#constraints-examples-node-uniqueness[node property uniqueness constraints].
+// TODO: Switch the row above to the one below when adding back relationship key and uniqueness constraints
+//Only xref::constraints/examples.adoc#constraints-examples-node-uniqueness[node] and xref::constraints/examples.adoc#constraints-examples-relationship-uniqueness[relationship] property uniqueness constraints.
 
 |===
 

--- a/modules/ROOT/pages/keyword-glossary.adoc
+++ b/modules/ROOT/pages/keyword-glossary.adoc
@@ -54,17 +54,19 @@ Typically used when modifying or importing large amounts of data.
 | Schema
 | Create a constraint that ensures all nodes with a particular label have all the specified properties and that the combination of property values is unique; i.e. ensures existence and uniqueness.
 
-| xref::constraints/syntax.adoc#constraints-syntax-create-rel-key[CREATE CONSTRAINT [rel_key\] [IF NOT EXISTS\] FOR ()-"["r:REL_TYPE"\]"-() REQUIRE (r.prop1[, ..., r.propN\]) IS [REL[ATIONSHIP\]\] KEY [OPTIONS {optionKey: optionValue[, ...\]}\]]
-| Schema
-| Create a constraint that ensures all relationships with a particular type have all the specified properties and that the combination of property values is unique; i.e. ensures existence and uniqueness.
+// TODO: Re-add this part when adding back relationship key and uniqueness constraints
+//| xref::constraints/syntax.adoc#constraints-syntax-create-rel-key[CREATE CONSTRAINT [rel_key\] [IF NOT EXISTS\] FOR ()-"["r:REL_TYPE"\]"-() REQUIRE (r.prop1[, ..., r.propN\]) IS [REL[ATIONSHIP\]\] KEY [OPTIONS {optionKey: optionValue[, ...\]}\]]
+//| Schema
+//| Create a constraint that ensures all relationships with a particular type have all the specified properties and that the combination of property values is unique; i.e. ensures existence and uniqueness.
 
 | xref::constraints/syntax.adoc#constraints-syntax-create-node-unique[CREATE CONSTRAINT [uniqueness\] [IF NOT EXISTS\] FOR (n:Label) REQUIRE (n.prop1[, ..., n.propN\]) IS [NODE\] UNIQUE [OPTIONS {optionKey: optionValue[, ...\]}\]]
 | Schema
 | Create a constraint that ensures the uniqueness of the combination of node label and property values for a particular property key combination across all nodes.
 
-| xref::constraints/syntax.adoc#constraints-syntax-create-rel-unique[CREATE CONSTRAINT [uniqueness\] [IF NOT EXISTS\] FOR ()-"["r:REL_TYPE"\]"-() REQUIRE (r.prop1[, ..., r.propN\]) IS [REL[ATIONSHIP\]\] UNIQUE [OPTIONS {optionKey: optionValue[, ...\]}\]]
-| Schema
-| Create a constraint that ensures the uniqueness of the combination of relationship type and property values for a particular property key combination across all relationships.
+// TODO: Re-add this part when adding back relationship key and uniqueness constraints
+//| xref::constraints/syntax.adoc#constraints-syntax-create-rel-unique[CREATE CONSTRAINT [uniqueness\] [IF NOT EXISTS\] FOR ()-"["r:REL_TYPE"\]"-() REQUIRE (r.prop1[, ..., r.propN\]) IS [REL[ATIONSHIP\]\] UNIQUE [OPTIONS {optionKey: optionValue[, ...\]}\]]
+//| Schema
+//| Create a constraint that ensures the uniqueness of the combination of relationship type and property values for a particular property key combination across all relationships.
 
 | xref::indexes-for-full-text-search.adoc[CREATE FULLTEXT INDEX [name\] [IF NOT EXISTS\] FOR (n:Label["\|" ... "\|" LabelN\]) ON EACH "[" n.property[, ..., n.propertyN\] "\]" [OPTIONS {optionKey: optionValue[, ...\]}\]]
 | Schema
@@ -176,7 +178,9 @@ Either the pattern already exists, or it needs to be created.
 | Writing
 | Update labels on nodes and properties on nodes and relationships.
 
-| xref::constraints/syntax.adoc#constraints-syntax-list[SHOW [ALL\|UNIQUE\|NODE [PROPERTY\] EXIST[ENCE\]\|REL[ATIONSHIP\] [PROPERTY\] EXIST[ENCE\]\|[PROPERTY\] EXIST[ENCE\]\|NODE KEY\] CONSTRAINT[S\]]
+| xref::constraints/syntax.adoc#constraints-syntax-list[SHOW [ALL\|UNIQUE[NESS\]\|NODE [PROPERTY\] EXIST[ENCE\]\|REL[ATIONSHIP\] [PROPERTY\] EXIST[ENCE\]\|[PROPERTY\] EXIST[ENCE\]\|NODE KEY\] CONSTRAINT[S\]]
+// TODO: Switch the row above to the one below when adding back relationship key and uniqueness constraints
+//| xref::constraints/syntax.adoc#constraints-syntax-list[SHOW [ALL\|NODE UNIQUE[NESS\]\|REL[ATIONSHIP\] UNIQUE[NESS\]\|UNIQUE[NESS\]\|NODE [PROPERTY\] EXIST[ENCE\]\|REL[ATIONSHIP\] [PROPERTY\] EXIST[ENCE\]\|[PROPERTY\] EXIST[ENCE\]\|NODE KEY\|REL[ATIONSHIP\] KEY\|KEY\] CONSTRAINT[S\]]
 | Schema
 |
 List constraints in the database, either all or filtered on type.


### PR DESCRIPTION
Feature flag re-added due to issues with the new constraints and the `MERGE` clause.

Companion PR with: https://github.com/neo4j/docs-cheat-sheet/pull/51

- [x] Needs to be confirmed that the documentation that now gets removed isn't in the 5.x branch
- [x] check again once merged