### PR TITLE
Changing the label from deprecated to removed

### DIFF
--- a/modules/ROOT/pages/query-tuning/indexes.adoc
+++ b/modules/ROOT/pages/query-tuning/indexes.adoc
@@ -32,7 +32,7 @@ The different index types used for search performance are:
 * `RANGE`
 * `POINT`
 * `TEXT`
-* `BTREE` label:deprecated[]
+* `BTREE` label:removed[]
 
 [NOTE]
 ====


### PR DESCRIPTION
This is what happened to this index on Neo4j 5. Instead of just removing it from the list, I believe it's better to just change the label to removed so users are informed about that change.