### PR TITLE
Add a PDF-specific title

### DIFF
--- a/modules/ROOT/pages/introduction/index.adoc
+++ b/modules/ROOT/pages/introduction/index.adoc
@@ -1,6 +1,11 @@
 [[cypher-intro]]
+ifdef::backend-pdf[]
+= Neo4j {neo4j-version} Cypher Manual
+endif::[]
+ifndef::backend-pdf[]
 = Introduction
 :description: This section provides an introduction to the Cypher query language.
+endif::[]
 
 Welcome to the Neo4j Cypher Manual. 
 


### PR DESCRIPTION
When the title of the first page in a manual changes from something like 'Neo4j Cypher Manual' we need to add a condition to set a meaningful title for the PDF.