### PR TITLE
Add note about server commands and composite databases

### DIFF
--- a/modules/ROOT/pages/access-control/manage-servers.adoc
+++ b/modules/ROOT/pages/access-control/manage-servers.adoc
@@ -308,7 +308,7 @@ This may not be specified in combination with `allowedDatabases`.
 [NOTE]
 ====
 Composite databases are ignored by both `allowedDatabases` and `deniedDatabases`.
-The composite databases are available everywhere and holds no data on their own.
+The composite databases are available everywhere and hold no data on their own.
 ====
 
 [[server-management-alter-server]]
@@ -344,7 +344,7 @@ This may not be specified in combination with `allowedDatabases`.
 [NOTE]
 ====
 Composite databases are ignored by both `allowedDatabases` and `deniedDatabases`.
-The composite databases are available everywhere and holds no data on their own.
+The composite databases are available everywhere and hold no data on their own.
 ====
 
 [[server-management-rename-server]]


### PR DESCRIPTION
The `allowedDatabases` and `deniedDatabases` doesn't apply to composite databases.

Companion PR to https://github.com/neo4j/docs-operations/pull/386