### PR TITLE
Add attribute subs to codeblocks (#424)

### DIFF
--- a/modules/ROOT/pages/execution-plans/operators.adoc
+++ b/modules/ROOT/pages/execution-plans/operators.adoc
@@ -104,7 +104,7 @@ RETURN n
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -153,7 +153,7 @@ RETURN r
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -197,7 +197,7 @@ RETURN r
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -242,7 +242,7 @@ RETURN candidate
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -287,7 +287,7 @@ RETURN candidate
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -331,7 +331,7 @@ RETURN r, n1
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -376,7 +376,7 @@ RETURN r, n1
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -427,7 +427,7 @@ RETURN r
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -472,7 +472,7 @@ RETURN r
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -517,7 +517,7 @@ RETURN r
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -562,7 +562,7 @@ RETURN r
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -614,7 +614,7 @@ RETURN candidate
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -661,7 +661,7 @@ RETURN candidate
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -708,7 +708,7 @@ RETURN countryOrLocation
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -752,7 +752,7 @@ RETURN countryAndLocation
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -790,7 +790,7 @@ MATCH ()-[r]->() RETURN r
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -825,7 +825,7 @@ MATCH ()-[r]-() RETURN r
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -867,7 +867,7 @@ RETURN r
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -908,7 +908,7 @@ RETURN r
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -951,7 +951,7 @@ RETURN friendOrFoe
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -994,7 +994,7 @@ RETURN friendOrFoe
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1038,7 +1038,7 @@ RETURN n
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1081,7 +1081,7 @@ RETURN person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1132,7 +1132,7 @@ RETURN location
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1185,7 +1185,7 @@ RETURN t
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1241,7 +1241,7 @@ RETURN location, person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1292,7 +1292,7 @@ MERGE (t:Team {name: 'Engineering', id: 42})
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1349,7 +1349,7 @@ RETURN l
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1395,7 +1395,7 @@ RETURN t
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1445,7 +1445,7 @@ RETURN l
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1490,7 +1490,7 @@ RETURN l
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1534,7 +1534,7 @@ RETURN l
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1583,7 +1583,7 @@ RETURN p, q
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1634,7 +1634,7 @@ RETURN p.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1690,7 +1690,7 @@ RETURN other.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1749,7 +1749,7 @@ RETURN other.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1813,7 +1813,7 @@ RETURN other.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1877,7 +1877,7 @@ RETURN other.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1939,7 +1939,7 @@ RETURN other.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1997,7 +1997,7 @@ RETURN other.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2057,7 +2057,7 @@ RETURN other.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2119,7 +2119,7 @@ RETURN other.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2184,7 +2184,7 @@ ON CREATE SET p.existed = false
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2232,7 +2232,7 @@ MERGE (s)-[:FRIENDS_WITH]->(s)
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2287,7 +2287,7 @@ RETURN p.name, [(p)-[:WORKS_IN]->(location) | location.name] AS cities
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2338,7 +2338,7 @@ MERGE (s)-[:FRIENDS_WITH]->(s)
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2394,7 +2394,7 @@ RETURN fof
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2441,7 +2441,7 @@ RETURN fof
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2493,7 +2493,7 @@ RETURN p, l
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2542,7 +2542,7 @@ RETURN p
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2589,7 +2589,7 @@ RETURN p, q
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2636,7 +2636,7 @@ RETURN p
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2689,7 +2689,7 @@ RETURN DISTINCT p, q
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2745,7 +2745,7 @@ RETURN DISTINCT p, q
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2794,7 +2794,7 @@ MERGE (t:Team {name: 'Engineering', id: 42})
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2845,7 +2845,7 @@ CREATE (:Person)
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2891,7 +2891,7 @@ RETURN n
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2935,7 +2935,7 @@ RETURN line
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -2998,7 +2998,7 @@ RETURN loc.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3058,7 +3058,7 @@ RETURN p, q
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3112,7 +3112,7 @@ RETURN a.name, b.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3169,7 +3169,7 @@ RETURN other.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3228,7 +3228,7 @@ RETURN other.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3293,7 +3293,7 @@ RETURN other.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3356,7 +3356,7 @@ RETURN p, t
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3405,7 +3405,7 @@ FOREACH (value IN [1,2,3] | CREATE (:Person {age: value}))
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3459,7 +3459,7 @@ MERGE ()
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3527,7 +3527,7 @@ RETURN
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3576,7 +3576,7 @@ RETURN p.name, count(*) AS count
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3624,7 +3624,7 @@ RETURN count(p) AS people
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3670,7 +3670,7 @@ RETURN count(r) AS jobs
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3714,7 +3714,7 @@ RETURN DISTINCT l
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3762,7 +3762,7 @@ RETURN DISTINCT p.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3808,7 +3808,7 @@ RETURN p
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3854,7 +3854,7 @@ LIMIT 3
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3901,7 +3901,7 @@ SKIP 1
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -3952,7 +3952,7 @@ ORDER BY p.name
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4003,7 +4003,7 @@ ORDER BY p.name, p.age
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4053,7 +4053,7 @@ LIMIT 2
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4105,7 +4105,7 @@ LIMIT 2
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4154,7 +4154,7 @@ MATCH (p:Country)
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4209,7 +4209,7 @@ RETURN value
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4256,7 +4256,7 @@ LIMIT 3
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4308,7 +4308,7 @@ RETURN p, q
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4359,7 +4359,7 @@ RETURN u, v
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4409,7 +4409,7 @@ RETURN 'hello' AS greeting
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4455,7 +4455,7 @@ RETURN p
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4501,7 +4501,7 @@ FOREACH (value IN [1,2,3] | MERGE (:Person {age: value}))
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4553,7 +4553,7 @@ ORDER BY label
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4601,7 +4601,7 @@ RETURN
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4650,7 +4650,7 @@ CREATE (max)-[:FRIENDS_WITH]->(chris)
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4696,7 +4696,7 @@ DELETE w
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4747,7 +4747,7 @@ DETACH DELETE p
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4799,7 +4799,7 @@ SET n:Person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4846,7 +4846,7 @@ REMOVE n:Person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4893,7 +4893,7 @@ SET n = {weekday: 'Monday', meal: 'Lunch'}
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4940,7 +4940,7 @@ SET r = {weight: 5, unit: 'kg'}
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -4987,7 +4987,7 @@ SET n.checked = true
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -5045,7 +5045,7 @@ FOR (c:Country) REQUIRE c.name is UNIQUE
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner ADMINISTRATION
 
@@ -5087,7 +5087,7 @@ FOR (c:Country) REQUIRE c.name is UNIQUE
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner ADMINISTRATION
 
@@ -5129,7 +5129,7 @@ DROP CONSTRAINT uniqueness
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner ADMINISTRATION
 
@@ -5168,7 +5168,7 @@ SHOW CONSTRAINTS
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -5212,7 +5212,7 @@ FOR (c:Country) ON (c.name)
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner ADMINISTRATION
 
@@ -5254,7 +5254,7 @@ FOR ()-[k:KNOWS]-() ON (k.since)
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner ADMINISTRATION
 
@@ -5294,7 +5294,7 @@ DROP INDEX my_index
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner ADMINISTRATION
 
@@ -5333,7 +5333,7 @@ SHOW INDEXES
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -5376,7 +5376,7 @@ SHOW FUNCTIONS
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -5417,7 +5417,7 @@ SHOW PROCEDURES
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -5458,7 +5458,7 @@ SHOW TRANSACTIONS
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -5499,7 +5499,7 @@ TERMINATE TRANSACTIONS 'database-transaction-123'
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 

--- a/modules/ROOT/pages/execution-plans/shortestpath-planning.adoc
+++ b/modules/ROOT/pages/execution-plans/shortestpath-planning.adoc
@@ -78,7 +78,7 @@ RETURN p
 ----
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 

--- a/modules/ROOT/pages/query-tuning/indexes.adoc
+++ b/modules/ROOT/pages/query-tuning/indexes.adoc
@@ -311,7 +311,7 @@ RETURN person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -353,7 +353,7 @@ RETURN r
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -397,7 +397,7 @@ RETURN person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -440,7 +440,7 @@ RETURN person, friend
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -483,7 +483,7 @@ RETURN person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -527,7 +527,7 @@ RETURN person, friend
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -573,7 +573,7 @@ RETURN person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -613,7 +613,7 @@ RETURN person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -702,7 +702,7 @@ RETURN friend, person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -762,7 +762,7 @@ RETURN r.since
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -812,7 +812,7 @@ RETURN person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -860,7 +860,7 @@ RETURN person
 
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -906,7 +906,7 @@ RETURN person, friend
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -944,7 +944,7 @@ RETURN person, friend
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -983,7 +983,7 @@ RETURN person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1031,7 +1031,7 @@ RETURN person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1071,7 +1071,7 @@ RETURN person, friend
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1123,7 +1123,7 @@ RETURN person, friend
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1202,7 +1202,7 @@ RETURN person
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1243,7 +1243,7 @@ RETURN person, friend
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1282,7 +1282,7 @@ RETURN p
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1327,7 +1327,7 @@ RETURN r.lastMetPoint
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -1377,7 +1377,7 @@ RETURN person.firstname
 ----
 
 .Query Plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 

--- a/modules/ROOT/pages/query-tuning/using.adoc
+++ b/modules/ROOT/pages/query-tuning/using.adoc
@@ -70,7 +70,7 @@ The query above will be used in some of the examples on this page.
 Without any hints, one index and no join is used.
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -171,7 +171,7 @@ RETURN *
 ----
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -224,7 +224,7 @@ RETURN *
 ----
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -265,7 +265,7 @@ RETURN *
 ----
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -316,7 +316,7 @@ RETURN *
 ----
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -360,7 +360,7 @@ RETURN *
 ----
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -417,7 +417,7 @@ RETURN *
 ----
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -475,7 +475,7 @@ RETURN *
 ----
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -532,7 +532,7 @@ RETURN *
 ----
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -585,7 +585,7 @@ RETURN *
 ----
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -643,7 +643,7 @@ RETURN *
 ----
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -702,7 +702,7 @@ RETURN *
 Without any hint, the planner did not use a join to solve the `OPTIONAL MATCH`.
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 
@@ -739,7 +739,7 @@ RETURN *
 Now the planner uses a join to solve the `OPTIONAL MATCH`.
 
 .Query plan
-[role="queryplan"]
+[role="queryplan", subs="attributes+"]
 ----
 Planner COST
 


### PR DESCRIPTION
We are using the `{neo4j-version-minor}` attribute in queryplan codeblocks, but this is not converted into its attribute value by default.

This PR adds `subs=attributes+` to `role=queryplan` codeblocks so that attribute substitution in the codeblock is processed, and then any default substitutions are applied.

See the Asciidoctor docs for more information:
https://docs.asciidoctor.org/asciidoc/latest/subs/apply-subs-to-blocks/