### PR TITLE
Adding reference to dbms in the command for set-initial-password (#472)

### DIFF
--- a/modules/ROOT/pages/access-control/manage-users.adoc
+++ b/modules/ROOT/pages/access-control/manage-users.adoc
@@ -382,7 +382,7 @@ SHOW USERS
 |===
 
 When first starting a Neo4j DBMS, there is always a single default user `neo4j` with administrative privileges.
-It is possible to set the initial password using link:{neo4j-docs-base-uri}/operations-manual/{page-version}/configuration/set-initial-password[neo4j-admin set-initial-password], otherwise it is necessary to change the password after the first login.
+It is possible to set the initial password using link:{neo4j-docs-base-uri}/operations-manual/{page-version}/configuration/set-initial-password[`neo4j-admin dbms set-initial-password <password>`], otherwise it is necessary to change the password after the first login.
 
 .Show user
 ======


### PR DESCRIPTION
The original command line includes dbms, whereas here in the text it is not mentioned.

Cherry-picked from https://github.com/neo4j/docs-cypher/pull/472