### PR TITLE
Update textual representation of path results

### DIFF
--- a/modules/ROOT/pages/clauses/create.adoc
+++ b/modules/ROOT/pages/clauses/create.adoc
@@ -242,7 +242,7 @@ This query creates three nodes and two relationships in one go, assigns it to a 
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +p+
-| [{"name":"Andy"},{},{"name":"Neo4j"},{"name":"Neo4j"},{},{"name":"Michael"}]
+| (:Person {name: "Andy"})-[:WORKS_AT]->(:Company {name: "Neo4j"})<-[:WORKS_AT]-(:Person {name: "Michael"})
 1+d|Rows: 1 +
 Nodes created: 3 +
 Relationships created: 2 +

--- a/modules/ROOT/pages/clauses/match.adoc
+++ b/modules/ROOT/pages/clauses/match.adoc
@@ -540,7 +540,7 @@ image::MATCH_properties_on_variable_length_path.svg[width="400",role="middle"]
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +p+
-| +[{"name":"Charlie Sheen"},{"role":"Jake Peterson","lead":true},{"title":"No Code of Conduct"},{"title":"No Code of Conduct"},{"role":"Bill Peterson","lead":true},{"name":"Martin Sheen"}]+
+| +(:Person {name: "Charlie Sheen"})-[:ACTED_IN {role: "Jake Peterson",lead: true}]->(:Movie {title: "No Code of Conduct"})<-[:ACTED_IN {role: "Bill Peterson",lead: true}]-(:Person {name: "Martin Sheen"})+
 1+d|Rows: 1
 |===
 
@@ -595,8 +595,8 @@ image::MATCH_named_path_example.svg[width="500",role="middle"]
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +p+
-| +[{"name":"Michael Douglas"},{"role":"Gordon Gekko"},{"title":"Wall Street"}]+
-| +[{"name":"Michael Douglas"},{"role":"President Andrew Shepherd"},{"title":"The American President"}]+
+| +(:Person {name: "Michael Douglas"})-[:ACTED_IN {role: "President Andrew Shepherd"}]->(:Movie {title: "The American President"})+
+| +(:Person {name: "Michael Douglas"})-[:ACTED_IN {role: "Gordon Gekko"}]->(:Movie {title: "Wall Street"})+
 1+d|Rows: 2
 |===
 
@@ -632,7 +632,7 @@ image::MATCH_shortestpath_example.svg[width="400",role="middle"]
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +p+
-| +[{"name":"Martin Sheen"},{"role":"Carl Fox"},{"title":"Wall Street"},{"title":"Wall Street"},{},{"name":"Oliver Stone"}]+
+| +(:Person {name: "Martin Sheen"})-[:ACTED_IN {role: "Carl Fox"}]->(:Movie {title: "Wall Street"})<-[:DIRECTED]-(:Person {name: "Oliver Stone"})+
 1+d|Rows: 1
 |===
 
@@ -662,7 +662,7 @@ image::MATCH_shortestpath_with_predicates_example.svg[width="400",role="middle"]
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +p+
-|+[{"name":"Rob Reiner"},{},{"name":"Martin Sheen"},{"name":"Martin Sheen"},{"role":"A.J. MacInerney"},{"title":"The American President"}]+│
+|+(:Person {name: "Rob Reiner"})-[:OLD FRIENDS]->(:Person {name: "Martin Sheen"})-[:ACTED_IN {role: "A.J. MacInerney"}]->(:Movie {title: "The American President"})+│
 1+d|Rows: 1
 |===
 
@@ -691,8 +691,8 @@ image::MATCH_allshortestpaths_example.svg[width="400",role="middle"]
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +p+
-| +[{"name":"Martin Sheen"},{"role":"Carl Fox"},{"title":"Wall Street"},{"title":"Wall Street"},{"role":"Gordon Gekko"},{"name":"Michael Douglas"}]+
-| +[{"name":"Martin Sheen"},{"role":"A.J. MacInerney"},{"title":"The American President"},{"title":"The American President"},{"role":"President Andrew Shepherd"},{"name":"Michael Douglas"}]+
+| +(:Person {name: "Martin Sheen"})-[:ACTED_IN {role: "Carl Fox"}]->(:Movie {title: "Wall Street"})<-[:ACTED_IN {role: "Gordon Gekko"}]-(:Person {name: "Michael Douglas"})+
+| +(:Person {name: "Martin Sheen"})-[:ACTED_IN {role: "A.J. MacInerney"}]->(:Movie {title: "The American President"})<-[:ACTED_IN {role: "President Andrew Shepherd"}]-(:Person {name: "Michael Douglas"})+
 1+d|Rows: 2
 |===
 

--- a/modules/ROOT/pages/clauses/return.adoc
+++ b/modules/ROOT/pages/clauses/return.adoc
@@ -113,8 +113,8 @@ This returns the two nodes, and the two possible paths between them.
 [role="queryresult",options="header,footer",cols="4*<m"]
 |===
 | +keanu+ | +m+ | +p+ | +r+
-| +{"bornIn":"Beirut","nationality":"Canadian","name":"Keanu Reeves"}+ | +{"title":"Man of Tai Chi","released":2013}+ | +[{"bornIn":"Beirut","nationality":"Canadian","name":"Keanu Reeves"},{},{"title":"Man of Tai Chi","released":2013}]+ | +{:ACTED_IN}+
-| +{"bornIn":"Beirut","nationality":"Canadian","name":"Keanu Reeves"}+ | +{"title":"Man of Tai Chi","released":2013}+ | +[{"bornIn":"Beirut","nationality":"Canadian","name":"Keanu Reeves"},{},{"title":"Man of Tai Chi","released":2013}]+ | +{:DIRECTED}+
+| +{"bornIn":"Beirut","nationality":"Canadian","name":"Keanu Reeves"}+ | +{"title":"Man of Tai Chi","released":2013}+ | +(:Person {bornIn: "Beirut",nationality: "Canadian",name: "Keanu Reeves"})-[:ACTED_IN]->(:Movie {title: "Man of Tai Chi",released: 2013})+ | +{:ACTED_IN}+
+| +{"bornIn":"Beirut","nationality":"Canadian","name":"Keanu Reeves"}+ | +{"title":"Man of Tai Chi","released":2013}+ | +(:Person {bornIn: "Beirut",nationality: "Canadian",name: "Keanu Reeves"})-[:DIRECTED]->(:Movie {title: "Man of Tai Chi",released: 2013})+ | +{:DIRECTED}+
 4+d|Rows: 1
 |===
 
@@ -209,7 +209,7 @@ Returns a predicate, a literal and function call with a pattern expression param
 [role="queryresult",options="header,footer",cols="3*<m"]
 |===
 | +m.released < 2012+ | +"I'm a literal"+ | +(m)--()+
-| +false+ | +"I'm a literal"+ | +[[{"title":"Man of Tai Chi","released":2013},{},{"bornIn":"Beirut","nationality":"Canadian","name":"Keanu Reeves"}],[{"title":"Man of Tai Chi","released":2013},{},{"bornIn":"Beirut","nationality":"Canadian","name":"Keanu Reeves"}]]+
+| +false+ | +"I'm a literal"+ | +[(:Movie {title: "Man of Tai Chi",released: 2013})<-[:DIRECTED]-(:Person {bornIn: "Beirut",nationality: "Canadian",name: "Keanu Reeves"}), (:Movie {title: "Man of Tai Chi",released: 2013})<-[:ACTED_IN]-(:Person {bornIn: "Beirut",nationality: "Canadian",name: "Keanu Reeves"})]+
 3+d|Rows: 1
 |===
 

--- a/modules/ROOT/pages/functions/list.adoc
+++ b/modules/ROOT/pages/functions/list.adoc
@@ -221,7 +221,7 @@ A list containing all the nodes in the path `p` is returned.
 |===
 
 | +nodes(p)+
-| +[(:Person:Developer {name: "Alice",eyes: "brown",age: 38}), ({name: "Bob",eyes: "blue",age: 25}), ({array: ["one", "two", "three"],name: "Eskil",eyes: "blue",age: 41})]+
+| +[(:Person:Developer {name: "Alice",eyes: "brown",age: 38}), ({name: "Bob",eyes: "blue",age: 25}), ({array: ['one', 'two', 'three'],name: "Eskil",eyes: "blue",age: 41})]+
 1+d|Rows: 1
 
 |===

--- a/modules/ROOT/pages/functions/list.adoc
+++ b/modules/ROOT/pages/functions/list.adoc
@@ -221,7 +221,7 @@ A list containing all the nodes in the path `p` is returned.
 |===
 
 | +nodes(p)+
-| +[{"name":"Alice","eyes":"brown","age":38},{"name":"Bob","eyes":"blue","age":25},{"array":['one', 'two', 'three']},{"name":"Eskil","eyes":"blue","age":41}]+
+| +[(:Person:Developer {name: "Alice",eyes: "brown",age: 38}), ({name: "Bob",eyes: "blue",age: 25}), ({array: ["one", "two", "three"],name: "Eskil",eyes: "blue",age: 41})]+
 1+d|Rows: 1
 
 |===

--- a/modules/ROOT/pages/functions/predicate.adoc
+++ b/modules/ROOT/pages/functions/predicate.adoc
@@ -103,7 +103,7 @@ image::predicate_function_example.svg[width="300",role="middle"]
 |===
 
 | +p+
-| +[{"nationality":"Canadian","name":"Keanu Reeves","age":58},{},{"nationality":"American","name":"Carrie Anne Moss","age":55},{"nationality":"American","name":"Carrie Anne Moss","age":55},{},{"nationality":"Australian","name":"Guy Pearce","age":55}]+
+| +(:Person {nationality: "Canadian",name: "Keanu Reeves",age: 58})-[:KNOWS]->(:Person {nationality: "American",name: "Carrie Anne Moss",age: 55})-[:KNOWS]->(:Person {nationality: "Australian",name: "Guy Pearce",age: 55})+
 1+d|Rows: 1
 
 |===
@@ -493,8 +493,8 @@ image::predicate_function_example.svg[width="300",role="middle"]
 |===
 
 | +p+
-| +[{"nationality":"Canadian","name":"Keanu Reeves","age":58},{},{"nationality":"American","name":"Carrie Anne Moss","age":55}]+
-| +[{"nationality":"Canadian","name":"Keanu Reeves","age":58},{},{"nationality":"American","name":"Carrie Anne Moss","age":55},{"nationality":"American","name":"Carrie Anne Moss","age":55},{},{"nationality":"Australian","name":"Guy Pearce","age":55}]+
+| +(:Person {nationality: "Canadian",name: "Keanu Reeves",age: 58})-[:KNOWS]->(:Person {nationality: "American",name: "Carrie Anne Moss",age: 55})+
+| +(:Person {nationality: "Canadian",name: "Keanu Reeves",age: 58})-[:KNOWS]->(:Person {nationality: "American",name: "Carrie Anne Moss",age: 55})-[:KNOWS]->(:Person {nationality: "Australian",name: "Guy Pearce",age: 55})+
 1+d|Rows: 2
 
 |===
@@ -560,7 +560,7 @@ In every returned path there is exactly one node which the `nationality` propert
 |===
 
 | +p+
-| +[{"nationality":"Canadian","name":"Keanu Reeves","age":58},{},{"nationality":"Northern Irish","name":"Liam Neeson","age":70}]  +
+| +(:Person {nationality: "Canadian",name: "Keanu Reeves",age: 58})-[:KNOWS]->(:Person {nationality: "Northern Irish",name: "Liam Neeson",age: 70})+
 1+d|Rows: 1
 
 |===


### PR DESCRIPTION
In 5.6 Browser updated the formatting of the textual representation of returned paths to include the relationship types connecting nodes and to more generally represent the ascii-art style used by Cypher.
This PR updates the Cypher Manual accordingly. 