### PR TITLE
Make example in `limit.adoc` deterministic

### DIFF
--- a/modules/ROOT/pages/clauses/limit.adoc
+++ b/modules/ROOT/pages/clauses/limit.adoc
@@ -130,12 +130,13 @@ Properties set: 1
 If we want to limit the number of updates we can split the query using the `WITH` clause:
 
 .Query
-[source, cypher, role="test-result-skip"]
+[source, cypher]
 ----
 MATCH (n)
 WITH n LIMIT 1
 SET n.locked = true
 RETURN n
+ORDER BY n.name
 ----
 
 Writes `locked` property on one node and return that node:


### PR DESCRIPTION
This makes the example always return the same result by enforcing an ordering, so that we don't need to skip testing its result (this PR updates #405). The sense of the example is unaffected.