### PR TITLE
Remove `WAIT` from database creation tests setups

### DIFF
--- a/modules/ROOT/pages/aliases.adoc
+++ b/modules/ROOT/pages/aliases.adoc
@@ -244,17 +244,17 @@ This prevents issues such as a transaction executing against multiple target dat
 ////
 [source, cypher, role=test-setup]
 ----
-CREATE DATABASE `movies` WAIT;
+CREATE DATABASE `movies`;
 CREATE ALIAS `films` FOR DATABASE `movies`;
 CREATE ALIAS `motion pictures` FOR DATABASE `movies` PROPERTIES { nameContainsSpace: true };
-CREATE DATABASE `northwind-graph-2020` WAIT;  // wait, so aliases get `currentStatus: online`
-CREATE DATABASE `northwind-graph-2021` WAIT;
-CREATE DATABASE `northwind-graph-2022` WAIT;
-CREATE DATABASE `sci-fi-books` WAIT;
-CREATE COMPOSITE DATABASE `library` WAIT;
+CREATE DATABASE `northwind-graph-2020`;
+CREATE DATABASE `northwind-graph-2021`;
+CREATE DATABASE `northwind-graph-2022`;
+CREATE DATABASE `sci-fi-books`;
+CREATE COMPOSITE DATABASE `library`;
 CREATE ALIAS `library`.`sci-fi` FOR DATABASE `sci-fi-books`;
-CREATE COMPOSITE DATABASE garden WAIT;
-CREATE DATABASE `perennial-flowers` WAIT;
+CREATE COMPOSITE DATABASE garden;
+CREATE DATABASE `perennial-flowers`;
 ----
 
 CREATE ALIAS `library`.`romance` FOR DATABASE `romance-books` AT 'neo4j+s://location:7687' USER alice PASSWORD 'password';

--- a/modules/ROOT/pages/databases.adoc
+++ b/modules/ROOT/pages/databases.adoc
@@ -3,7 +3,7 @@
 ////
 [source, cypher, role=test-setup]
 ----
-CREATE DATABASE `movies` WAIT;
+CREATE DATABASE `movies`;
 CREATE ALIAS `films` FOR DATABASE `movies`;
 CREATE ALIAS `motion pictures` FOR DATABASE `movies`;
 ----
@@ -438,9 +438,9 @@ For composite databases the `constituents` column is particularly interesting as
 ////
 [source, cypher, role=test-setup]
 ----
-CREATE COMPOSITE DATABASE `library` WAIT;
-CREATE DATABASE `sci-fi` WAIT;
-CREATE DATABASE `romance` WAIT;
+CREATE COMPOSITE DATABASE `library`;
+CREATE DATABASE `sci-fi`;
+CREATE DATABASE `romance`;
 CREATE ALIAS `library`.`sci-fi` FOR DATABASE `sci-fi`;
 CREATE ALIAS `library`.`romance` FOR DATABASE `romance`;
 ----


### PR DESCRIPTION
Since https://github.com/neo4j/docs-testing/commit/a350d6967bae90d0145024c1d9fb0188a2450abc , the tester automatically appends `WAIT` to database administration queries that don't have it, so we don't need to put it in explicitly.