### PR TITLE
Update `server.tag` documentation

### DIFF
--- a/modules/ROOT/pages/access-control/manage-servers.adoc
+++ b/modules/ROOT/pages/access-control/manage-servers.adoc
@@ -317,7 +317,7 @@ The composite databases are available everywhere and hold no data on their own.
 
 [NOTE]
 ====
-When a server is enabled if `tags` are not provided in `OPTIONS` the default server tags are taken from the setting `initial.server.tags`.
+When a server is enabled, if `tags` are not provided in `OPTIONS`, the default server tags are taken from the setting `initial.server.tags`.
 ====
 
 [[server-management-alter-server]]


### PR DESCRIPTION
- Document how the `initial.server.tags` is used from config settings when the server is enabled. 
- Document how `tags` can be changed at runtime via `ALTER SERVER`.