### PR TITLE
Deprecate different orders inside a UNION clause

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -38,7 +38,7 @@ RETURN 'val' as two, 'val' as one
 ----
 a|
 
-The order of the variables in the `RETURN` of a `UNION` clause should match.
+Using differently ordered return items in a `UNION [ALL]` clause is deprecated. Replaced by:
 
 [source, cypher, role="noheader"]
 ----


### PR DESCRIPTION
Will be targeting the next release, 5.4. Adds a deprecation message to enforce Union branch ordering.