### PR TITLE
5.x downgrade operator

### DIFF
--- a/modules/ROOT/pages/execution-plans/operators.adoc
+++ b/modules/ROOT/pages/execution-plans/operators.adoc
@@ -71,7 +71,7 @@ CREATE (mattias)-[:FRIENDS_WITH]->(max);
 CREATE (pontus)-[:FRIENDS_WITH]->(mats);
 CREATE (konstantin)-[:FRIENDS_WITH]->(steven);
 CREATE (craig)-[:FRIENDS_WITH]->(stefan);
-CREATE (petra)-[:FRIENDS_WITH]->(lovis);f
+CREATE (petra)-[:FRIENDS_WITH]->(lovis);
 CREATE (me)-[:FRIENDS_WITH]->(chris);
 CREATE (chris)-[:FRIENDS_WITH]->(stefan);
 CREATE (bob)-[:FRIENDS_WITH]->(andy);


### PR DESCRIPTION
One operator upgrade is not exist in 5.4.0 yet.
We should only have this change in dev branch for now