### PR TITLE
Restructure index section

### DIFF
--- a/modules/ROOT/pages/clauses/index.adoc
+++ b/modules/ROOT/pages/clauses/index.adoc
@@ -21,7 +21,7 @@ These comprise clauses used to manage databases, schema and security; further de
 m| xref::administration/databases.adoc[CREATE \| DROP \| START \| STOP DATABASE]
 | Create, drop, start or stop a database.
 
-m| xref::indexes-for-search-performance.adoc#administration-indexes-syntax[CREATE \| DROP INDEX]
+m| xref::indexes-for-search-performance.adoc#indexes-syntax[CREATE \| DROP INDEX]
 | Create or drop an index on all nodes with a particular label and property.
 
 m| xref::constraints/syntax.adoc[CREATE \| DROP CONSTRAINT]

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -3389,7 +3389,7 @@ label:new[]
 DROP INDEX name
 ----
 a|
-xref:indexes-for-search-performance.adoc#administration-indexes-drop-an-index[New command] for dropping an index by name.
+xref:indexes-for-search-performance.adoc#indexes-drop-an-index[New command] for dropping an index by name.
 
 
 a|

--- a/modules/ROOT/pages/indexes-for-full-text-search.adoc
+++ b/modules/ROOT/pages/indexes-for-full-text-search.adoc
@@ -1,6 +1,6 @@
 :description: This chapter describes how to use full-text indexes, to enable full-text search.
 
-[[administration-indexes-fulltext-search]]
+[[indexes-fulltext-search]]
 = Full-text search index
 
 [abstract]
@@ -40,13 +40,13 @@ In contrast to xref::indexes-for-search-performance.adoc[other indexes], a full-
 
 * applied to more than one label.
 * applied to more than one relationship type.
-* applied to more than one property at a time (similar to a xref::indexes-for-search-performance.adoc#administration-indexes-create-a-composite-range-index-for-nodes[_composite index_]) but with an important difference:
+* applied to more than one property at a time (similar to a xref::indexes-for-search-performance.adoc#indexes-create-a-composite-range-index-for-nodes[_composite index_]) but with an important difference:
 While a composite index applies only to entities that match the indexed label and _all_ of the indexed properties, full-text index will index entities that have at least one of the indexed labels or relationship types, and at least one of the indexed properties.
 
 For information on how to configure full-text indexes, refer to link:{neo4j-docs-base-uri}/operations-manual/{page-version}/performance/index-configuration#index-configuration-fulltext[Operations Manual -> Indexes to support full-text search].
 
 
-[[administration-indexes-fulltext-search-manage]]
+[[indexes-fulltext-search-manage]]
 == Full-text search procedures
 
 Full-text indexes are managed through commands and used through built-in procedures, see link:{neo4j-docs-base-uri}/operations-manual/{page-version}/reference/procedures[Operations Manual -> Procedures] for a complete reference.
@@ -89,12 +89,12 @@ Create a relationship full-text index for the given relationship types and prope
 
 | Listing all full-text indexes.
 | `SHOW FULLTEXT INDEXES`
-| Lists all full-text indexes, see xref::indexes-for-search-performance.adoc#administration-indexes-list-indexes[the `SHOW INDEXES` command] for details.
+| Lists all full-text indexes, see xref::indexes-for-search-performance.adoc#indexes-list-indexes[the `SHOW INDEXES` command] for details.
 
 |===
 
 
-[[administration-indexes-fulltext-search-create-and-configure]]
+[[indexes-fulltext-search-create-and-configure]]
 == Create and configure full-text indexes
 
 Full-text indexes are created with the `CREATE FULLTEXT INDEX` command.
@@ -247,7 +247,7 @@ Added 1 index.
 ======
 
 
-[[administration-indexes-fulltext-search-query]]
+[[indexes-fulltext-search-query]]
 == Query full-text indexes
 
 Full-text indexes will, in addition to any exact matches, also return _approximate_ matches to a given query.
@@ -375,7 +375,7 @@ RETURN node.title, node.description, score
 A complete description of the Lucene query syntax can be found in the link:https://lucene.apache.org/core/8_2_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html#package.description[Lucene documentation].
 
 
-[[administration-indexes-fulltext-search-text-array-properties]]
+[[indexes-fulltext-search-text-array-properties]]
 == Handling of Text Array properties
 
 If the indexed property contains a text array, each element of this array is analyzed independently and all produced terms are associated with the same property name.
@@ -443,10 +443,10 @@ RETURN
 ======
 
 
-[[administration-indexes-fulltext-search-drop]]
+[[indexes-fulltext-search-drop]]
 == Drop full-text indexes
 
-A full-text node index is dropped by using the xref::indexes-for-search-performance.adoc#administration-indexes-drop-an-index[same command as for other indexes], `DROP INDEX`.
+A full-text node index is dropped by using the xref::indexes-for-search-performance.adoc#indexes-drop-an-index[same command as for other indexes], `DROP INDEX`.
 
 
 .+DROP INDEX+

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -323,74 +323,6 @@ listing indexes require xref::administration/access-control/database-administrat
 xref:query-tuning/using.adoc[Planner hints and the USING keyword] describes how to make the Cypher planner use specific indexes (especially in cases where the planner would not necessarily have used them).
 
 
-[[indexes-single-vs-composite-index]]
-== Composite index limitations
-
-Like single-property range indexes, composite range indexes support all predicates:
-
-* equality check: `n.prop = value`
-* list membership check: `n.prop IN list`
-* existence check: `n.prop IS NOT NULL`
-* range search: `n.prop > value`
-* prefix search: `STARTS WITH`
-
-[NOTE]
-====
-For details about each operator, see xref::syntax/operators.adoc[Operators].
-====
-
-However, predicates might be planned as existence check and a filter.
-For most predicates, this can be avoided by following these restrictions:
-
-* If there is any `equality check` and `list membership check` predicates,
-they need to be for the first properties defined by the index.
-* There can be up to one `range search` or `prefix search` predicate.
-* There can be any number of `existence check` predicates.
-* Any predicate after a `range search`, `prefix search` or `existence check` predicate has to be an `existence check` predicate.
-
-[NOTE]
-====
-The `suffix search` (`ENDS WITH`) and `substring search` (`CONTAINS`) predicates can utilize the index as well.
-However, they are always planned as an existence check and a filter and any predicates following after will therefore also be planned as such.
-====
-
-For example, an index on nodes with `:Label(prop1,prop2,prop3,prop4,prop5,prop6)` and predicates:
-
-[source, cypher, role=test-skip]
-----
-WHERE n.prop1 = 'x' AND n.prop2 = 1 AND n.prop3 > 5 AND n.prop4 < 'e' AND n.prop5 = true AND n.prop6 IS NOT NULL
-----
-
-will be planned as:
-
-[source, cypher, role=test-skip]
-----
-WHERE n.prop1 = 'x' AND n.prop2 = 1 AND n.prop3 > 5 AND n.prop4 IS NOT NULL AND n.prop5 IS NOT NULL AND n.prop6 IS NOT NULL
-----
-
-with filters on `n.prop4 < 'e'` and `n.prop5 = true`, since `n.prop3` has a `range search` predicate.
-
-And an index on nodes with `:Label(prop1,prop2)` with predicates:
-
-[source, cypher, role=test-skip]
-----
-WHERE n.prop1 ENDS WITH 'x' AND n.prop2 = false
-----
-
-will be planned as:
-
-[source, cypher, role=test-skip]
-----
-WHERE n.prop1 IS NOT NULL AND n.prop2 IS NOT NULL
-----
-
-with filters on `n.prop1 ENDS WITH 'x'` and `n.prop2 = false`, since `n.prop1` has a `suffix search` predicate.
-
-Composite indexes require predicates on all properties indexed.
-If there are predicates on only a subset of the indexed properties, it will not be possible to use the composite index.
-To get this kind of fallback behavior, it is necessary to create additional indexes on the relevant sub-set of properties or on single properties.
-
-
 [[indexes-create-indexes]]
 == +CREATE INDEX+
 
@@ -421,36 +353,6 @@ Creating an index requires xref::administration/access-control/database-administ
 ====
 The new index is not immediately available, but is created in the background.
 ====
-
-*Examples:*
-
-* xref::indexes-for-search-performance.adoc#indexes-create-range-index[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-single-property-range-index-for-nodes[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-single-property-range-index-for-relationships[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-composite-range-index-for-nodes[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-composite-range-index-for-relationships[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-range-index-only-if-it-does-not-already-exist[]
-* xref::indexes-for-search-performance.adoc#indexes-create-token-index[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-node-label-lookup-index[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-type-lookup-index[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-lookup-index-only-if-it-does-not-already-exist[]
-* xref::indexes-for-search-performance.adoc#indexes-create-point-index[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-node-point-index[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-point-index[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-only-if-it-does-not-already-exist[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-specifying-the-index-configuration[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-specifying-both-the-index-provider-and-configuration[]
-* xref::indexes-for-search-performance.adoc#indexes-create-text-index[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-node-text-index[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-text-index[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-only-if-it-does-not-already-exist[]
-** xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-specifying-the-index-provider[]
-* xref::indexes-for-search-performance.adoc#indexes-create-conflicting-index[]
-** xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-already-existing-index[]
-** xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-index[]
-** xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-when-a-constraint-already-exists[]
-** xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-constraint[]
-
 
 [[indexes-create-range-index]]
 === Creating a range index
@@ -893,53 +795,6 @@ Added 1 index.
 
 Specifying the index configuration can be combined with specifying index provider.
 Though only one valid value exists for the index provider, `point-1.0`, which is the default value.
-
-[discrete]
-[[indexes-create-a-point-index-specifying-both-the-index-provider-and-configuration]]
-==== Create a point index specifying both the index provider and configuration
-
-To create a point index with a specific index provider and configuration, the `OPTIONS` clause is used.
-Only one valid value exists for the index provider, `point-1.0`, which is the default value.
-
-The valid configuration settings are:
-
-* `spatial.cartesian.min`
-* `spatial.cartesian.max`
-* `spatial.cartesian-3d.min`
-* `spatial.cartesian-3d.max`
-* `spatial.wgs-84.min`
-* `spatial.wgs-84.max`
-* `spatial.wgs-84-3d.min`
-* `spatial.wgs-84-3d.max`
-
-Non-specified settings have their respective default values.
-
-.+Creating a point index with index provider and configuration+
-======
-
-.Query
-[source, cypher]
-----
-CREATE POINT INDEX index_with_options
-FOR ()-[r:TYPE]-() ON (r.prop1)
-OPTIONS {
- indexProvider: 'point-1.0',
- indexConfig: {
-   `spatial.wgs-84.min`: [-100.0, -80.0],
-   `spatial.wgs-84.max`: [100.0, 80.0]
-  }
-}
-----
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
-
-Index provider and configuration can also be specified separately.
 
 
 [[indexes-create-text-index]]
@@ -1474,4 +1329,72 @@ DROP INDEX missing_index_name IF EXISTS
 ----
 
 ======
+
+
+[[indexes-single-vs-composite-index]]
+== Composite index limitations
+
+Like single-property range indexes, composite range indexes support all predicates:
+
+* equality check: `n.prop = value`
+* list membership check: `n.prop IN list`
+* existence check: `n.prop IS NOT NULL`
+* range search: `n.prop > value`
+* prefix search: `STARTS WITH`
+
+[NOTE]
+====
+For details about each operator, see xref::syntax/operators.adoc[Operators].
+====
+
+However, predicates might be planned as existence check and a filter.
+For most predicates, this can be avoided by following these restrictions:
+
+* If there is any `equality check` and `list membership check` predicates,
+they need to be for the first properties defined by the index.
+* There can be up to one `range search` or `prefix search` predicate.
+* There can be any number of `existence check` predicates.
+* Any predicate after a `range search`, `prefix search` or `existence check` predicate has to be an `existence check` predicate.
+
+[NOTE]
+====
+The `suffix search` (`ENDS WITH`) and `substring search` (`CONTAINS`) predicates can utilize the index as well.
+However, they are always planned as an existence check and a filter and any predicates following after will therefore also be planned as such.
+====
+
+For example, an index on nodes with `:Label(prop1,prop2,prop3,prop4,prop5,prop6)` and predicates:
+
+[source, cypher, role=test-skip]
+----
+WHERE n.prop1 = 'x' AND n.prop2 = 1 AND n.prop3 > 5 AND n.prop4 < 'e' AND n.prop5 = true AND n.prop6 IS NOT NULL
+----
+
+will be planned as:
+
+[source, cypher, role=test-skip]
+----
+WHERE n.prop1 = 'x' AND n.prop2 = 1 AND n.prop3 > 5 AND n.prop4 IS NOT NULL AND n.prop5 IS NOT NULL AND n.prop6 IS NOT NULL
+----
+
+with filters on `n.prop4 < 'e'` and `n.prop5 = true`, since `n.prop3` has a `range search` predicate.
+
+And an index on nodes with `:Label(prop1,prop2)` with predicates:
+
+[source, cypher, role=test-skip]
+----
+WHERE n.prop1 ENDS WITH 'x' AND n.prop2 = false
+----
+
+will be planned as:
+
+[source, cypher, role=test-skip]
+----
+WHERE n.prop1 IS NOT NULL AND n.prop2 IS NOT NULL
+----
+
+with filters on `n.prop1 ENDS WITH 'x'` and `n.prop2 = false`, since `n.prop1` has a `suffix search` predicate.
+
+Composite indexes require predicates on all properties indexed.
+If there are predicates on only a subset of the indexed properties, it will not be possible to use the composite index.
+To get this kind of fallback behavior, it is necessary to create additional indexes on the relevant sub-set of properties or on single properties.
 

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -295,6 +295,7 @@ With `IF EXISTS`, no error is thrown and nothing happens should the index not ex
 
 |===
 
+
 .List indexes
 [options="noheader", width="100%", cols="2, 8a"]
 |===
@@ -322,7 +323,7 @@ Creating an index requires xref::administration/access-control/database-administ
 while dropping an index requires xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `DROP INDEX` privilege] and
 listing indexes require xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `SHOW INDEX` privilege].
 
-xref::query-tuning/using.adoc[Planner hints and the USING keyword] describes how to make the Cypher planner use specific indexes (especially in cases where the planner would not necessarily have used them).
+xref:query-tuning/using.adoc[Planner hints and the USING keyword] describes how to make the Cypher planner use specific indexes (especially in cases where the planner would not necessarily have used them).
 
 
 [[administration-indexes-single-vs-composite-index]]
@@ -396,21 +397,47 @@ To get this kind of fallback behavior, it is necessary to create additional inde
 [[administration-indexes-examples]]
 == +CREATE INDEX+
 
+Creating an index is done with the `+CREATE ... INDEX ...+` command.
+If no index type is specified in the create command a range index will be created.
+
+[IMPORTANT]
+====
+The index name must be unique among both indexes and constraints.
+====
+
+[NOTE]
+====
+Best practice is to give the index a name when it is created.
+If the index is not explicitly named, it gets an auto-generated name.
+====
+
+[NOTE]
+====
+The `+CREATE ... INDEX ...+` command is optionally idempotent. This mean that its default behavior is to throw an error if an attempt is made to create the same index twice.
+With `IF NOT EXISTS`, no error is thrown and nothing happens should an index with the same name or same schema and index type already exist.
+It may still throw an error if conflicting constraints exist, such as constraints with the same name or schema and backing index type.
+====
+
+Creating an index requires xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `CREATE INDEX` privilege].
+
+[NOTE]
+====
+The new index is not immediately available, but is created in the background.
+====
+
 *Examples:*
 
 * xref::indexes-for-search-performance.adoc#administration-indexes-create-a-single-property-range-index-for-nodes[]
 * xref::indexes-for-search-performance.adoc#administration-indexes-create-a-single-property-range-index-for-relationships[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-range-index-only-if-it-does-not-already-exist[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-range-index-specifying-the-index-provider[]
 * xref::indexes-for-search-performance.adoc#administration-indexes-create-a-composite-range-index-for-nodes[]
 * xref::indexes-for-search-performance.adoc#administration-indexes-create-a-composite-range-index-for-relationships[]
+* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-range-index-only-if-it-does-not-already-exist[]
 * xref::indexes-for-search-performance.adoc#administration-indexes-create-a-node-label-lookup-index[]
 * xref::indexes-for-search-performance.adoc#administration-indexes-create-a-relationship-type-lookup-index[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-token-lookup-index-specifying-the-index-provider[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-lookup-index-only-if-it-does-not-already-exist[]
 * xref::indexes-for-search-performance.adoc#administration-indexes-create-a-node-point-index[]
 * xref::indexes-for-search-performance.adoc#administration-indexes-create-a-relationship-point-index[]
 * xref::indexes-for-search-performance.adoc#administration-indexes-create-a-point-index-only-if-it-does-not-already-exist[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-point-index-specifying-the-index-provider[]
 * xref::indexes-for-search-performance.adoc#administration-indexes-create-a-point-index-specifying-the-index-configuration[]
 * xref::indexes-for-search-performance.adoc#administration-indexes-create-a-point-index-specifying-both-the-index-provider-and-configuration[]
 * xref::indexes-for-search-performance.adoc#administration-indexes-create-a-node-text-index[]
@@ -424,21 +451,19 @@ To get this kind of fallback behavior, it is necessary to create additional inde
 
 
 [discrete]
-[[administration-indexes-create-a-single-property-range-index-for-nodes]]
-=== Create a single-property range index for nodes
+=== Creating a range index
 
-A named range index on a single property for all nodes with a particular label can be created with:
-
-[source, syntax, role="noheader"]
-----
-CREATE INDEX index_name FOR (n:Label) ON (n.property)
-----
+Range indexes have only one index provider available, `range-1.0`, and no supported index configuration.
 
 Note that the index is not immediately available, but is created in the background.
 
+[discrete]
+[[administration-indexes-create-a-single-property-range-index-for-nodes]]
+==== Create a single-property range index for nodes
 
-.+CREATE INDEX+
+.+Creating a named range index on a single property for all nodes with a particular label+
 ======
+The following statement will create a named range index on all nodes labeled with `Person` and which have the `surname` property:
 
 .Query
 [source, cypher]
@@ -459,26 +484,16 @@ Added 1 index.
 
 ======
 
-
 [discrete]
 [[administration-indexes-create-a-single-property-range-index-for-relationships]]
-=== Create a single-property range index for relationships
+==== Create a single-property range index for relationships
 
-A named range index on a single property for all relationships with a particular relationship type can be created with:
-
-[source, syntax, role="noheader"]
-----
-CREATE INDEX index_name FOR ()-[r:TYPE]-() ON (r.property)
-----
-
-Note that the index is not immediately available, but is created in the background.
-
-
-.+CREATE INDEX+
+.+Creating a named range index on a single property for all relationships with a particular relationship type+
 ======
+The following statement will create a named range index on all relationships with relationship type `KNOWS` and property `since`:
 
 .Query
-[source, cypher, indent=0]
+[source, cypher]
 ----
 CREATE INDEX rel_range_index_name FOR ()-[r:KNOWS]-() ON (r.since)
 ----
@@ -496,73 +511,9 @@ Added 1 index.
 
 ======
 
-
-[discrete]
-[[administration-indexes-create-a-range-index-only-if-it-does-not-already-exist]]
-=== Create a range index only if it does not already exist
-
-If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
-
-
-.+CREATE RANGE INDEX+
-======
-
-.Query
-[source, cypher]
-----
-CREATE INDEX node_range_index_name IF NOT EXISTS
-FOR (n:Person) ON (n.surname)
-----
-
-[NOTE]
-====
-The index will not be created if there already exists an index with the same schema and type, same name or both.
-====
-
-.Result
-[queryresult]
-----
-(no changes, no records)
-----
-
-======
-
-
-[discrete]
-[[administration-indexes-create-a-range-index-specifying-the-index-provider]]
-=== Create a range index specifying the index provider
-
-To create a range index with a specific index provider, the `OPTIONS` clause is used.
-Only one valid value exists for the index provider, `range-1.0`, which is the default value.
-
-
-.+CREATE INDEX+
-======
-
-.Query
-[source, cypher, indent=0]
-----
-CREATE INDEX range_index_with_provider
-FOR ()-[r:TYPE]-() ON (r.prop1)
-OPTIONS {
-  indexProvider: 'range-1.0'
-}
-----
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
-
-There is no supported index configuration for range indexes.
-
-
 [discrete]
 [[administration-indexes-create-a-composite-range-index-for-nodes]]
-=== Create a composite range index for nodes
+==== Create a composite range index for nodes
 
 A named range index on multiple properties for all nodes with a particular label -- i.e. a composite index -- can be created with:
 
@@ -572,10 +523,9 @@ CREATE INDEX index_name FOR (n:Label) ON (n.prop1, ..., n.propN)
 ----
 
 Only nodes with the specified label and that contain all the properties in the index definition will be added to the index.
-Note that the composite index is not immediately available, but is created in the background.
 
 
-.+CREATE INDEX+
+.+Creating a named range index on multiple properties for all nodes with a particular label+
 ======
 
 The following statement will create a named composite range index on all nodes labeled with `Person` and which have both an `age` and `country` property:
@@ -599,10 +549,9 @@ Added 1 index.
 
 ======
 
-
 [discrete]
 [[administration-indexes-create-a-composite-range-index-for-relationships]]
-=== Create a composite range index for relationships
+==== Create a composite range index for relationships
 
 A named range index on multiple properties for all relationships with a particular relationship type -- i.e. a composite index -- can be created with:
 
@@ -612,10 +561,9 @@ CREATE INDEX index_name FOR ()-[r:TYPE]-() ON (r.prop1, ..., r.propN)
 ----
 
 Only relationships with the specified type and that contain all the properties in the index definition will be added to the index.
-Note that the composite index is not immediately available, but is created in the background.
 
 
-.+CREATE INDEX+
+.+Creating a named range index on multiple properties for all relationships with a particular relationship type+
 ======
 
 The following statement will create a named composite range index on all relationships labeled with `PURCHASED` and which have both a `date` and `amount` property:
@@ -639,26 +587,56 @@ Added 1 index.
 
 ======
 
-
 [discrete]
-[[administration-indexes-create-a-node-label-lookup-index]]
-=== Create a node label lookup index
+[[administration-indexes-create-a-range-index-only-if-it-does-not-already-exist]]
+==== Create a range index only if it does not already exist
 
-A named node label lookup index for all nodes with one or more labels can be created with:
+If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
 
-[source, syntax, role="noheader"]
+.+Creating a range index with `IF NOT EXISTS`+
+======
+The following statement will attempt to create a named range index on all nodes labeled with `Person` and which have the `surname` property:
+
+.Query
+[source, cypher]
 ----
-CREATE LOOKUP INDEX index_name FOR (n) ON EACH labels(n)
+CREATE INDEX node_range_index_name IF NOT EXISTS
+FOR (n:Person) ON (n.surname)
 ----
 
 [NOTE]
 ====
-The index is not immediately available, but is created in the background.
+The index will not be created if there already exists an index with the same schema and type, same name or both.
 ====
 
+.Result
+[queryresult]
+----
+(no changes, no records)
+----
 
-.+CREATE LOOKUP INDEX+
 ======
+
+
+[discrete]
+=== Creating a token lookup index
+
+Token lookup indexes (node label and relationship type lookup indexes) have only one index provider available, `token-lookup-1.0`, and no supported index configuration.
+
+Note that the index is not immediately available, but is created in the background.
+
+[discrete]
+[[administration-indexes-create-a-node-label-lookup-index]]
+==== Create a node label lookup index
+
+[NOTE]
+====
+Only one node label lookup index can exist at the time.
+====
+
+.+Creating a named node label lookup index for all nodes with one or more labels+
+======
+The following statement will create a named node label lookup index on all nodes with labels:
 
 // Lookup indexes exist by default, recreating them would raise an error
 .Query
@@ -669,7 +647,7 @@ CREATE LOOKUP INDEX node_label_lookup_index FOR (n) ON EACH labels(n)
 
 [NOTE]
 ====
-Note that a node label lookup index can only be created once and that the index name must be unique.
+The index name must be unique.
 ====
 
 .Result
@@ -680,29 +658,18 @@ Added 1 index.
 
 ======
 
-[NOTE]
-====
-Only one node label lookup index can exist at the time.
-====
-
 [discrete]
 [[administration-indexes-create-a-relationship-type-lookup-index]]
-=== Create a relationship type lookup index
-
-A named relationship type lookup index for all relationships with any relationship type can be created with:
-
-[source, syntax, role="noheader"]
-----
-CREATE LOOKUP INDEX index_name FOR ()-[r]-() ON EACH type(r)
-----
+==== Create a relationship type lookup index
 
 [NOTE]
 ====
-The index is not immediately available, but is created in the background.
+Only one relationship type lookup index can exist at the time.
 ====
 
-.+CREATE LOOKUP INDEX+
+.+Creating a named relationship type lookup index for all relationships with any relationship type+
 ======
+The following statement will create a named relationship type lookup index on all relationships:
 
 // Lookup indexes exist by default, recreating them would raise an error
 .Query
@@ -713,7 +680,7 @@ CREATE LOOKUP INDEX rel_type_lookup_index FOR ()-[r]-() ON EACH type(r)
 
 [NOTE]
 ====
-Note that a relationship type lookup index can only be created once and that the index name must be unique.
+The index name must be unique.
 ====
 
 .Result
@@ -724,70 +691,55 @@ Added 1 index.
 
 ======
 
-[NOTE]
-====
-Only one relationship type lookup index can exist at the time.
-====
-
-// do we want an IF NOT EXISTS example for LOOKUP indexes?
-
 [discrete]
-[[administration-indexes-create-a-token-lookup-index-specifying-the-index-provider]]
-=== Create a token lookup index specifying the index provider
+[[indexes-create-a-lookup-index-only-if-it-does-not-already-exist]]
+==== Create a token lookup index only if it does not already exist
 
-Token lookup indexes (node label and relationship type lookup indexes) allow setting the index provider using the `OPTIONS` clause.
-Only one valid value exists for the index provider, `token-lookup-1.0`, which is the default value.
+If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
 
-// Cypher only has the keyword LOOKUP why is the option named `token-lookup` ???
-// -> the name `token-lookup` came from kernel but wasn't added as part of the cypher commands,
-//    because there is currently only one type of lookup indexes which are token lookup ones.
-//    The name `token` is a collective word for both node label and relationship type,
-//    hence the `node label lookup index` and `relationship type lookup index` variations above.
-
-
-.+CREATE LOOKUP INDEX+
+.+Creating a node label index with `IF NOT EXISTS`+
 ======
+The following statement will attempt to create a named node label lookup index on all nodes with labels:
 
-// Lookup indexes exist by default, recreating them would raise an error
 .Query
-[source, cypher, role=test-skip]
+[source, cypher]
 ----
-CREATE LOOKUP INDEX node_label_lookup_index FOR (n) ON EACH labels(n)
-OPTIONS {indexProvider: 'token-lookup-1.0'}
+CREATE LOOKUP INDEX node_label_lookup IF NOT EXISTS FOR (n) ON EACH labels(n)
 ----
 
 [NOTE]
 ====
-Note that the above command will fail if any node label lookup index already exists.
+The index will not be created if there already exists an index with the same schema and type, same name or both.
 ====
 
 .Result
 [queryresult]
 ----
-Added 1 index.
+(no changes, no records)
 ----
 
 ======
 
-There is no supported index configuration for token lookup indexes.
-
 
 [discrete]
-[[administration-indexes-create-a-node-point-index]]
-=== Create a node point index
+=== Creating a point index
 
-A named point index on a single property for all nodes with a particular label can be created with:
+Point indexes have only one index provider available, `point-1.0`, but it does have supported index configuration, see the last examples.
 
-[source, syntax, role="noheader"]
-----
-CREATE POINT INDEX index_name FOR (n:Label) ON (n.property)
-----
+[NOTE]
+====
+Note that point indexes only recognize point values and do not support multiple properties.
+====
 
 Note that the index is not immediately available, but is created in the background.
 
+[discrete]
+[[administration-indexes-create-a-node-point-index]]
+==== Create a node point index
 
-.+CREATE POINT INDEX+
+.+Creating a named point index on a single property for all nodes with a particular label+
 ======
+The following statement will create a named point index on all nodes labeled with `Person` and which have the `sublocation` property:
 
 .Query
 [source, cypher]
@@ -808,27 +760,13 @@ Added 1 index.
 
 ======
 
-[NOTE]
-====
-Note that point indexes only recognize point values and do not support multiple properties.
-====
-
 [discrete]
 [[administration-indexes-create-a-relationship-point-index]]
-=== Create a relationship point index
+==== Create a relationship point index
 
-A named point index on a single property for all relationships with a particular relationship type can be created with:
-
-[source, syntax]
-----
-CREATE POINT INDEX index_name FOR ()-[r:TYPE]-() ON (r.property)
-----
-
-Note that the index is not immediately available, but is created in the background.
-
-
-.+CREATE POINT INDEX+
+.+Creating a named point index on a single property for all relationships with a particular relationship type+
 ======
+The following statement will create a named point index on all relationships with relationship type `STREET` and property `intersection`:
 
 .Query
 [source, cypher]
@@ -849,19 +787,14 @@ Added 1 index.
 
 ======
 
-[NOTE]
-====
-Note that point indexes only recognize point values and do not support multiple properties.
-====
-
 [discrete]
 [[administration-indexes-create-a-point-index-only-if-it-does-not-already-exist]]
-=== Create a point index only if it does not already exist
+==== Create a point index only if it does not already exist
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
 
 
-.+CREATE POINT INDEX+
+.+Creating a point index with `IF NOT EXISTS`+
 ======
 
 .Query
@@ -884,41 +817,9 @@ Note that the index will not be created if there already exists an index with th
 
 ======
 
-
-[discrete]
-[[administration-indexes-create-a-point-index-specifying-the-index-provider]]
-=== Create a point index specifying the index provider
-
-To create a point index with a specific index provider, the `OPTIONS` clause is used.
-Only one valid value exists for the index provider, `point-1.0`, which is the default value.
-
-.+CREATE POINT INDEX+
-======
-
-.Query
-[source, cypher]
-----
-CREATE POINT INDEX index_with_provider
-FOR (n:Label) ON (n.prop1)
-OPTIONS {
-  indexProvider: 'point-1.0'
-}
-----
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
-
-Specifying the index provider can be combined with specifying index configuration.
-
-
 [discrete]
 [[administration-indexes-create-a-point-index-specifying-the-index-configuration]]
-=== Create a point index specifying the index configuration
+==== Create a point index specifying the index configuration
 
 To create a point index with a specific index configuration, the `OPTIONS` clause is used.
 
@@ -936,11 +837,11 @@ The valid configuration settings are:
 Non-specified settings have their respective default values.
 
 
-.+CREATE POINT INDEX+
+.+Creating a point index with index configuration+
 ======
 
 .Query
-[source, cypher, indent=0]
+[source, cypher]
 ----
 CREATE POINT INDEX index_with_config
 FOR (n:Label) ON (n.prop2)
@@ -961,11 +862,11 @@ Added 1 index.
 ======
 
 Specifying the index configuration can be combined with specifying index provider.
-
+Though only one valid value exists for the index provider, `point-1.0`, which is the default value.
 
 [discrete]
 [[administration-indexes-create-a-point-index-specifying-both-the-index-provider-and-configuration]]
-=== Create a point index specifying both the index provider and configuration
+==== Create a point index specifying both the index provider and configuration
 
 To create a point index with a specific index provider and configuration, the `OPTIONS` clause is used.
 Only one valid value exists for the index provider, `point-1.0`, which is the default value.
@@ -983,7 +884,7 @@ The valid configuration settings are:
 
 Non-specified settings have their respective default values.
 
-.+CREATE POINT INDEX+
+.+Creating a point index with index provider and configuration+
 ======
 
 .Query
@@ -1012,26 +913,27 @@ Index provider and configuration can also be specified separately.
 
 
 [discrete]
-[[administration-indexes-create-a-node-text-index]]
-=== Create a node text index
+=== Creating a text index
 
-A named text index on a single property for all nodes with a particular label can be created with:
-
-[source, syntax, role="noheader"]
-----
-CREATE TEXT INDEX index_name FOR (n:Label) ON (n.property)
-----
+Text indexes have two index providers available, `text-2.0` (default) and `text-1.0` (deprecated), and no supported index configuration.
 
 [NOTE]
 ====
-The index is not immediately available, but is created in the background.
+Text indexes only recognize string values and do not support multiple properties.
 ====
 
-.+CREATE TEXT INDEX+
+Note that the index is not immediately available, but is created in the background.
+
+[discrete]
+[[administration-indexes-create-a-node-text-index]]
+==== Create a node text index
+
+.+Creating a named text index on a single property for all nodes with a particular label+
 ======
+The following statement will create a named text index on all nodes labeled with `Person` and which have the `nickname` property:
 
 .Query
-[source, cypher, indent=0]
+[source, cypher]
 ----
 CREATE TEXT INDEX node_index_nickname FOR (n:Person) ON (n.nickname)
 ----
@@ -1049,29 +951,13 @@ Added 1 index.
 
 ======
 
-[NOTE]
-====
-Text indexes only recognize string values and do not support multiple properties.
-====
-
 [discrete]
 [[administration-indexes-create-a-relationship-text-index]]
-=== Create a relationship text index
+==== Create a relationship text index
 
-A named text index on a single property for all relationships with a particular relationship type can be created with:
-
-[source, syntax, role="noheader"]
-----
-CREATE TEXT INDEX index_name FOR ()-[r:TYPE]-() ON (r.property)
-----
-
-[NOTE]
-====
-The index is not immediately available, but is created in the background.
-====
-
-.+CREATE TEXT INDEX+
+.+Creating a named text index on a single property for all relationships with a particular relationship type+
 ======
+The following statement will create a named text index on all relationships with relationship type `KNOWS` and property `interest`:
 
 .Query
 [source, cypher]
@@ -1092,20 +978,16 @@ Added 1 index.
 
 ======
 
-[NOTE]
-====
-Note that text indexes only recognize string values and do not support multiple properties.
-====
-
 [discrete]
 [[administration-indexes-create-a-text-index-only-if-it-does-not-already-exist]]
-=== Create a text index only if it does not already exist
+==== Create a text index only if it does not already exist
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
 
 
-.+CREATE TEXT INDEX+
+.+Creating a text index with `IF NOT EXISTS`+
 ======
+The following statement will attempt to create a named text index on all nodes labeled with `Person` and which have the `nickname` property:
 
 .Query
 [source, cypher]
@@ -1126,15 +1008,15 @@ Note that the index will not be created if there already exists an index with th
 
 ======
 
-
 [discrete]
 [[administration-indexes-create-a-text-index-specifying-the-index-provider]]
-=== Create a text index specifying the index provider
+==== Create a text index specifying the index provider
 
 To create a text index with a specific index provider, the `OPTIONS` clause is used.
-The valid values for the index provider are `text-2.0` and `text-1.0` (deprecated). The default provider is `text-2.0`.
+The valid values for the index provider are `text-2.0` and `text-1.0` (deprecated).
+The default provider is `text-2.0`.
 
-.+CREATE TEXT INDEX+
+.+Creating a text index with index provider+
 ======
 
 .Query
@@ -1154,13 +1036,17 @@ Added 1 index.
 
 There is no supported index configuration for text indexes.
 
+
+[discrete]
+=== Creating an index when a conflicting index or constraint exists
+
 [discrete]
 [[administration-indexes-failure-to-create-an-already-existing-index]]
-=== Failure to create an already existing index
+==== Failure to create an already existing index
 
 Create an index on the property `title` on nodes with the `Book` label, when that index already exists.
 
-.+CREATE RANGE INDEX+
+.+Creating a duplicated index+
 ======
 
 ////
@@ -1186,21 +1072,21 @@ There already exists an index (:Book {title}).
 
 ======
 
-
 [discrete]
 [[administration-indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-index]]
-=== Failure to create an index with the same name as an already existing index
+==== Failure to create an index with the same name as an already existing index
 
 Create a named index on the property `numberOfPages` on nodes with the `Book` label, when an index with the given name already exists.
+The index type of the existing index does not matter.
 
 
-.+CREATE RANGE INDEX+
+.+Creating an index with a duplicated name+
 ======
 
 ////
 [source, cypher, role=test-setup]
 ----
-CREATE INDEX indexOnBooks FOR (b:Label1) ON (b.prop1)
+CREATE TEXT INDEX indexOnBooks FOR (b:Label1) ON (b.prop1)
 ----
 ////
 
@@ -1220,15 +1106,14 @@ There already exists an index called 'indexOnBooks'.
 
 ======
 
-
 [discrete]
 [[administration-indexes-failure-to-create-an-index-when-a-constraint-already-exists]]
-=== Failure to create an index when a constraint already exists
+==== Failure to create an index when a constraint already exists
 
 Create an index on the property `isbn` on nodes with the `Book` label, when an index-backed constraint already exists on that schema.
+This is only relevant for range indexes.
 
-
-.+CREATE RANGE INDEX+
+.+Creating a range index on same schema as existing index-backed constraint+
 ======
 
 ////
@@ -1244,7 +1129,7 @@ CREATE CONSTRAINT FOR (book:Book) REQUIRE (book.isbn) IS UNIQUE
 CREATE INDEX bookIsbnIndex FOR (book:Book) ON (book.isbn)
 ----
 
-In this case the index can not be created because a index-backed constraint already exists on that label and property combination.
+In this case the index can not be created because an index-backed constraint already exists on that label and property combination.
 
 .Error message
 [source, error]
@@ -1254,15 +1139,14 @@ There is a uniqueness constraint on (:Book {isbn}), so an index is already creat
 
 ======
 
-
 [discrete]
 [[administration-indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-constraint]]
-=== Failure to create an index with the same name as an already existing constraint
+==== Failure to create an index with the same name as an already existing constraint
 
 Create a named index on the property `numberOfPages` on nodes with the `Book` label, when a constraint with the given name already exists.
 
 
-.+CREATE RANGE INDEX+
+.+Creating an index with same name as an existing constraint+
 ======
 
 ////
@@ -1363,6 +1247,8 @@ Full output: `+SHOW INDEXES YIELD *+`.
 
 Listing indexes also allows for `WHERE` and `YIELD` clauses to filter the returned rows and columns.
 
+Listing indexes require xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `SHOW INDEX` privilege].
+
 *Examples:*
 
 * xref::indexes-for-search-performance.adoc#administration-indexes-listing-all-indexes[]
@@ -1377,7 +1263,7 @@ To list all indexes with the default output columns, the `SHOW INDEXES` command 
 If all columns are required, use `SHOW INDEXES YIELD *`.
 
 
-.+SHOW INDEXES+
+.+Showing all indexes+
 ======
 
 .Query
@@ -1436,7 +1322,7 @@ Another more flexible way of filtering the output is to use the `WHERE` clause.
 An example is to only show indexes not belonging to constraints.
 
 
-.+SHOW RANGE INDEXES+
+.+Showing range indexes+
 ======
 
 .Query
@@ -1481,6 +1367,14 @@ An index can be dropped (removed) using the name with the `DROP INDEX index_name
 This command can drop indexes of any type, except those backing constraints.
 The name of the index can be found using the xref::indexes-for-search-performance.adoc#administration-indexes-list-indexes[`SHOW INDEXES` command], given in the output column `name`.
 
+[NOTE]
+====
+The `DROP INDEX` command is optionally idempotent.
+This means that its default behavior is to throw an error if an attempt is made to drop the same index twice.
+With `IF EXISTS`, no error is thrown and nothing happens should the index not exist.
+====
+
+Dropping an index requires xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `DROP INDEX` privilege].
 
 *Examples:*
 
@@ -1493,11 +1387,11 @@ The name of the index can be found using the xref::indexes-for-search-performanc
 === Drop an index
 
 
-.+DROP INDEX+
+.+Dropping an index+
 ======
 
 .Query
-[source, cypher, indent=0]
+[source, cypher]
 ----
 DROP INDEX example_index
 ----
@@ -1518,11 +1412,11 @@ Removed 1 index.
 If it is uncertain if an index exists and you want to drop it if it does but not get an error should it not, use `IF EXISTS`.
 
 
-.+DROP INDEX+
+.+Dropping an index with `IF NOT EXISTS`+
 ======
 
 .Query
-[source, cypher, indent=0]
+[source, cypher]
 ----
 DROP INDEX missing_index_name IF EXISTS
 ----

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -354,6 +354,27 @@ The new index is not immediately available, but is created in the background.
 Creating a range index can be done with the `CREATE INDEX` command.
 Note that the index name must be unique.
 
+[source, syntax, role="noheader"]
+----
+CREATE [RANGE] INDEX [index_name] [IF NOT EXISTS]
+FOR (n:LabelName)
+ON (n.propertyName_1[,
+    n.propertyName_2,
+    ...
+    n.propertyName_n])
+[OPTIONS "{" option: value[, ...] "}"]
+
+CREATE [RANGE] INDEX [index_name] [IF NOT EXISTS]
+FOR ()-"["r:TYPE_NAME"]"-()
+ON (r.propertyName_1[,
+    r.propertyName_2,
+    ...
+    r.propertyName_n])
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
+
 Range indexes have only one index provider available, `range-1.0`, and no supported index configuration.
 
 Note that the index is not immediately available, but is created in the background.
@@ -513,6 +534,21 @@ The index will not be created if there already exists an index with the same sch
 Creating a text index can be done with the `CREATE TEXT INDEX` command.
 Note that the index name must be unique.
 
+[source, syntax, role="noheader"]
+----
+CREATE TEXT INDEX [index_name] [IF NOT EXISTS]
+FOR (n:LabelName)
+ON (n.propertyName)
+[OPTIONS "{" option: value[, ...] "}"]
+
+CREATE TEXT INDEX [index_name] [IF NOT EXISTS]
+FOR ()-"["r:TYPE_NAME"]"-()
+ON (r.propertyName)
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
+
 Text indexes have two index providers available, `text-2.0` (default) and `text-1.0` (deprecated), and no supported index configuration.
 
 [NOTE]
@@ -637,6 +673,21 @@ There is no supported index configuration for text indexes.
 
 Creating a point index can be done with the `CREATE POINT INDEX` command.
 Note that the index name must be unique.
+
+[source, syntax, role="noheader"]
+----
+CREATE POINT INDEX [index_name] [IF NOT EXISTS]
+FOR (n:LabelName)
+ON (n.propertyName)
+[OPTIONS "{" option: value[, ...] "}"]
+
+CREATE POINT INDEX [index_name] [IF NOT EXISTS]
+FOR ()-"["r:TYPE_NAME"]"-()
+ON (r.propertyName)
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
 
 Point indexes have only one index provider available, `point-1.0`, but it does have supported index configuration, see the last examples.
 
@@ -782,6 +833,21 @@ Though only one valid value exists for the index provider, `point-1.0`, which is
 
 Creating a token lookup index (node label or relationship type lookup index) can be done with the `CREATE LOOKUP INDEX` command.
 Note that the index name must be unique.
+
+[source, syntax, role="noheader"]
+----
+CREATE LOOKUP INDEX [index_name] [IF NOT EXISTS]
+FOR (n)
+ON EACH labels(n)
+[OPTIONS "{" option: value[, ...] "}"]
+
+CREATE LOOKUP INDEX [index_name] [IF NOT EXISTS]
+FOR ()-"["r"]"-()
+ON [EACH] type(r)
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
 
 Token lookup indexes have only one index provider available, `token-lookup-1.0`, and no supported index configuration.
 
@@ -1025,7 +1091,19 @@ There already exists a constraint called 'bookRecommendations'.
 [[indexes-list-indexes]]
 == +SHOW INDEXES+
 
-Listing indexes can be done with `SHOW INDEXES`, which will produce a table with the following columns:
+Listing indexes can be done with `SHOW INDEXES`.
+
+[source, syntax, role="noheader"]
+----
+SHOW [ALL \| FULLTEXT \| LOOKUP \| POINT \| RANGE \| TEXT] INDEX[ES]
+  [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+  [WHERE expression]
+  [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+----
+
+More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
+
+This command will produce a table with the following columns:
 
 .List indexes output
 [options="header", cols="4,6,2"]
@@ -1163,7 +1241,7 @@ This can be used to drop the index with the xref::indexes-for-search-performance
 [[indexes-listing-indexes-with-filtering]]
 === Listing indexes with filtering
 
-One way of filtering the output from `SHOW INDEXES` by index type is the use of type keywords, listed in the xref::indexes-for-search-performance.adoc#indexes-syntax[syntax table].
+One way of filtering the output from `SHOW INDEXES` by index type is the use of type keywords, listed in the syntax description.
 
 For example, to show only range indexes, use `SHOW RANGE INDEXES`.
 
@@ -1215,6 +1293,13 @@ SHOW INDEXES YIELD * WHERE ...
 An index can be dropped (removed) using the name with the `DROP INDEX index_name` command.
 This command can drop indexes of any type, except those backing constraints.
 The name of the index can be found using the xref::indexes-for-search-performance.adoc#indexes-list-indexes[`SHOW INDEXES` command], given in the output column `name`.
+
+[source, syntax, role="noheader"]
+----
+DROP INDEX index_name [IF EXISTS]
+----
+
+More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
 
 The `DROP INDEX` command is optionally idempotent.
 This means that its default behavior is to throw an error if an attempt is made to drop the same index twice.

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -633,9 +633,9 @@ The index will not be created if there already exists an index with the same sch
 [[indexes-create-token-index]]
 === Creating a token lookup index
 
-Creating a token lookup index can be done with the `CREATE LOOKUP INDEX` command.
+Creating a token lookup index (node label or relationship type lookup index) can be done with the `CREATE LOOKUP INDEX` command.
 
-Token lookup indexes (node label and relationship type lookup indexes) have only one index provider available, `token-lookup-1.0`, and no supported index configuration.
+Token lookup indexes have only one index provider available, `token-lookup-1.0`, and no supported index configuration.
 
 Note that the index is not immediately available, but is created in the background.
 

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -1,6 +1,6 @@
 :description: This section explains how to manage indexes used for search performance.
 
-[[administration-indexes-search-performance]]
+[[indexes-search-performance]]
 = Indexes for search performance
 
 [abstract]
@@ -15,7 +15,7 @@ See specifically xref::query-tuning/indexes.adoc[The use of indexes] for example
 For information on index configuration and limitations, refer to link:{neo4j-docs-base-uri}/operations-manual/{page-version}/performance/index-configuration[Operations Manual -> Index configuration].
 
 
-[[administration-indexes-types]]
+[[indexes-types-and-limitations]]
 == Indexes (types and limitations)
 
 A database index is a redundant copy of some of the data in the database for the purpose of making searches of related data more efficient.
@@ -32,9 +32,6 @@ There are multiple index types available:
 * Point index.
 * Full-text index.
 
-// The BTREE index type was replaced in 5.0 by more specific index types (RANGE, POINT, and TEXT).
-// RANGE is now the default index type for CREATE INDEX.
-
 See xref::indexes-for-full-text-search.adoc[Full-text search index] for more information about full-text indexes.
 Lookup indexes contain nodes with one or more labels or relationship types, without regard for any properties.
 
@@ -43,7 +40,7 @@ Cypher enables the creation of range indexes on one or more properties for all n
 * An index created on a single property for any given label or relationship type is called a _single-property index_.
 * An index created on more than one property for any given label or relationship type is called a _composite index_.
 
-Differences in the usage patterns between composite and single-property indexes are described in xref::indexes-for-search-performance.adoc#administration-indexes-single-vs-composite-index[].
+Differences in the usage patterns between composite and single-property indexes are described in xref::indexes-for-search-performance.adoc#indexes-single-vs-composite-index[].
 
 Additionally, text and point indexes are a kind of single-property indexes, with the limitation that they only recognize properties with string and point values, respectively.
 Nodes or relationships with the indexed label or relationship type where the indexed property is of another value type are not included in the index.
@@ -57,7 +54,7 @@ If the index is not explicitly named, it gets an auto-generated name.
 Using the keyword `IF NOT EXISTS` makes the command idempotent, and no error will be thrown if you attempt to create the same index twice.
 
 
-[[administration-indexes-syntax]]
+[[indexes-syntax]]
 == Syntax
 
 [IMPORTANT]
@@ -326,7 +323,7 @@ listing indexes require xref::administration/access-control/database-administrat
 xref:query-tuning/using.adoc[Planner hints and the USING keyword] describes how to make the Cypher planner use specific indexes (especially in cases where the planner would not necessarily have used them).
 
 
-[[administration-indexes-single-vs-composite-index]]
+[[indexes-single-vs-composite-index]]
 == Composite index limitations
 
 Like single-property range indexes, composite range indexes support all predicates:
@@ -394,7 +391,7 @@ If there are predicates on only a subset of the indexed properties, it will not 
 To get this kind of fallback behavior, it is necessary to create additional indexes on the relevant sub-set of properties or on single properties.
 
 
-[[administration-indexes-examples]]
+[[indexes-create-indexes]]
 == +CREATE INDEX+
 
 Creating an index is done with the `+CREATE ... INDEX ...+` command.
@@ -427,27 +424,27 @@ The new index is not immediately available, but is created in the background.
 
 *Examples:*
 
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-single-property-range-index-for-nodes[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-single-property-range-index-for-relationships[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-composite-range-index-for-nodes[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-composite-range-index-for-relationships[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-range-index-only-if-it-does-not-already-exist[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-node-label-lookup-index[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-relationship-type-lookup-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-single-property-range-index-for-nodes[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-single-property-range-index-for-relationships[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-composite-range-index-for-nodes[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-composite-range-index-for-relationships[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-range-index-only-if-it-does-not-already-exist[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-node-label-lookup-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-type-lookup-index[]
 * xref::indexes-for-search-performance.adoc#indexes-create-a-lookup-index-only-if-it-does-not-already-exist[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-node-point-index[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-relationship-point-index[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-point-index-only-if-it-does-not-already-exist[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-point-index-specifying-the-index-configuration[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-point-index-specifying-both-the-index-provider-and-configuration[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-node-text-index[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-relationship-text-index[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-text-index-only-if-it-does-not-already-exist[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-create-a-text-index-specifying-the-index-provider[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-failure-to-create-an-already-existing-index[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-index[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-failure-to-create-an-index-when-a-constraint-already-exists[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-constraint[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-node-point-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-point-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-only-if-it-does-not-already-exist[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-specifying-the-index-configuration[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-specifying-both-the-index-provider-and-configuration[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-node-text-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-text-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-only-if-it-does-not-already-exist[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-specifying-the-index-provider[]
+* xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-already-existing-index[]
+* xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-index[]
+* xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-when-a-constraint-already-exists[]
+* xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-constraint[]
 
 
 [discrete]
@@ -458,7 +455,7 @@ Range indexes have only one index provider available, `range-1.0`, and no suppor
 Note that the index is not immediately available, but is created in the background.
 
 [discrete]
-[[administration-indexes-create-a-single-property-range-index-for-nodes]]
+[[indexes-create-a-single-property-range-index-for-nodes]]
 ==== Create a single-property range index for nodes
 
 .+Creating a named range index on a single property for all nodes with a particular label+
@@ -485,7 +482,7 @@ Added 1 index.
 ======
 
 [discrete]
-[[administration-indexes-create-a-single-property-range-index-for-relationships]]
+[[indexes-create-a-single-property-range-index-for-relationships]]
 ==== Create a single-property range index for relationships
 
 .+Creating a named range index on a single property for all relationships with a particular relationship type+
@@ -512,7 +509,7 @@ Added 1 index.
 ======
 
 [discrete]
-[[administration-indexes-create-a-composite-range-index-for-nodes]]
+[[indexes-create-a-composite-range-index-for-nodes]]
 ==== Create a composite range index for nodes
 
 A named range index on multiple properties for all nodes with a particular label -- i.e. a composite index -- can be created with:
@@ -550,7 +547,7 @@ Added 1 index.
 ======
 
 [discrete]
-[[administration-indexes-create-a-composite-range-index-for-relationships]]
+[[indexes-create-a-composite-range-index-for-relationships]]
 ==== Create a composite range index for relationships
 
 A named range index on multiple properties for all relationships with a particular relationship type -- i.e. a composite index -- can be created with:
@@ -588,7 +585,7 @@ Added 1 index.
 ======
 
 [discrete]
-[[administration-indexes-create-a-range-index-only-if-it-does-not-already-exist]]
+[[indexes-create-a-range-index-only-if-it-does-not-already-exist]]
 ==== Create a range index only if it does not already exist
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
@@ -626,7 +623,7 @@ Token lookup indexes (node label and relationship type lookup indexes) have only
 Note that the index is not immediately available, but is created in the background.
 
 [discrete]
-[[administration-indexes-create-a-node-label-lookup-index]]
+[[indexes-create-a-node-label-lookup-index]]
 ==== Create a node label lookup index
 
 [NOTE]
@@ -659,7 +656,7 @@ Added 1 index.
 ======
 
 [discrete]
-[[administration-indexes-create-a-relationship-type-lookup-index]]
+[[indexes-create-a-relationship-type-lookup-index]]
 ==== Create a relationship type lookup index
 
 [NOTE]
@@ -734,7 +731,7 @@ Note that point indexes only recognize point values and do not support multiple 
 Note that the index is not immediately available, but is created in the background.
 
 [discrete]
-[[administration-indexes-create-a-node-point-index]]
+[[indexes-create-a-node-point-index]]
 ==== Create a node point index
 
 .+Creating a named point index on a single property for all nodes with a particular label+
@@ -761,7 +758,7 @@ Added 1 index.
 ======
 
 [discrete]
-[[administration-indexes-create-a-relationship-point-index]]
+[[indexes-create-a-relationship-point-index]]
 ==== Create a relationship point index
 
 .+Creating a named point index on a single property for all relationships with a particular relationship type+
@@ -788,7 +785,7 @@ Added 1 index.
 ======
 
 [discrete]
-[[administration-indexes-create-a-point-index-only-if-it-does-not-already-exist]]
+[[indexes-create-a-point-index-only-if-it-does-not-already-exist]]
 ==== Create a point index only if it does not already exist
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
@@ -818,7 +815,7 @@ Note that the index will not be created if there already exists an index with th
 ======
 
 [discrete]
-[[administration-indexes-create-a-point-index-specifying-the-index-configuration]]
+[[indexes-create-a-point-index-specifying-the-index-configuration]]
 ==== Create a point index specifying the index configuration
 
 To create a point index with a specific index configuration, the `OPTIONS` clause is used.
@@ -865,7 +862,7 @@ Specifying the index configuration can be combined with specifying index provide
 Though only one valid value exists for the index provider, `point-1.0`, which is the default value.
 
 [discrete]
-[[administration-indexes-create-a-point-index-specifying-both-the-index-provider-and-configuration]]
+[[indexes-create-a-point-index-specifying-both-the-index-provider-and-configuration]]
 ==== Create a point index specifying both the index provider and configuration
 
 To create a point index with a specific index provider and configuration, the `OPTIONS` clause is used.
@@ -925,7 +922,7 @@ Text indexes only recognize string values and do not support multiple properties
 Note that the index is not immediately available, but is created in the background.
 
 [discrete]
-[[administration-indexes-create-a-node-text-index]]
+[[indexes-create-a-node-text-index]]
 ==== Create a node text index
 
 .+Creating a named text index on a single property for all nodes with a particular label+
@@ -952,7 +949,7 @@ Added 1 index.
 ======
 
 [discrete]
-[[administration-indexes-create-a-relationship-text-index]]
+[[indexes-create-a-relationship-text-index]]
 ==== Create a relationship text index
 
 .+Creating a named text index on a single property for all relationships with a particular relationship type+
@@ -979,7 +976,7 @@ Added 1 index.
 ======
 
 [discrete]
-[[administration-indexes-create-a-text-index-only-if-it-does-not-already-exist]]
+[[indexes-create-a-text-index-only-if-it-does-not-already-exist]]
 ==== Create a text index only if it does not already exist
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
@@ -1009,7 +1006,7 @@ Note that the index will not be created if there already exists an index with th
 ======
 
 [discrete]
-[[administration-indexes-create-a-text-index-specifying-the-index-provider]]
+[[indexes-create-a-text-index-specifying-the-index-provider]]
 ==== Create a text index specifying the index provider
 
 To create a text index with a specific index provider, the `OPTIONS` clause is used.
@@ -1041,7 +1038,7 @@ There is no supported index configuration for text indexes.
 === Creating an index when a conflicting index or constraint exists
 
 [discrete]
-[[administration-indexes-failure-to-create-an-already-existing-index]]
+[[indexes-failure-to-create-an-already-existing-index]]
 ==== Failure to create an already existing index
 
 Create an index on the property `title` on nodes with the `Book` label, when that index already exists.
@@ -1073,7 +1070,7 @@ There already exists an index (:Book {title}).
 ======
 
 [discrete]
-[[administration-indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-index]]
+[[indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-index]]
 ==== Failure to create an index with the same name as an already existing index
 
 Create a named index on the property `numberOfPages` on nodes with the `Book` label, when an index with the given name already exists.
@@ -1107,7 +1104,7 @@ There already exists an index called 'indexOnBooks'.
 ======
 
 [discrete]
-[[administration-indexes-failure-to-create-an-index-when-a-constraint-already-exists]]
+[[indexes-failure-to-create-an-index-when-a-constraint-already-exists]]
 ==== Failure to create an index when a constraint already exists
 
 Create an index on the property `isbn` on nodes with the `Book` label, when an index-backed constraint already exists on that schema.
@@ -1140,7 +1137,7 @@ There is a uniqueness constraint on (:Book {isbn}), so an index is already creat
 ======
 
 [discrete]
-[[administration-indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-constraint]]
+[[indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-constraint]]
 ==== Failure to create an index with the same name as an already existing constraint
 
 Create a named index on the property `numberOfPages` on nodes with the `Book` label, when a constraint with the given name already exists.
@@ -1173,7 +1170,7 @@ There already exists a constraint called 'bookRecommendations'.
 ======
 
 
-[[administration-indexes-list-indexes]]
+[[indexes-list-indexes]]
 == +SHOW INDEXES+
 
 Listing indexes can be done with `SHOW INDEXES`, which will produce a table with the following columns:
@@ -1251,12 +1248,12 @@ Listing indexes require xref::administration/access-control/database-administrat
 
 *Examples:*
 
-* xref::indexes-for-search-performance.adoc#administration-indexes-listing-all-indexes[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-listing-indexes-with-filtering[]
+* xref::indexes-for-search-performance.adoc#indexes-listing-all-indexes[]
+* xref::indexes-for-search-performance.adoc#indexes-listing-indexes-with-filtering[]
 
 
 [discrete]
-[[administration-indexes-listing-all-indexes]]
+[[indexes-listing-all-indexes]]
 === Listing all indexes
 
 To list all indexes with the default output columns, the `SHOW INDEXES` command can be used.
@@ -1273,7 +1270,7 @@ SHOW INDEXES
 ----
 
 One of the output columns from `SHOW INDEXES` is the name of the index.
-This can be used to drop the index with the xref::indexes-for-search-performance.adoc#administration-indexes-drop-an-index[`DROP INDEX` command].
+This can be used to drop the index with the xref::indexes-for-search-performance.adoc#indexes-drop-an-index[`DROP INDEX` command].
 
 // SHOW INDEXES default outputs
 // 4.4: id, name, state, populationPercent, uniqueness, type, entityType, labelsOrTypes, properties, indexProvider
@@ -1311,10 +1308,10 @@ This can be used to drop the index with the xref::indexes-for-search-performance
 
 
 [discrete]
-[[administration-indexes-listing-indexes-with-filtering]]
+[[indexes-listing-indexes-with-filtering]]
 === Listing indexes with filtering
 
-One way of filtering the output from `SHOW INDEXES` by index type is the use of type keywords, listed in the xref::indexes-for-search-performance.adoc#administration-indexes-syntax[syntax table].
+One way of filtering the output from `SHOW INDEXES` by index type is the use of type keywords, listed in the xref::indexes-for-search-performance.adoc#indexes-syntax[syntax table].
 
 For example, to show only range indexes, use `SHOW RANGE INDEXES`.
 
@@ -1360,12 +1357,12 @@ SHOW INDEXES YIELD * WHERE ...
 ======
 
 
-[[administration-indexes-drop-indexes]]
+[[indexes-drop-indexes]]
 == +DROP INDEX+
 
 An index can be dropped (removed) using the name with the `DROP INDEX index_name` command.
 This command can drop indexes of any type, except those backing constraints.
-The name of the index can be found using the xref::indexes-for-search-performance.adoc#administration-indexes-list-indexes[`SHOW INDEXES` command], given in the output column `name`.
+The name of the index can be found using the xref::indexes-for-search-performance.adoc#indexes-list-indexes[`SHOW INDEXES` command], given in the output column `name`.
 
 [NOTE]
 ====
@@ -1378,12 +1375,12 @@ Dropping an index requires xref::administration/access-control/database-administ
 
 *Examples:*
 
-* xref::indexes-for-search-performance.adoc#administration-indexes-drop-an-index[]
-* xref::indexes-for-search-performance.adoc#administration-indexes-drop-a-non-existing-index[]
+* xref::indexes-for-search-performance.adoc#indexes-drop-an-index[]
+* xref::indexes-for-search-performance.adoc#indexes-drop-a-non-existing-index[]
 
 
 [discrete]
-[[administration-indexes-drop-an-index]]
+[[indexes-drop-an-index]]
 === Drop an index
 
 
@@ -1406,7 +1403,7 @@ Removed 1 index.
 
 
 [discrete]
-[[administration-indexes-drop-a-non-existing-index]]
+[[indexes-drop-a-non-existing-index]]
 === Drop a non-existing index
 
 If it is uncertain if an index exists and you want to drop it if it does but not get an error should it not, use `IF EXISTS`.

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -103,6 +103,7 @@ ON (n.propertyName_1[,
 Create a range index on nodes, either on a single property or composite.
 
 Index provider can be specified using the `OPTIONS` clause.
+There is only one available index provider for this index.
 
 |===
 
@@ -129,6 +130,7 @@ ON (r.propertyName_1[,
 Create a range index on relationships, either on a single property or composite.
 
 Index provider can be specified using the `OPTIONS` clause.
+There is only one available index provider for this index.
 
 |===
 
@@ -198,6 +200,7 @@ ON (n.propertyName)
 Create a point index on nodes where the property has a point value.
 
 Index provider and configuration can be specified using the `OPTIONS` clause.
+There is only one available index provider for this index.
 
 |===
 
@@ -221,6 +224,7 @@ ON (r.propertyName)
 Create a point index on relationships where the property has a point value.
 
 Index provider and configuration can be specified using the `OPTIONS` clause.
+There is only one available index provider for this index.
 
 |===
 
@@ -244,6 +248,7 @@ ON EACH labels(n)
 Create a node label lookup index.
 
 Index provider can be specified using the `OPTIONS` clause.
+There is only one available index provider for this index.
 
 |===
 
@@ -267,6 +272,7 @@ ON [EACH] type(r)
 Create a relationship type lookup index.
 
 Index provider can be specified using the `OPTIONS` clause.
+There is only one available index provider for this index.
 
 |===
 
@@ -362,22 +368,20 @@ ON (n.propertyName_1[,
     n.propertyName_2,
     ...
     n.propertyName_n])
-[OPTIONS "{" option: value[, ...] "}"]
-
+----
+[source, syntax, role="noheader"]
+----
 CREATE [RANGE] INDEX [index_name] [IF NOT EXISTS]
 FOR ()-"["r:TYPE_NAME"]"-()
 ON (r.propertyName_1[,
     r.propertyName_2,
     ...
     r.propertyName_n])
-[OPTIONS "{" option: value[, ...] "}"]
 ----
 
 More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
 
 Range indexes have only one index provider available, `range-1.0`, and no supported index configuration.
-
-Note that the index is not immediately available, but is created in the background.
 
 *Examples:*
 
@@ -540,7 +544,9 @@ CREATE TEXT INDEX [index_name] [IF NOT EXISTS]
 FOR (n:LabelName)
 ON (n.propertyName)
 [OPTIONS "{" option: value[, ...] "}"]
-
+----
+[source, syntax, role="noheader"]
+----
 CREATE TEXT INDEX [index_name] [IF NOT EXISTS]
 FOR ()-"["r:TYPE_NAME"]"-()
 ON (r.propertyName)
@@ -555,8 +561,6 @@ Text indexes have two index providers available, `text-2.0` (default) and `text-
 ====
 Text indexes only recognize string values and do not support multiple properties.
 ====
-
-Note that the index is not immediately available, but is created in the background.
 
 *Examples:*
 
@@ -680,7 +684,9 @@ CREATE POINT INDEX [index_name] [IF NOT EXISTS]
 FOR (n:LabelName)
 ON (n.propertyName)
 [OPTIONS "{" option: value[, ...] "}"]
-
+----
+[source, syntax, role="noheader"]
+----
 CREATE POINT INDEX [index_name] [IF NOT EXISTS]
 FOR ()-"["r:TYPE_NAME"]"-()
 ON (r.propertyName)
@@ -689,14 +695,12 @@ ON (r.propertyName)
 
 More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
 
-Point indexes have only one index provider available, `point-1.0`, but it does have supported index configuration, see the last examples.
+Point indexes have supported index configuration, see the last examples, but only one index provider available, `point-1.0`.
 
 [NOTE]
 ====
 Note that point indexes only recognize point values and do not support multiple properties.
 ====
-
-Note that the index is not immediately available, but is created in the background.
 
 *Examples:*
 
@@ -839,19 +843,17 @@ Note that the index name must be unique.
 CREATE LOOKUP INDEX [index_name] [IF NOT EXISTS]
 FOR (n)
 ON EACH labels(n)
-[OPTIONS "{" option: value[, ...] "}"]
-
+----
+[source, syntax, role="noheader"]
+----
 CREATE LOOKUP INDEX [index_name] [IF NOT EXISTS]
 FOR ()-"["r"]"-()
 ON [EACH] type(r)
-[OPTIONS "{" option: value[, ...] "}"]
 ----
 
 More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
 
 Token lookup indexes have only one index provider available, `token-lookup-1.0`, and no supported index configuration.
-
-Note that the index is not immediately available, but is created in the background.
 
 *Examples:*
 

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -711,7 +711,6 @@ Note that point indexes only recognize point values and do not support multiple 
 * xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-point-index[]
 * xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-only-if-it-does-not-already-exist[]
 * xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-specifying-the-index-configuration[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-specifying-both-the-index-provider-and-configuration[]
 
 [discrete]
 [[indexes-create-a-node-point-index]]

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -854,6 +854,7 @@ Added 1 index.
 Note that point indexes only recognize point values and do not support multiple properties.
 ====
 
+[discrete]
 [[administration-indexes-create-a-point-index-only-if-it-does-not-already-exist]]
 === Create a point index only if it does not already exist
 
@@ -1362,9 +1363,6 @@ Full output: `+SHOW INDEXES YIELD *+`.
 
 Listing indexes also allows for `WHERE` and `YIELD` clauses to filter the returned rows and columns.
 
-
-== +SHOW INDEXES+
-
 *Examples:*
 
 * xref::indexes-for-search-performance.adoc#administration-indexes-listing-all-indexes[]
@@ -1483,9 +1481,6 @@ An index can be dropped (removed) using the name with the `DROP INDEX index_name
 This command can drop indexes of any type, except those backing constraints.
 The name of the index can be found using the xref::indexes-for-search-performance.adoc#administration-indexes-list-indexes[`SHOW INDEXES` command], given in the output column `name`.
 
-
-[[drop-indexes-examples]]
-== +DROP INDEX+
 
 *Examples:*
 

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -424,35 +424,48 @@ The new index is not immediately available, but is created in the background.
 
 *Examples:*
 
-* xref::indexes-for-search-performance.adoc#indexes-create-a-single-property-range-index-for-nodes[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-single-property-range-index-for-relationships[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-composite-range-index-for-nodes[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-composite-range-index-for-relationships[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-range-index-only-if-it-does-not-already-exist[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-node-label-lookup-index[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-type-lookup-index[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-lookup-index-only-if-it-does-not-already-exist[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-node-point-index[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-point-index[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-only-if-it-does-not-already-exist[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-specifying-the-index-configuration[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-specifying-both-the-index-provider-and-configuration[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-node-text-index[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-text-index[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-only-if-it-does-not-already-exist[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-specifying-the-index-provider[]
-* xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-already-existing-index[]
-* xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-index[]
-* xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-when-a-constraint-already-exists[]
-* xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-constraint[]
+* xref::indexes-for-search-performance.adoc#indexes-create-range-index[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-single-property-range-index-for-nodes[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-single-property-range-index-for-relationships[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-composite-range-index-for-nodes[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-composite-range-index-for-relationships[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-range-index-only-if-it-does-not-already-exist[]
+* xref::indexes-for-search-performance.adoc#indexes-create-token-index[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-node-label-lookup-index[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-type-lookup-index[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-lookup-index-only-if-it-does-not-already-exist[]
+* xref::indexes-for-search-performance.adoc#indexes-create-point-index[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-node-point-index[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-point-index[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-only-if-it-does-not-already-exist[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-specifying-the-index-configuration[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-specifying-both-the-index-provider-and-configuration[]
+* xref::indexes-for-search-performance.adoc#indexes-create-text-index[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-node-text-index[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-text-index[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-only-if-it-does-not-already-exist[]
+** xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-specifying-the-index-provider[]
+* xref::indexes-for-search-performance.adoc#indexes-create-conflicting-index[]
+** xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-already-existing-index[]
+** xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-index[]
+** xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-when-a-constraint-already-exists[]
+** xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-constraint[]
 
 
-[discrete]
+[[indexes-create-range-index]]
 === Creating a range index
 
 Range indexes have only one index provider available, `range-1.0`, and no supported index configuration.
 
 Note that the index is not immediately available, but is created in the background.
+
+*Examples:*
+
+* xref::indexes-for-search-performance.adoc#indexes-create-a-single-property-range-index-for-nodes[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-single-property-range-index-for-relationships[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-composite-range-index-for-nodes[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-composite-range-index-for-relationships[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-range-index-only-if-it-does-not-already-exist[]
 
 [discrete]
 [[indexes-create-a-single-property-range-index-for-nodes]]
@@ -615,12 +628,18 @@ The index will not be created if there already exists an index with the same sch
 ======
 
 
-[discrete]
+[[indexes-create-token-index]]
 === Creating a token lookup index
 
 Token lookup indexes (node label and relationship type lookup indexes) have only one index provider available, `token-lookup-1.0`, and no supported index configuration.
 
 Note that the index is not immediately available, but is created in the background.
+
+*Examples:*
+
+* xref::indexes-for-search-performance.adoc#indexes-create-a-node-label-lookup-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-type-lookup-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-lookup-index-only-if-it-does-not-already-exist[]
 
 [discrete]
 [[indexes-create-a-node-label-lookup-index]]
@@ -718,7 +737,7 @@ The index will not be created if there already exists an index with the same sch
 ======
 
 
-[discrete]
+[[indexes-create-point-index]]
 === Creating a point index
 
 Point indexes have only one index provider available, `point-1.0`, but it does have supported index configuration, see the last examples.
@@ -729,6 +748,14 @@ Note that point indexes only recognize point values and do not support multiple 
 ====
 
 Note that the index is not immediately available, but is created in the background.
+
+*Examples:*
+
+* xref::indexes-for-search-performance.adoc#indexes-create-a-node-point-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-point-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-only-if-it-does-not-already-exist[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-specifying-the-index-configuration[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-point-index-specifying-both-the-index-provider-and-configuration[]
 
 [discrete]
 [[indexes-create-a-node-point-index]]
@@ -909,7 +936,7 @@ Added 1 index.
 Index provider and configuration can also be specified separately.
 
 
-[discrete]
+[[indexes-create-text-index]]
 === Creating a text index
 
 Text indexes have two index providers available, `text-2.0` (default) and `text-1.0` (deprecated), and no supported index configuration.
@@ -920,6 +947,13 @@ Text indexes only recognize string values and do not support multiple properties
 ====
 
 Note that the index is not immediately available, but is created in the background.
+
+*Examples:*
+
+* xref::indexes-for-search-performance.adoc#indexes-create-a-node-text-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-text-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-only-if-it-does-not-already-exist[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-specifying-the-index-provider[]
 
 [discrete]
 [[indexes-create-a-node-text-index]]
@@ -1034,8 +1068,15 @@ Added 1 index.
 There is no supported index configuration for text indexes.
 
 
-[discrete]
+[[indexes-create-conflicting-index]]
 === Creating an index when a conflicting index or constraint exists
+
+*Examples:*
+
+* xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-already-existing-index[]
+* xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-index[]
+* xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-when-a-constraint-already-exists[]
+* xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-constraint[]
 
 [discrete]
 [[indexes-failure-to-create-an-already-existing-index]]

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -53,281 +53,7 @@ If the index is not explicitly named, it gets an auto-generated name.
 * Index creation is by default not idempotent, and an error will be thrown if you attempt to create the same index twice.
 Using the keyword `IF NOT EXISTS` makes the command idempotent, and no error will be thrown if you attempt to create the same index twice.
 
-
-[[indexes-syntax]]
-== Syntax
-
-[IMPORTANT]
-====
-The index name must be unique among both indexes and constraints.
-====
-
-[NOTE]
-====
-Best practice is to give the index a name when it is created.
-If the index is not explicitly named, it gets an auto-generated name.
-====
-
-[NOTE]
-====
-The `+CREATE ... INDEX ...+` command is optionally idempotent. This mean that its default behavior is to throw an error if an attempt is made to create the same index twice.
-With `IF NOT EXISTS`, no error is thrown and nothing happens should an index with the same name or same schema and index type already exist.
-It may still throw an error if conflicting constraints exist, such as constraints with the same name or schema and backing index type.
-====
-
-[NOTE]
-====
-More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
-====
-
-
-.+Create a range index on nodes+
-[options="noheader", width="100%", cols="2, 8a"]
-|===
-
-| Syntax
-|
-[source, syntax, role="noheader"]
-----
-CREATE [RANGE] INDEX [index_name] [IF NOT EXISTS]
-FOR (n:LabelName)
-ON (n.propertyName_1[,
-    n.propertyName_2,
-    ...
-    n.propertyName_n])
-[OPTIONS "{" option: value[, ...] "}"]
-----
-
-| Description
-|
-Create a range index on nodes, either on a single property or composite.
-
-Index provider can be specified using the `OPTIONS` clause.
-There is only one available index provider for this index.
-
-|===
-
-
-.+Create a range index on relationships+
-[options="noheader", width="100%", cols="2, 8a"]
-|===
-
-| Syntax
-|
-[source, syntax, role="noheader"]
-----
-CREATE [RANGE] INDEX [index_name] [IF NOT EXISTS]
-FOR ()-"["r:TYPE_NAME"]"-()
-ON (r.propertyName_1[,
-    r.propertyName_2,
-    ...
-    r.propertyName_n])
-[OPTIONS "{" option: value[, ...] "}"]
-----
-
-| Description
-|
-Create a range index on relationships, either on a single property or composite.
-
-Index provider can be specified using the `OPTIONS` clause.
-There is only one available index provider for this index.
-
-|===
-
-
-.+Create a text index on nodes+
-[options="noheader", width="100%", cols="2, 8a"]
-|===
-
-| Syntax
-|
-[source, syntax, role="noheader"]
-----
-CREATE TEXT INDEX [index_name] [IF NOT EXISTS]
-FOR (n:LabelName)
-ON (n.propertyName)
-[OPTIONS "{" option: value[, ...] "}"]
-----
-
-| Description
-|
-Create a text index on nodes where the property has a string value.
-
-Index provider can be specified using the `OPTIONS` clause.
-
-|===
-
-
-.+Create a text index on relationships+
-[options="noheader", width="100%", cols="2, 8a"]
-|===
-
-| Syntax
-|
-[source, syntax, role="noheader"]
-----
-CREATE TEXT INDEX [index_name] [IF NOT EXISTS]
-FOR ()-"["r:TYPE_NAME"]"-()
-ON (r.propertyName)
-[OPTIONS "{" option: value[, ...] "}"]
-----
-
-| Description
-|
-Create a text index on relationships where the property has a string value.
-
-Index provider can be specified using the `OPTIONS` clause.
-
-|===
-
-
-.+Create a point index on nodes+
-[options="noheader", width="100%", cols="2, 8a"]
-|===
-
-| Syntax
-|
-[source, syntax, role="noheader"]
-----
-CREATE POINT INDEX [index_name] [IF NOT EXISTS]
-FOR (n:LabelName)
-ON (n.propertyName)
-[OPTIONS "{" option: value[, ...] "}"]
-----
-
-| Description
-|
-Create a point index on nodes where the property has a point value.
-
-Index provider and configuration can be specified using the `OPTIONS` clause.
-There is only one available index provider for this index.
-
-|===
-
-
-.+Create a point index on relationships+
-[options="noheader", width="100%", cols="2, 8a"]
-|===
-
-| Syntax
-|
-[source, syntax, role="noheader"]
-----
-CREATE POINT INDEX [index_name] [IF NOT EXISTS]
-FOR ()-"["r:TYPE_NAME"]"-()
-ON (r.propertyName)
-[OPTIONS "{" option: value[, ...] "}"]
-----
-
-| Description
-|
-Create a point index on relationships where the property has a point value.
-
-Index provider and configuration can be specified using the `OPTIONS` clause.
-There is only one available index provider for this index.
-
-|===
-
-
-.+Create a node label lookup index+
-[options="noheader", width="100%", cols="2, 8a"]
-|===
-
-| Syntax
-|
-[source, syntax, role="noheader"]
-----
-CREATE LOOKUP INDEX [index_name] [IF NOT EXISTS]
-FOR (n)
-ON EACH labels(n)
-[OPTIONS "{" option: value[, ...] "}"]
-----
-
-| Description
-|
-Create a node label lookup index.
-
-Index provider can be specified using the `OPTIONS` clause.
-There is only one available index provider for this index.
-
-|===
-
-
-.+Create a relationship type lookup index+
-[options="noheader", width="100%", cols="2, 8a"]
-|===
-
-| Syntax
-|
-[source, syntax, role="noheader"]
-----
-CREATE LOOKUP INDEX [index_name] [IF NOT EXISTS]
-FOR ()-"["r"]"-()
-ON [EACH] type(r)
-[OPTIONS "{" option: value[, ...] "}"]
-----
-
-| Description
-|
-Create a relationship type lookup index.
-
-Index provider can be specified using the `OPTIONS` clause.
-There is only one available index provider for this index.
-
-|===
-
-
-.+Drop an index+
-[options="noheader", width="100%", cols="2, 8a"]
-|===
-
-| Syntax
-|
-[source, syntax, role="noheader"]
-----
-DROP INDEX index_name [IF EXISTS]
-----
-
-| Description
-| Drop an index of any index type.
-
-| Note
-|
-The command is optionally idempotent. This means that its default behavior is to throw an error if an attempt is made to drop the same index twice.
-With `IF EXISTS`, no error is thrown and nothing happens should the index not exist.
-
-|===
-
-
-.List indexes
-[options="noheader", width="100%", cols="2, 8a"]
-|===
-
-| Syntax
-|
-[source, syntax, role="noheader"]
-----
-SHOW [ALL \| FULLTEXT \| LOOKUP \| POINT \| RANGE \| TEXT] INDEX[ES]
-  [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
-  [WHERE expression]
-  [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
-----
-
-| Description
-| List indexes in the database, either all or filtered on index type.
-
-| Note
-| When using the `RETURN` clause, the `YIELD` clause is mandatory and must not be omitted.
-
-|===
-
-
-Creating an index requires xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `CREATE INDEX` privilege],
-while dropping an index requires xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `DROP INDEX` privilege] and
-listing indexes require xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `SHOW INDEX` privilege].
-
-xref:query-tuning/using.adoc[Planner hints and the USING keyword] describes how to make the Cypher planner use specific indexes (especially in cases where the planner would not necessarily have used them).
-
+For a brief overview of the syntax, for all the index commands, see xref::indexes-for-search-performance.adoc#indexes-syntax[].
 
 [[indexes-create-indexes]]
 == +CREATE INDEX+
@@ -1127,6 +853,281 @@ DROP INDEX missing_index_name IF EXISTS
 ----
 
 If an index with that name exists it is removed, if not the command does nothing.
+
+
+[[indexes-syntax]]
+== Syntax
+
+[IMPORTANT]
+====
+The index name must be unique among both indexes and constraints.
+====
+
+[NOTE]
+====
+Best practice is to give the index a name when it is created.
+If the index is not explicitly named, it gets an auto-generated name.
+====
+
+[NOTE]
+====
+The `+CREATE ... INDEX ...+` command is optionally idempotent. This mean that its default behavior is to throw an error if an attempt is made to create the same index twice.
+With `IF NOT EXISTS`, no error is thrown and nothing happens should an index with the same name or same schema and index type already exist.
+It may still throw an error if conflicting constraints exist, such as constraints with the same name or schema and backing index type.
+====
+
+[NOTE]
+====
+More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
+====
+
+
+.+Create a range index on nodes+
+[options="noheader", width="100%", cols="2, 8a"]
+|===
+
+| Syntax
+|
+[source, syntax, role="noheader"]
+----
+CREATE [RANGE] INDEX [index_name] [IF NOT EXISTS]
+FOR (n:LabelName)
+ON (n.propertyName_1[,
+    n.propertyName_2,
+    ...
+    n.propertyName_n])
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+| Description
+|
+Create a range index on nodes, either on a single property or composite.
+
+Index provider can be specified using the `OPTIONS` clause.
+There is only one available index provider for this index.
+
+|===
+
+
+.+Create a range index on relationships+
+[options="noheader", width="100%", cols="2, 8a"]
+|===
+
+| Syntax
+|
+[source, syntax, role="noheader"]
+----
+CREATE [RANGE] INDEX [index_name] [IF NOT EXISTS]
+FOR ()-"["r:TYPE_NAME"]"-()
+ON (r.propertyName_1[,
+    r.propertyName_2,
+    ...
+    r.propertyName_n])
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+| Description
+|
+Create a range index on relationships, either on a single property or composite.
+
+Index provider can be specified using the `OPTIONS` clause.
+There is only one available index provider for this index.
+
+|===
+
+
+.+Create a text index on nodes+
+[options="noheader", width="100%", cols="2, 8a"]
+|===
+
+| Syntax
+|
+[source, syntax, role="noheader"]
+----
+CREATE TEXT INDEX [index_name] [IF NOT EXISTS]
+FOR (n:LabelName)
+ON (n.propertyName)
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+| Description
+|
+Create a text index on nodes where the property has a string value.
+
+Index provider can be specified using the `OPTIONS` clause.
+
+|===
+
+
+.+Create a text index on relationships+
+[options="noheader", width="100%", cols="2, 8a"]
+|===
+
+| Syntax
+|
+[source, syntax, role="noheader"]
+----
+CREATE TEXT INDEX [index_name] [IF NOT EXISTS]
+FOR ()-"["r:TYPE_NAME"]"-()
+ON (r.propertyName)
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+| Description
+|
+Create a text index on relationships where the property has a string value.
+
+Index provider can be specified using the `OPTIONS` clause.
+
+|===
+
+
+.+Create a point index on nodes+
+[options="noheader", width="100%", cols="2, 8a"]
+|===
+
+| Syntax
+|
+[source, syntax, role="noheader"]
+----
+CREATE POINT INDEX [index_name] [IF NOT EXISTS]
+FOR (n:LabelName)
+ON (n.propertyName)
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+| Description
+|
+Create a point index on nodes where the property has a point value.
+
+Index provider and configuration can be specified using the `OPTIONS` clause.
+There is only one available index provider for this index.
+
+|===
+
+
+.+Create a point index on relationships+
+[options="noheader", width="100%", cols="2, 8a"]
+|===
+
+| Syntax
+|
+[source, syntax, role="noheader"]
+----
+CREATE POINT INDEX [index_name] [IF NOT EXISTS]
+FOR ()-"["r:TYPE_NAME"]"-()
+ON (r.propertyName)
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+| Description
+|
+Create a point index on relationships where the property has a point value.
+
+Index provider and configuration can be specified using the `OPTIONS` clause.
+There is only one available index provider for this index.
+
+|===
+
+
+.+Create a node label lookup index+
+[options="noheader", width="100%", cols="2, 8a"]
+|===
+
+| Syntax
+|
+[source, syntax, role="noheader"]
+----
+CREATE LOOKUP INDEX [index_name] [IF NOT EXISTS]
+FOR (n)
+ON EACH labels(n)
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+| Description
+|
+Create a node label lookup index.
+
+Index provider can be specified using the `OPTIONS` clause.
+There is only one available index provider for this index.
+
+|===
+
+
+.+Create a relationship type lookup index+
+[options="noheader", width="100%", cols="2, 8a"]
+|===
+
+| Syntax
+|
+[source, syntax, role="noheader"]
+----
+CREATE LOOKUP INDEX [index_name] [IF NOT EXISTS]
+FOR ()-"["r"]"-()
+ON [EACH] type(r)
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+| Description
+|
+Create a relationship type lookup index.
+
+Index provider can be specified using the `OPTIONS` clause.
+There is only one available index provider for this index.
+
+|===
+
+
+.+Drop an index+
+[options="noheader", width="100%", cols="2, 8a"]
+|===
+
+| Syntax
+|
+[source, syntax, role="noheader"]
+----
+DROP INDEX index_name [IF EXISTS]
+----
+
+| Description
+| Drop an index of any index type.
+
+| Note
+|
+The command is optionally idempotent. This means that its default behavior is to throw an error if an attempt is made to drop the same index twice.
+With `IF EXISTS`, no error is thrown and nothing happens should the index not exist.
+
+|===
+
+
+.List indexes
+[options="noheader", width="100%", cols="2, 8a"]
+|===
+
+| Syntax
+|
+[source, syntax, role="noheader"]
+----
+SHOW [ALL \| FULLTEXT \| LOOKUP \| POINT \| RANGE \| TEXT] INDEX[ES]
+  [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+  [WHERE expression]
+  [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
+----
+
+| Description
+| List indexes in the database, either all or filtered on index type.
+
+| Note
+| When using the `RETURN` clause, the `YIELD` clause is mandatory and must not be omitted.
+
+|===
+
+
+Creating an index requires xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `CREATE INDEX` privilege],
+while dropping an index requires xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `DROP INDEX` privilege] and
+listing indexes require xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `SHOW INDEX` privilege].
+
+xref:query-tuning/using.adoc[Planner hints and the USING keyword] describes how to make the Cypher planner use specific indexes (especially in cases where the planner would not necessarily have used them).
 
 
 [[indexes-single-vs-composite-index]]

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -455,6 +455,8 @@ The new index is not immediately available, but is created in the background.
 [[indexes-create-range-index]]
 === Creating a range index
 
+Creating a range index can be done with the `CREATE INDEX` command.
+
 Range indexes have only one index provider available, `range-1.0`, and no supported index configuration.
 
 Note that the index is not immediately available, but is created in the background.
@@ -631,6 +633,8 @@ The index will not be created if there already exists an index with the same sch
 [[indexes-create-token-index]]
 === Creating a token lookup index
 
+Creating a token lookup index can be done with the `CREATE LOOKUP INDEX` command.
+
 Token lookup indexes (node label and relationship type lookup indexes) have only one index provider available, `token-lookup-1.0`, and no supported index configuration.
 
 Note that the index is not immediately available, but is created in the background.
@@ -739,6 +743,8 @@ The index will not be created if there already exists an index with the same sch
 
 [[indexes-create-point-index]]
 === Creating a point index
+
+Creating a point index can be done with the `CREATE POINT INDEX` command.
 
 Point indexes have only one index provider available, `point-1.0`, but it does have supported index configuration, see the last examples.
 
@@ -938,6 +944,8 @@ Index provider and configuration can also be specified separately.
 
 [[indexes-create-text-index]]
 === Creating a text index
+
+Creating a text index can be done with the `CREATE TEXT INDEX` command.
 
 Text indexes have two index providers available, `text-2.0` (default) and `text-1.0` (deprecated), and no supported index configuration.
 

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -133,52 +133,6 @@ Index provider can be specified using the `OPTIONS` clause.
 |===
 
 
-.+Create a node label lookup index+
-[options="noheader", width="100%", cols="2, 8a"]
-|===
-
-| Syntax
-|
-[source, syntax, role="noheader"]
-----
-CREATE LOOKUP INDEX [index_name] [IF NOT EXISTS]
-FOR (n)
-ON EACH labels(n)
-[OPTIONS "{" option: value[, ...] "}"]
-----
-
-| Description
-|
-Create a node label lookup index.
-
-Index provider can be specified using the `OPTIONS` clause.
-
-|===
-
-
-.+Create a relationship type lookup index+
-[options="noheader", width="100%", cols="2, 8a"]
-|===
-
-| Syntax
-|
-[source, syntax, role="noheader"]
-----
-CREATE LOOKUP INDEX [index_name] [IF NOT EXISTS]
-FOR ()-"["r"]"-()
-ON [EACH] type(r)
-[OPTIONS "{" option: value[, ...] "}"]
-----
-
-| Description
-|
-Create a relationship type lookup index.
-
-Index provider can be specified using the `OPTIONS` clause.
-
-|===
-
-
 .+Create a text index on nodes+
 [options="noheader", width="100%", cols="2, 8a"]
 |===
@@ -271,6 +225,52 @@ Index provider and configuration can be specified using the `OPTIONS` clause.
 |===
 
 
+.+Create a node label lookup index+
+[options="noheader", width="100%", cols="2, 8a"]
+|===
+
+| Syntax
+|
+[source, syntax, role="noheader"]
+----
+CREATE LOOKUP INDEX [index_name] [IF NOT EXISTS]
+FOR (n)
+ON EACH labels(n)
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+| Description
+|
+Create a node label lookup index.
+
+Index provider can be specified using the `OPTIONS` clause.
+
+|===
+
+
+.+Create a relationship type lookup index+
+[options="noheader", width="100%", cols="2, 8a"]
+|===
+
+| Syntax
+|
+[source, syntax, role="noheader"]
+----
+CREATE LOOKUP INDEX [index_name] [IF NOT EXISTS]
+FOR ()-"["r"]"-()
+ON [EACH] type(r)
+[OPTIONS "{" option: value[, ...] "}"]
+----
+
+| Description
+|
+Create a relationship type lookup index.
+
+Index provider can be specified using the `OPTIONS` clause.
+
+|===
+
+
 .+Drop an index+
 [options="noheader", width="100%", cols="2, 8a"]
 |===
@@ -329,23 +329,17 @@ xref:query-tuning/using.adoc[Planner hints and the USING keyword] describes how 
 Creating an index is done with the `+CREATE ... INDEX ...+` command.
 If no index type is specified in the create command a range index will be created.
 
+Best practice is to give the index a name when it is created.
+If the index is not explicitly named, it gets an auto-generated name.
+
 [IMPORTANT]
 ====
 The index name must be unique among both indexes and constraints.
 ====
 
-[NOTE]
-====
-Best practice is to give the index a name when it is created.
-If the index is not explicitly named, it gets an auto-generated name.
-====
-
-[NOTE]
-====
-The `+CREATE ... INDEX ...+` command is optionally idempotent. This mean that its default behavior is to throw an error if an attempt is made to create the same index twice.
+The `+CREATE INDEX+` command is optionally idempotent. This mean that its default behavior is to throw an error if an attempt is made to create the same index twice.
 With `IF NOT EXISTS`, no error is thrown and nothing happens should an index with the same name or same schema and index type already exist.
 It may still throw an error if conflicting constraints exist, such as constraints with the same name or schema and backing index type.
-====
 
 Creating an index requires xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `CREATE INDEX` privilege].
 
@@ -358,6 +352,7 @@ The new index is not immediately available, but is created in the background.
 === Creating a range index
 
 Creating a range index can be done with the `CREATE INDEX` command.
+Note that the index name must be unique.
 
 Range indexes have only one index provider available, `range-1.0`, and no supported index configuration.
 
@@ -385,11 +380,6 @@ The following statement will create a named range index on all nodes labeled wit
 CREATE INDEX node_range_index_name FOR (n:Person) ON (n.surname)
 ----
 
-[NOTE]
-====
-The index name must be unique.
-====
-
 .Result
 [queryresult]
 ----
@@ -411,11 +401,6 @@ The following statement will create a named range index on all relationships wit
 ----
 CREATE INDEX rel_range_index_name FOR ()-[r:KNOWS]-() ON (r.since)
 ----
-
-[NOTE]
-====
-The index name must be unique.
-====
 
 .Result
 [queryresult]
@@ -450,11 +435,6 @@ The following statement will create a named composite range index on all nodes l
 CREATE INDEX composite_range_node_index_name FOR (n:Person) ON (n.age, n.country)
 ----
 
-[NOTE]
-====
-The index name must be unique.
-====
-
 .Result
 [queryresult]
 ----
@@ -487,11 +467,6 @@ The following statement will create a named composite range index on all relatio
 ----
 CREATE INDEX composite_range_rel_index_name FOR ()-[r:PURCHASED]-() ON (r.date, r.amount)
 ----
-
-[NOTE]
-====
-The index name must be unique.
-====
 
 .Result
 [queryresult]
@@ -532,106 +507,92 @@ The index will not be created if there already exists an index with the same sch
 ======
 
 
-[[indexes-create-token-index]]
-=== Creating a token lookup index
+[[indexes-create-text-index]]
+=== Creating a text index
 
-Creating a token lookup index (node label or relationship type lookup index) can be done with the `CREATE LOOKUP INDEX` command.
+Creating a text index can be done with the `CREATE TEXT INDEX` command.
+Note that the index name must be unique.
 
-Token lookup indexes have only one index provider available, `token-lookup-1.0`, and no supported index configuration.
+Text indexes have two index providers available, `text-2.0` (default) and `text-1.0` (deprecated), and no supported index configuration.
+
+[NOTE]
+====
+Text indexes only recognize string values and do not support multiple properties.
+====
 
 Note that the index is not immediately available, but is created in the background.
 
 *Examples:*
 
-* xref::indexes-for-search-performance.adoc#indexes-create-a-node-label-lookup-index[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-type-lookup-index[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-lookup-index-only-if-it-does-not-already-exist[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-node-text-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-text-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-only-if-it-does-not-already-exist[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-specifying-the-index-provider[]
 
 [discrete]
-[[indexes-create-a-node-label-lookup-index]]
-==== Create a node label lookup index
+[[indexes-create-a-node-text-index]]
+==== Create a node text index
 
-[NOTE]
-====
-Only one node label lookup index can exist at the time.
-====
-
-.+Creating a named node label lookup index for all nodes with one or more labels+
+.+Creating a named text index on a single property for all nodes with a particular label+
 ======
-The following statement will create a named node label lookup index on all nodes with labels:
-
-// Lookup indexes exist by default, recreating them would raise an error
-.Query
-[source, cypher, role=test-skip]
-----
-CREATE LOOKUP INDEX node_label_lookup_index FOR (n) ON EACH labels(n)
-----
-
-[NOTE]
-====
-The index name must be unique.
-====
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
-
-[discrete]
-[[indexes-create-a-relationship-type-lookup-index]]
-==== Create a relationship type lookup index
-
-[NOTE]
-====
-Only one relationship type lookup index can exist at the time.
-====
-
-.+Creating a named relationship type lookup index for all relationships with any relationship type+
-======
-The following statement will create a named relationship type lookup index on all relationships:
-
-// Lookup indexes exist by default, recreating them would raise an error
-.Query
-[source, cypher, role=test-skip]
-----
-CREATE LOOKUP INDEX rel_type_lookup_index FOR ()-[r]-() ON EACH type(r)
-----
-
-[NOTE]
-====
-The index name must be unique.
-====
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
-
-[discrete]
-[[indexes-create-a-lookup-index-only-if-it-does-not-already-exist]]
-==== Create a token lookup index only if it does not already exist
-
-If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
-
-.+Creating a node label index with `IF NOT EXISTS`+
-======
-The following statement will attempt to create a named node label lookup index on all nodes with labels:
+The following statement will create a named text index on all nodes labeled with `Person` and which have the `nickname` property:
 
 .Query
 [source, cypher]
 ----
-CREATE LOOKUP INDEX node_label_lookup IF NOT EXISTS FOR (n) ON EACH labels(n)
+CREATE TEXT INDEX node_index_nickname FOR (n:Person) ON (n.nickname)
+----
+
+.Result
+[queryresult]
+----
+Added 1 index.
+----
+
+======
+
+[discrete]
+[[indexes-create-a-relationship-text-index]]
+==== Create a relationship text index
+
+.+Creating a named text index on a single property for all relationships with a particular relationship type+
+======
+The following statement will create a named text index on all relationships with relationship type `KNOWS` and property `interest`:
+
+.Query
+[source, cypher]
+----
+CREATE TEXT INDEX relprop_index_name FOR ()-[r:KNOWS]-() ON (r.interest)
+----
+
+.Result
+[queryresult]
+----
+Added 1 index.
+----
+
+======
+
+[discrete]
+[[indexes-create-a-text-index-only-if-it-does-not-already-exist]]
+==== Create a text index only if it does not already exist
+
+If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
+
+
+.+Creating a text index with `IF NOT EXISTS`+
+======
+The following statement will attempt to create a named text index on all nodes labeled with `Person` and which have the `nickname` property:
+
+.Query
+[source, cypher]
+----
+CREATE TEXT INDEX node_index_name IF NOT EXISTS FOR (n:Person) ON (n.nickname)
 ----
 
 [NOTE]
 ====
-The index will not be created if there already exists an index with the same schema and type, same name or both.
+Note that the index will not be created if there already exists an index with the same schema and type, same name or both.
 ====
 
 .Result
@@ -642,11 +603,40 @@ The index will not be created if there already exists an index with the same sch
 
 ======
 
+[discrete]
+[[indexes-create-a-text-index-specifying-the-index-provider]]
+==== Create a text index specifying the index provider
+
+To create a text index with a specific index provider, the `OPTIONS` clause is used.
+The valid values for the index provider are `text-2.0` and `text-1.0` (deprecated).
+The default provider is `text-2.0`.
+
+.+Creating a text index with index provider+
+======
+
+.Query
+[source, cypher]
+----
+CREATE TEXT INDEX index_with_indexprovider FOR ()-[r:TYPE]-() ON (r.prop1)
+OPTIONS {indexProvider: 'text-2.0'}
+----
+
+.Result
+[queryresult]
+----
+Added 1 index.
+----
+
+======
+
+There is no supported index configuration for text indexes.
+
 
 [[indexes-create-point-index]]
 === Creating a point index
 
 Creating a point index can be done with the `CREATE POINT INDEX` command.
+Note that the index name must be unique.
 
 Point indexes have only one index provider available, `point-1.0`, but it does have supported index configuration, see the last examples.
 
@@ -679,11 +669,6 @@ The following statement will create a named point index on all nodes labeled wit
 CREATE POINT INDEX node_index_name FOR (n:Person) ON (n.sublocation)
 ----
 
-[NOTE]
-====
-The index name must be unique.
-====
-
 .Result
 [queryresult]
 ----
@@ -705,11 +690,6 @@ The following statement will create a named point index on all relationships wit
 ----
 CREATE POINT INDEX rel_index_name FOR ()-[r:STREET]-() ON (r.intersection)
 ----
-
-[NOTE]
-====
-The index name must be unique.
-====
 
 .Result
 [queryresult]
@@ -797,45 +777,41 @@ Specifying the index configuration can be combined with specifying index provide
 Though only one valid value exists for the index provider, `point-1.0`, which is the default value.
 
 
-[[indexes-create-text-index]]
-=== Creating a text index
+[[indexes-create-token-index]]
+=== Creating a token lookup index
 
-Creating a text index can be done with the `CREATE TEXT INDEX` command.
+Creating a token lookup index (node label or relationship type lookup index) can be done with the `CREATE LOOKUP INDEX` command.
+Note that the index name must be unique.
 
-Text indexes have two index providers available, `text-2.0` (default) and `text-1.0` (deprecated), and no supported index configuration.
-
-[NOTE]
-====
-Text indexes only recognize string values and do not support multiple properties.
-====
+Token lookup indexes have only one index provider available, `token-lookup-1.0`, and no supported index configuration.
 
 Note that the index is not immediately available, but is created in the background.
 
 *Examples:*
 
-* xref::indexes-for-search-performance.adoc#indexes-create-a-node-text-index[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-text-index[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-only-if-it-does-not-already-exist[]
-* xref::indexes-for-search-performance.adoc#indexes-create-a-text-index-specifying-the-index-provider[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-node-label-lookup-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-type-lookup-index[]
+* xref::indexes-for-search-performance.adoc#indexes-create-a-lookup-index-only-if-it-does-not-already-exist[]
 
 [discrete]
-[[indexes-create-a-node-text-index]]
-==== Create a node text index
-
-.+Creating a named text index on a single property for all nodes with a particular label+
-======
-The following statement will create a named text index on all nodes labeled with `Person` and which have the `nickname` property:
-
-.Query
-[source, cypher]
-----
-CREATE TEXT INDEX node_index_nickname FOR (n:Person) ON (n.nickname)
-----
+[[indexes-create-a-node-label-lookup-index]]
+==== Create a node label lookup index
 
 [NOTE]
 ====
-The index name must be unique.
+Only one node label lookup index can exist at the time.
 ====
+
+.+Creating a named node label lookup index for all nodes with one or more labels+
+======
+The following statement will create a named node label lookup index on all nodes with labels:
+
+// Lookup indexes exist by default, recreating them would raise an error
+.Query
+[source, cypher, role=test-skip]
+----
+CREATE LOOKUP INDEX node_label_lookup_index FOR (n) ON EACH labels(n)
+----
 
 .Result
 [queryresult]
@@ -846,23 +822,24 @@ Added 1 index.
 ======
 
 [discrete]
-[[indexes-create-a-relationship-text-index]]
-==== Create a relationship text index
-
-.+Creating a named text index on a single property for all relationships with a particular relationship type+
-======
-The following statement will create a named text index on all relationships with relationship type `KNOWS` and property `interest`:
-
-.Query
-[source, cypher]
-----
-CREATE TEXT INDEX relprop_index_name FOR ()-[r:KNOWS]-() ON (r.interest)
-----
+[[indexes-create-a-relationship-type-lookup-index]]
+==== Create a relationship type lookup index
 
 [NOTE]
 ====
-The index name must be unique.
+Only one relationship type lookup index can exist at the time.
 ====
+
+.+Creating a named relationship type lookup index for all relationships with any relationship type+
+======
+The following statement will create a named relationship type lookup index on all relationships:
+
+// Lookup indexes exist by default, recreating them would raise an error
+.Query
+[source, cypher, role=test-skip]
+----
+CREATE LOOKUP INDEX rel_type_lookup_index FOR ()-[r]-() ON EACH type(r)
+----
 
 .Result
 [queryresult]
@@ -873,25 +850,24 @@ Added 1 index.
 ======
 
 [discrete]
-[[indexes-create-a-text-index-only-if-it-does-not-already-exist]]
-==== Create a text index only if it does not already exist
+[[indexes-create-a-lookup-index-only-if-it-does-not-already-exist]]
+==== Create a token lookup index only if it does not already exist
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
 
-
-.+Creating a text index with `IF NOT EXISTS`+
+.+Creating a node label index with `IF NOT EXISTS`+
 ======
-The following statement will attempt to create a named text index on all nodes labeled with `Person` and which have the `nickname` property:
+The following statement will attempt to create a named node label lookup index on all nodes with labels:
 
 .Query
 [source, cypher]
 ----
-CREATE TEXT INDEX node_index_name IF NOT EXISTS FOR (n:Person) ON (n.nickname)
+CREATE LOOKUP INDEX node_label_lookup IF NOT EXISTS FOR (n) ON EACH labels(n)
 ----
 
 [NOTE]
 ====
-Note that the index will not be created if there already exists an index with the same schema and type, same name or both.
+The index will not be created if there already exists an index with the same schema and type, same name or both.
 ====
 
 .Result
@@ -901,34 +877,6 @@ Note that the index will not be created if there already exists an index with th
 ----
 
 ======
-
-[discrete]
-[[indexes-create-a-text-index-specifying-the-index-provider]]
-==== Create a text index specifying the index provider
-
-To create a text index with a specific index provider, the `OPTIONS` clause is used.
-The valid values for the index provider are `text-2.0` and `text-1.0` (deprecated).
-The default provider is `text-2.0`.
-
-.+Creating a text index with index provider+
-======
-
-.Query
-[source, cypher]
-----
-CREATE TEXT INDEX index_with_indexprovider FOR ()-[r:TYPE]-() ON (r.prop1)
-OPTIONS {indexProvider: 'text-2.0'}
-----
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
-
-There is no supported index configuration for text indexes.
 
 
 [[indexes-create-conflicting-index]]
@@ -1268,12 +1216,9 @@ An index can be dropped (removed) using the name with the `DROP INDEX index_name
 This command can drop indexes of any type, except those backing constraints.
 The name of the index can be found using the xref::indexes-for-search-performance.adoc#indexes-list-indexes[`SHOW INDEXES` command], given in the output column `name`.
 
-[NOTE]
-====
 The `DROP INDEX` command is optionally idempotent.
 This means that its default behavior is to throw an error if an attempt is made to drop the same index twice.
 With `IF EXISTS`, no error is thrown and nothing happens should the index not exist.
-====
 
 Dropping an index requires xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `DROP INDEX` privilege].
 

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -383,7 +383,8 @@ More details about the syntax descriptions can be found xref:administration/inde
 
 Range indexes have only one index provider available, `range-1.0`, and no supported index configuration.
 
-*Examples:*
+[discrete]
+==== Examples
 
 * xref::indexes-for-search-performance.adoc#indexes-create-a-single-property-range-index-for-nodes[]
 * xref::indexes-for-search-performance.adoc#indexes-create-a-single-property-range-index-for-relationships[]
@@ -393,7 +394,7 @@ Range indexes have only one index provider available, `range-1.0`, and no suppor
 
 [discrete]
 [[indexes-create-a-single-property-range-index-for-nodes]]
-==== Create a single-property range index for nodes
+===== Create a single-property range index for nodes
 
 .+Creating a named range index on a single property for all nodes with a particular label+
 ======
@@ -415,7 +416,7 @@ Added 1 index.
 
 [discrete]
 [[indexes-create-a-single-property-range-index-for-relationships]]
-==== Create a single-property range index for relationships
+===== Create a single-property range index for relationships
 
 .+Creating a named range index on a single property for all relationships with a particular relationship type+
 ======
@@ -437,7 +438,7 @@ Added 1 index.
 
 [discrete]
 [[indexes-create-a-composite-range-index-for-nodes]]
-==== Create a composite range index for nodes
+===== Create a composite range index for nodes
 
 A named range index on multiple properties for all nodes with a particular label -- i.e. a composite index -- can be created with:
 
@@ -470,7 +471,7 @@ Added 1 index.
 
 [discrete]
 [[indexes-create-a-composite-range-index-for-relationships]]
-==== Create a composite range index for relationships
+===== Create a composite range index for relationships
 
 A named range index on multiple properties for all relationships with a particular relationship type -- i.e. a composite index -- can be created with:
 
@@ -503,7 +504,7 @@ Added 1 index.
 
 [discrete]
 [[indexes-create-a-range-index-only-if-it-does-not-already-exist]]
-==== Create a range index only if it does not already exist
+===== Create a range index only if it does not already exist
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
 
@@ -562,7 +563,8 @@ Text indexes have two index providers available, `text-2.0` (default) and `text-
 Text indexes only recognize string values and do not support multiple properties.
 ====
 
-*Examples:*
+[discrete]
+==== Examples
 
 * xref::indexes-for-search-performance.adoc#indexes-create-a-node-text-index[]
 * xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-text-index[]
@@ -571,7 +573,7 @@ Text indexes only recognize string values and do not support multiple properties
 
 [discrete]
 [[indexes-create-a-node-text-index]]
-==== Create a node text index
+===== Create a node text index
 
 .+Creating a named text index on a single property for all nodes with a particular label+
 ======
@@ -593,7 +595,7 @@ Added 1 index.
 
 [discrete]
 [[indexes-create-a-relationship-text-index]]
-==== Create a relationship text index
+===== Create a relationship text index
 
 .+Creating a named text index on a single property for all relationships with a particular relationship type+
 ======
@@ -645,7 +647,7 @@ Note that the index will not be created if there already exists an index with th
 
 [discrete]
 [[indexes-create-a-text-index-specifying-the-index-provider]]
-==== Create a text index specifying the index provider
+===== Create a text index specifying the index provider
 
 To create a text index with a specific index provider, the `OPTIONS` clause is used.
 The valid values for the index provider are `text-2.0` and `text-1.0` (deprecated).
@@ -702,7 +704,8 @@ Point indexes have supported index configuration, see the last examples, but onl
 Note that point indexes only recognize point values and do not support multiple properties.
 ====
 
-*Examples:*
+[discrete]
+==== Examples
 
 * xref::indexes-for-search-performance.adoc#indexes-create-a-node-point-index[]
 * xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-point-index[]
@@ -712,7 +715,7 @@ Note that point indexes only recognize point values and do not support multiple 
 
 [discrete]
 [[indexes-create-a-node-point-index]]
-==== Create a node point index
+===== Create a node point index
 
 .+Creating a named point index on a single property for all nodes with a particular label+
 ======
@@ -734,7 +737,7 @@ Added 1 index.
 
 [discrete]
 [[indexes-create-a-relationship-point-index]]
-==== Create a relationship point index
+===== Create a relationship point index
 
 .+Creating a named point index on a single property for all relationships with a particular relationship type+
 ======
@@ -756,7 +759,7 @@ Added 1 index.
 
 [discrete]
 [[indexes-create-a-point-index-only-if-it-does-not-already-exist]]
-==== Create a point index only if it does not already exist
+===== Create a point index only if it does not already exist
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
 
@@ -786,7 +789,7 @@ Note that the index will not be created if there already exists an index with th
 
 [discrete]
 [[indexes-create-a-point-index-specifying-the-index-configuration]]
-==== Create a point index specifying the index configuration
+===== Create a point index specifying the index configuration
 
 To create a point index with a specific index configuration, the `OPTIONS` clause is used.
 
@@ -855,7 +858,8 @@ More details about the syntax descriptions can be found xref:administration/inde
 
 Token lookup indexes have only one index provider available, `token-lookup-1.0`, and no supported index configuration.
 
-*Examples:*
+[discrete]
+==== Examples
 
 * xref::indexes-for-search-performance.adoc#indexes-create-a-node-label-lookup-index[]
 * xref::indexes-for-search-performance.adoc#indexes-create-a-relationship-type-lookup-index[]
@@ -863,7 +867,7 @@ Token lookup indexes have only one index provider available, `token-lookup-1.0`,
 
 [discrete]
 [[indexes-create-a-node-label-lookup-index]]
-==== Create a node label lookup index
+===== Create a node label lookup index
 
 [NOTE]
 ====
@@ -891,7 +895,7 @@ Added 1 index.
 
 [discrete]
 [[indexes-create-a-relationship-type-lookup-index]]
-==== Create a relationship type lookup index
+===== Create a relationship type lookup index
 
 [NOTE]
 ====
@@ -919,7 +923,7 @@ Added 1 index.
 
 [discrete]
 [[indexes-create-a-lookup-index-only-if-it-does-not-already-exist]]
-==== Create a token lookup index only if it does not already exist
+===== Create a token lookup index only if it does not already exist
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
 
@@ -949,8 +953,6 @@ The index will not be created if there already exists an index with the same sch
 
 [[indexes-create-conflicting-index]]
 === Creating an index when a conflicting index or constraint exists
-
-*Examples:*
 
 * xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-already-existing-index[]
 * xref::indexes-for-search-performance.adoc#indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-index[]
@@ -1178,7 +1180,8 @@ Listing indexes also allows for `WHERE` and `YIELD` clauses to filter the return
 
 Listing indexes require xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `SHOW INDEX` privilege].
 
-*Examples:*
+[discrete]
+=== Examples
 
 * xref::indexes-for-search-performance.adoc#indexes-listing-all-indexes[]
 * xref::indexes-for-search-performance.adoc#indexes-listing-indexes-with-filtering[]
@@ -1186,7 +1189,7 @@ Listing indexes require xref::administration/access-control/database-administrat
 
 [discrete]
 [[indexes-listing-all-indexes]]
-=== Listing all indexes
+==== Listing all indexes
 
 To list all indexes with the default output columns, the `SHOW INDEXES` command can be used.
 If all columns are required, use `SHOW INDEXES YIELD *`.
@@ -1241,7 +1244,7 @@ This can be used to drop the index with the xref::indexes-for-search-performance
 
 [discrete]
 [[indexes-listing-indexes-with-filtering]]
-=== Listing indexes with filtering
+==== Listing indexes with filtering
 
 One way of filtering the output from `SHOW INDEXES` by index type is the use of type keywords, listed in the syntax description.
 
@@ -1309,7 +1312,8 @@ With `IF EXISTS`, no error is thrown and nothing happens should the index not ex
 
 Dropping an index requires xref::administration/access-control/database-administration.adoc#access-control-database-administration-index[the `DROP INDEX` privilege].
 
-*Examples:*
+[discrete]
+=== Examples
 
 * xref::indexes-for-search-performance.adoc#indexes-drop-an-index[]
 * xref::indexes-for-search-performance.adoc#indexes-drop-a-non-existing-index[]
@@ -1317,7 +1321,7 @@ Dropping an index requires xref::administration/access-control/database-administ
 
 [discrete]
 [[indexes-drop-an-index]]
-=== Drop an index
+==== Drop an index
 
 
 .+Dropping an index+
@@ -1340,7 +1344,7 @@ Removed 1 index.
 
 [discrete]
 [[indexes-drop-a-non-existing-index]]
-=== Drop a non-existing index
+==== Drop a non-existing index
 
 If it is uncertain if an index exists and you want to drop it if it does but not get an error should it not, use `IF EXISTS`.
 

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -146,14 +146,8 @@ CREATE INDEX rel_range_index_name FOR ()-[r:KNOWS]-() ON (r.since)
 [[indexes-create-a-composite-range-index-for-nodes]]
 ===== Create a composite range index for nodes
 
-A named range index on multiple properties for all nodes with a particular label -- i.e. a composite index -- can be created with:
-
-[source, syntax, role="noheader"]
-----
-CREATE INDEX index_name FOR (n:Label) ON (n.prop1, ..., n.propN)
-----
-
-Only nodes with the specified label and that contain all the properties in the index definition will be added to the index.
+A range index on multiple properties is also called a composite index.
+For node range indexes, only nodes with the specified label and that contain all the specified properties will be added to the index.
 
 The following statement will create a named composite range index on all nodes labeled with `Person` and which have both an `age` and `country` property.
 
@@ -167,14 +161,8 @@ CREATE INDEX composite_range_node_index_name FOR (n:Person) ON (n.age, n.country
 [[indexes-create-a-composite-range-index-for-relationships]]
 ===== Create a composite range index for relationships
 
-A named range index on multiple properties for all relationships with a particular relationship type -- i.e. a composite index -- can be created with:
-
-[source, syntax, role="noheader"]
-----
-CREATE INDEX index_name FOR ()-[r:TYPE]-() ON (r.prop1, ..., r.propN)
-----
-
-Only relationships with the specified type and that contain all the properties in the index definition will be added to the index.
+A range index on multiple properties is also called a composite index.
+For relationship range indexes, only relationships with the specified type and that contain all the specified properties will be added to the index.
 
 The following statement will create a named composite range index on all relationships labeled with `PURCHASED` and which have both a `date` and `amount` property.
 
@@ -264,7 +252,7 @@ CREATE TEXT INDEX rel_text_index_name FOR ()-[r:KNOWS]-() ON (r.interest)
 
 [discrete]
 [[indexes-create-a-text-index-only-if-it-does-not-already-exist]]
-==== Create a text index only if it does not already exist
+===== Create a text index only if it does not already exist
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
 
@@ -445,11 +433,6 @@ Token lookup indexes have only one index provider available, `token-lookup-1.0`,
 [[indexes-create-a-node-label-lookup-index]]
 ===== Create a node label lookup index
 
-[NOTE]
-====
-Only one node label lookup index can exist at the time.
-====
-
 The following statement will create a named node label lookup index on all nodes with one or more labels:
 
 // Lookup indexes exist by default, recreating them would raise an error
@@ -459,14 +442,14 @@ The following statement will create a named node label lookup index on all nodes
 CREATE LOOKUP INDEX node_label_lookup_index FOR (n) ON EACH labels(n)
 ----
 
+[NOTE]
+====
+Only one node label lookup index can exist at a time.
+====
+
 [discrete]
 [[indexes-create-a-relationship-type-lookup-index]]
 ===== Create a relationship type lookup index
-
-[NOTE]
-====
-Only one relationship type lookup index can exist at the time.
-====
 
 The following statement will create a named relationship type lookup index on all relationships with any relationship type.
 
@@ -476,6 +459,11 @@ The following statement will create a named relationship type lookup index on al
 ----
 CREATE LOOKUP INDEX rel_type_lookup_index FOR ()-[r]-() ON EACH type(r)
 ----
+
+[NOTE]
+====
+Only one relationship type lookup index can exist at a time.
+====
 
 [discrete]
 [[indexes-create-a-lookup-index-only-if-it-does-not-already-exist]]

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -582,7 +582,7 @@ The following statement will create a named text index on all nodes labeled with
 .Query
 [source, cypher]
 ----
-CREATE TEXT INDEX node_index_nickname FOR (n:Person) ON (n.nickname)
+CREATE TEXT INDEX node_text_index_nickname FOR (n:Person) ON (n.nickname)
 ----
 
 .Result
@@ -604,7 +604,7 @@ The following statement will create a named text index on all relationships with
 .Query
 [source, cypher]
 ----
-CREATE TEXT INDEX relprop_index_name FOR ()-[r:KNOWS]-() ON (r.interest)
+CREATE TEXT INDEX rel_text_index_name FOR ()-[r:KNOWS]-() ON (r.interest)
 ----
 
 .Result
@@ -659,7 +659,7 @@ The default provider is `text-2.0`.
 .Query
 [source, cypher]
 ----
-CREATE TEXT INDEX index_with_indexprovider FOR ()-[r:TYPE]-() ON (r.prop1)
+CREATE TEXT INDEX text_index_with_indexprovider FOR ()-[r:TYPE]-() ON (r.prop1)
 OPTIONS {indexProvider: 'text-2.0'}
 ----
 
@@ -724,7 +724,7 @@ The following statement will create a named point index on all nodes labeled wit
 .Query
 [source, cypher]
 ----
-CREATE POINT INDEX node_index_name FOR (n:Person) ON (n.sublocation)
+CREATE POINT INDEX node_point_index_name FOR (n:Person) ON (n.sublocation)
 ----
 
 .Result
@@ -746,7 +746,7 @@ The following statement will create a named point index on all relationships wit
 .Query
 [source, cypher]
 ----
-CREATE POINT INDEX rel_index_name FOR ()-[r:STREET]-() ON (r.intersection)
+CREATE POINT INDEX rel_point_index_name FOR ()-[r:STREET]-() ON (r.intersection)
 ----
 
 .Result
@@ -770,7 +770,7 @@ If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure
 .Query
 [source, cypher]
 ----
-CREATE POINT INDEX node_index_name IF NOT EXISTS
+CREATE POINT INDEX node_point_index IF NOT EXISTS
 FOR (n:Person) ON (n.sublocation)
 ----
 
@@ -813,7 +813,7 @@ Non-specified settings have their respective default values.
 .Query
 [source, cypher]
 ----
-CREATE POINT INDEX index_with_config
+CREATE POINT INDEX point_index_with_config
 FOR (n:Label) ON (n.prop2)
 OPTIONS {
   indexConfig: {
@@ -1038,7 +1038,7 @@ This is only relevant for range indexes.
 ////
 [source, cypher, role=test-setup]
 ----
-CREATE CONSTRAINT FOR (book:Book) REQUIRE (book.isbn) IS UNIQUE
+CREATE CONSTRAINT uniqueBookIsbn FOR (book:Book) REQUIRE (book.isbn) IS UNIQUE
 ----
 ////
 
@@ -1214,29 +1214,26 @@ This can be used to drop the index with the xref::indexes-for-search-performance
 .Result
 [queryresult]
 ----
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| id | name                              | state    | populationPercent | type     | entityType     | labelsOrTypes | properties         | indexProvider      | owningConstraint      |
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| 20 | "composite_range_node_index_name" | "ONLINE" | 100.0             | "RANGE"  | "NODE"         | ["Person"]    | ["age", "country"] | "range-1.0"        | NULL                  |
-| 2  | "composite_range_rel_index_name"  | "ONLINE" | 100.0             | "RANGE"  | "RELATIONSHIP" | ["PURCHASED"] | ["date", "amount"] | "range-1.0"        | NULL                  |
-| 14 | "constraint_1bc95fcb"             | "ONLINE" | 100.0             | "RANGE"  | "NODE"         | ["Book"]      | ["isbn"]           | "range-1.0"        | "constraint_1bc95fcb" |
-| 4  | "example_index"                   | "ONLINE" | 100.0             | "RANGE"  | "NODE"         | ["Book"]      | ["title"]          | "range-1.0"        | NULL                  |
-| 7  | "indexOnBooks"                    | "ONLINE" | 100.0             | "RANGE"  | "NODE"         | ["Label1"]    | ["prop1"]          | "range-1.0"        | NULL                  |
-| 10 | "index_with_config"               | "ONLINE" | 100.0             | "POINT"  | "NODE"         | ["Label"]     | ["prop2"]          | "point-1.0"        | NULL                  |
-| 6  | "index_with_indexprovider"        | "ONLINE" | 100.0             | "TEXT"   | "RELATIONSHIP" | ["TYPE"]      | ["prop1"]          | "text-2.0"         | NULL                  |
-| 9  | "index_with_options"              | "ONLINE" | 100.0             | "POINT"  | "RELATIONSHIP" | ["TYPE"]      | ["prop1"]          | "point-1.0"        | NULL                  |
-| 8  | "index_with_provider"             | "ONLINE" | 100.0             | "POINT"  | "NODE"         | ["Label"]     | ["prop1"]          | "point-1.0"        | NULL                  |
-| 15 | "node_index_name"                 | "ONLINE" | 100.0             | "POINT"  | "NODE"         | ["Person"]    | ["sublocation"]    | "point-1.0"        | NULL                  |
-| 3  | "node_index_nickname"             | "ONLINE" | 100.0             | "TEXT"   | "NODE"         | ["Person"]    | ["nickname"]       | "text-2.0"         | NULL                  |
-| 11 | "node_label_lookup_index_2"       | "ONLINE" | 100.0             | "LOOKUP" | "NODE"         | NULL          | NULL               | "token-lookup-1.0" | NULL                  |
-| 16 | "node_range_index_name"           | "ONLINE" | 100.0             | "RANGE"  | "NODE"         | ["Person"]    | ["surname"]        | "range-1.0"        | NULL                  |
-| 19 | "range_index_with_provider"       | "ONLINE" | 100.0             | "RANGE"  | "RELATIONSHIP" | ["TYPE"]      | ["prop1"]          | "range-1.0"        | NULL                  |
-| 13 | "rel_index_name"                  | "ONLINE" | 100.0             | "POINT"  | "RELATIONSHIP" | ["STREET"]    | ["intersection"]   | "point-1.0"        | NULL                  |
-| 18 | "rel_range_index_name"            | "ONLINE" | 100.0             | "RANGE"  | "RELATIONSHIP" | ["KNOWS"]     | ["since"]          | "range-1.0"        | NULL                  |
-| 17 | "rel_type_lookup_index"           | "ONLINE" | 100.0             | "LOOKUP" | "RELATIONSHIP" | NULL          | NULL               | "token-lookup-1.0" | NULL                  |
-| 1  | "relprop_index_name"              | "ONLINE" | 100.0             | "TEXT"   | "RELATIONSHIP" | ["KNOWS"]     | ["interest"]       | "text-2.0"         | NULL                  |
-+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-18 rows
++--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| id | name                              | state    | populationPercent | type     | entityType     | labelsOrTypes | properties         | indexProvider      | owningConstraint |
++--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 3  | "composite_range_node_index_name" | "ONLINE" | 100.0             | "RANGE"  | "NODE"         | ["Person"]    | ["age", "country"] | "range-1.0"        | NULL             |
+| 4  | "composite_range_rel_index_name"  | "ONLINE" | 100.0             | "RANGE"  | "RELATIONSHIP" | ["PURCHASED"] | ["date", "amount"] | "range-1.0"        | NULL             |
+| 13 | "example_index"                   | "ONLINE" | 100.0             | "RANGE"  | "NODE"         | ["Book"]      | ["title"]          | "range-1.0"        | NULL             |
+| 14 | "indexOnBooks"                    | "ONLINE" | 100.0             | "TEXT"   | "NODE"         | ["Label1"]    | ["prop1"]          | "text-2.0"         | NULL             |
+| 11 | "node_label_lookup_index"         | "ONLINE" | 100.0             | "LOOKUP" | "NODE"         | NULL          | NULL               | "token-lookup-1.0" | NULL             |
+| 8  | "node_point_index_name"           | "ONLINE" | 100.0             | "POINT"  | "NODE"         | ["Person"]    | ["sublocation"]    | "point-1.0"        | NULL             |
+| 1  | "node_range_index_name"           | "ONLINE" | 100.0             | "RANGE"  | "NODE"         | ["Person"]    | ["surname"]        | "range-1.0"        | NULL             |
+| 5  | "node_text_index_nickname"        | "ONLINE" | 100.0             | "TEXT"   | "NODE"         | ["Person"]    | ["nickname"]       | "text-2.0"         | NULL             |
+| 10 | "point_index_with_config"         | "ONLINE" | 100.0             | "POINT"  | "NODE"         | ["Label"]     | ["prop2"]          | "point-1.0"        | NULL             |
+| 9  | "rel_point_index_name"            | "ONLINE" | 100.0             | "POINT"  | "RELATIONSHIP" | ["STREET"]    | ["intersection"]   | "point-1.0"        | NULL             |
+| 2  | "rel_range_index_name"            | "ONLINE" | 100.0             | "RANGE"  | "RELATIONSHIP" | ["KNOWS"]     | ["since"]          | "range-1.0"        | NULL             |
+| 6  | "rel_text_index_name"             | "ONLINE" | 100.0             | "TEXT"   | "RELATIONSHIP" | ["KNOWS"]     | ["interest"]       | "text-2.0"         | NULL             |
+| 12 | "rel_type_lookup_index"           | "ONLINE" | 100.0             | "LOOKUP" | "RELATIONSHIP" | NULL          | NULL               | "token-lookup-1.0" | NULL             |
+| 7  | "text_index_with_indexprovider"   | "ONLINE" | 100.0             | "TEXT"   | "RELATIONSHIP" | ["TYPE"]      | ["prop1"]          | "text-2.0"         | NULL             |
+| 15 | "uniqueBookIsbn"                  | "ONLINE" | 100.0             | "RANGE"  | "NODE"         | ["Book"]      | ["isbn"]           | "range-1.0"        | "uniqueBookIsbn" |
++--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+15 rows
 ----
 
 ======
@@ -1278,15 +1275,13 @@ SHOW INDEXES YIELD * WHERE ...
 +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | id | name                              | state    | populationPercent | type    | entityType     | labelsOrTypes | properties         | indexProvider | owningConstraint |
 +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| 20 | "composite_range_node_index_name" | "ONLINE" | 100.0             | "RANGE" | "NODE"         | ["Person"]    | ["age", "country"] | "range-1.0"   | NULL             |
-| 2  | "composite_range_rel_index_name"  | "ONLINE" | 100.0             | "RANGE" | "RELATIONSHIP" | ["PURCHASED"] | ["date", "amount"] | "range-1.0"   | NULL             |
-| 4  | "example_index"                   | "ONLINE" | 100.0             | "RANGE" | "NODE"         | ["Book"]      | ["title"]          | "range-1.0"   | NULL             |
-| 7  | "indexOnBooks"                    | "ONLINE" | 100.0             | "RANGE" | "NODE"         | ["Label1"]    | ["prop1"]          | "range-1.0"   | NULL             |
-| 16 | "node_range_index_name"           | "ONLINE" | 100.0             | "RANGE" | "NODE"         | ["Person"]    | ["surname"]        | "range-1.0"   | NULL             |
-| 19 | "range_index_with_provider"       | "ONLINE" | 100.0             | "RANGE" | "RELATIONSHIP" | ["TYPE"]      | ["prop1"]          | "range-1.0"   | NULL             |
-| 18 | "rel_range_index_name"            | "ONLINE" | 100.0             | "RANGE" | "RELATIONSHIP" | ["KNOWS"]     | ["since"]          | "range-1.0"   | NULL             |
+| 3  | "composite_range_node_index_name" | "ONLINE" | 100.0             | "RANGE" | "NODE"         | ["Person"]    | ["age", "country"] | "range-1.0"   | NULL             |
+| 4  | "composite_range_rel_index_name"  | "ONLINE" | 100.0             | "RANGE" | "RELATIONSHIP" | ["PURCHASED"] | ["date", "amount"] | "range-1.0"   | NULL             |
+| 13 | "example_index"                   | "ONLINE" | 100.0             | "RANGE" | "NODE"         | ["Book"]      | ["title"]          | "range-1.0"   | NULL             |
+| 1  | "node_range_index_name"           | "ONLINE" | 100.0             | "RANGE" | "NODE"         | ["Person"]    | ["surname"]        | "range-1.0"   | NULL             |
+| 2  | "rel_range_index_name"            | "ONLINE" | 100.0             | "RANGE" | "RELATIONSHIP" | ["KNOWS"]     | ["since"]          | "range-1.0"   | NULL             |
 +--------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-7 rows
+5 rows
 ----
 
 ======

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -396,45 +396,25 @@ Range indexes have only one index provider available, `range-1.0`, and no suppor
 [[indexes-create-a-single-property-range-index-for-nodes]]
 ===== Create a single-property range index for nodes
 
-.+Creating a named range index on a single property for all nodes with a particular label+
-======
-The following statement will create a named range index on all nodes labeled with `Person` and which have the `surname` property:
+The following statement will create a named range index on all nodes labeled with `Person` and which have the `surname` property.
 
-.Query
+.Creating a node range index on a single property
 [source, cypher]
 ----
 CREATE INDEX node_range_index_name FOR (n:Person) ON (n.surname)
 ----
 
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
-
 [discrete]
 [[indexes-create-a-single-property-range-index-for-relationships]]
 ===== Create a single-property range index for relationships
 
-.+Creating a named range index on a single property for all relationships with a particular relationship type+
-======
-The following statement will create a named range index on all relationships with relationship type `KNOWS` and property `since`:
+The following statement will create a named range index on all relationships with relationship type `KNOWS` and property `since`.
 
-.Query
+.Creating a relationship range index on a single property
 [source, cypher]
 ----
 CREATE INDEX rel_range_index_name FOR ()-[r:KNOWS]-() ON (r.since)
 ----
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
 
 [discrete]
 [[indexes-create-a-composite-range-index-for-nodes]]
@@ -449,25 +429,13 @@ CREATE INDEX index_name FOR (n:Label) ON (n.prop1, ..., n.propN)
 
 Only nodes with the specified label and that contain all the properties in the index definition will be added to the index.
 
+The following statement will create a named composite range index on all nodes labeled with `Person` and which have both an `age` and `country` property.
 
-.+Creating a named range index on multiple properties for all nodes with a particular label+
-======
-
-The following statement will create a named composite range index on all nodes labeled with `Person` and which have both an `age` and `country` property:
-
-.Query
+.Creating a composite node range index on multiple properties
 [source, cypher]
 ----
 CREATE INDEX composite_range_node_index_name FOR (n:Person) ON (n.age, n.country)
 ----
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
 
 [discrete]
 [[indexes-create-a-composite-range-index-for-relationships]]
@@ -482,25 +450,13 @@ CREATE INDEX index_name FOR ()-[r:TYPE]-() ON (r.prop1, ..., r.propN)
 
 Only relationships with the specified type and that contain all the properties in the index definition will be added to the index.
 
+The following statement will create a named composite range index on all relationships labeled with `PURCHASED` and which have both a `date` and `amount` property.
 
-.+Creating a named range index on multiple properties for all relationships with a particular relationship type+
-======
-
-The following statement will create a named composite range index on all relationships labeled with `PURCHASED` and which have both a `date` and `amount` property:
-
-.Query
+.Creating a composite relationship range index on multiple properties
 [source, cypher]
 ----
 CREATE INDEX composite_range_rel_index_name FOR ()-[r:PURCHASED]-() ON (r.date, r.amount)
 ----
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
 
 [discrete]
 [[indexes-create-a-range-index-only-if-it-does-not-already-exist]]
@@ -508,29 +464,14 @@ Added 1 index.
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
 
-.+Creating a range index with `IF NOT EXISTS`+
-======
-The following statement will attempt to create a named range index on all nodes labeled with `Person` and which have the `surname` property:
-
-.Query
+.Creating a range index with `IF NOT EXISTS`
 [source, cypher]
 ----
 CREATE INDEX node_range_index_name IF NOT EXISTS
 FOR (n:Person) ON (n.surname)
 ----
 
-[NOTE]
-====
 The index will not be created if there already exists an index with the same schema and type, same name or both.
-====
-
-.Result
-[queryresult]
-----
-(no changes, no records)
-----
-
-======
 
 
 [[indexes-create-text-index]]
@@ -575,45 +516,25 @@ Text indexes only recognize string values and do not support multiple properties
 [[indexes-create-a-node-text-index]]
 ===== Create a node text index
 
-.+Creating a named text index on a single property for all nodes with a particular label+
-======
-The following statement will create a named text index on all nodes labeled with `Person` and which have the `nickname` property:
+The following statement will create a named text index on all nodes labeled with `Person` and which have the `nickname` string property.
 
-.Query
+.Creating a node text index on a single property
 [source, cypher]
 ----
 CREATE TEXT INDEX node_text_index_nickname FOR (n:Person) ON (n.nickname)
 ----
 
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
-
 [discrete]
 [[indexes-create-a-relationship-text-index]]
 ===== Create a relationship text index
 
-.+Creating a named text index on a single property for all relationships with a particular relationship type+
-======
-The following statement will create a named text index on all relationships with relationship type `KNOWS` and property `interest`:
+The following statement will create a named text index on all relationships with relationship type `KNOWS` and string property `interest`.
 
-.Query
+.Creating a relationship text index on a single property
 [source, cypher]
 ----
 CREATE TEXT INDEX rel_text_index_name FOR ()-[r:KNOWS]-() ON (r.interest)
 ----
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
 
 [discrete]
 [[indexes-create-a-text-index-only-if-it-does-not-already-exist]]
@@ -621,29 +542,15 @@ Added 1 index.
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
 
+The following statement will attempt to create a named text index on all nodes labeled with `Person` and which have the `nickname` string property.
 
-.+Creating a text index with `IF NOT EXISTS`+
-======
-The following statement will attempt to create a named text index on all nodes labeled with `Person` and which have the `nickname` property:
-
-.Query
+.Creating a text index with `IF NOT EXISTS`
 [source, cypher]
 ----
 CREATE TEXT INDEX node_index_name IF NOT EXISTS FOR (n:Person) ON (n.nickname)
 ----
 
-[NOTE]
-====
 Note that the index will not be created if there already exists an index with the same schema and type, same name or both.
-====
-
-.Result
-[queryresult]
-----
-(no changes, no records)
-----
-
-======
 
 [discrete]
 [[indexes-create-a-text-index-specifying-the-index-provider]]
@@ -653,23 +560,12 @@ To create a text index with a specific index provider, the `OPTIONS` clause is u
 The valid values for the index provider are `text-2.0` and `text-1.0` (deprecated).
 The default provider is `text-2.0`.
 
-.+Creating a text index with index provider+
-======
-
-.Query
+.Creating a text index with index provider
 [source, cypher]
 ----
 CREATE TEXT INDEX text_index_with_indexprovider FOR ()-[r:TYPE]-() ON (r.prop1)
 OPTIONS {indexProvider: 'text-2.0'}
 ----
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
 
 There is no supported index configuration for text indexes.
 
@@ -716,45 +612,25 @@ Note that point indexes only recognize point values and do not support multiple 
 [[indexes-create-a-node-point-index]]
 ===== Create a node point index
 
-.+Creating a named point index on a single property for all nodes with a particular label+
-======
-The following statement will create a named point index on all nodes labeled with `Person` and which have the `sublocation` property:
+The following statement will create a named point index on all nodes labeled with `Person` and which have the `sublocation` point property.
 
-.Query
+.Creating a node point index on a single property
 [source, cypher]
 ----
 CREATE POINT INDEX node_point_index_name FOR (n:Person) ON (n.sublocation)
 ----
 
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
-
 [discrete]
 [[indexes-create-a-relationship-point-index]]
 ===== Create a relationship point index
 
-.+Creating a named point index on a single property for all relationships with a particular relationship type+
-======
-The following statement will create a named point index on all relationships with relationship type `STREET` and property `intersection`:
+The following statement will create a named point index on all relationships with relationship type `STREET` and point property `intersection`.
 
-.Query
+.Creating a relationship point index on a single property
 [source, cypher]
 ----
 CREATE POINT INDEX rel_point_index_name FOR ()-[r:STREET]-() ON (r.intersection)
 ----
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
 
 [discrete]
 [[indexes-create-a-point-index-only-if-it-does-not-already-exist]]
@@ -762,29 +638,14 @@ Added 1 index.
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
 
-
-.+Creating a point index with `IF NOT EXISTS`+
-======
-
-.Query
+.Creating a point index with `IF NOT EXISTS`
 [source, cypher]
 ----
 CREATE POINT INDEX node_point_index IF NOT EXISTS
 FOR (n:Person) ON (n.sublocation)
 ----
 
-[NOTE]
-====
 Note that the index will not be created if there already exists an index with the same schema and type, same name or both.
-====
-
-.Result
-[queryresult]
-----
-(no changes, no records)
-----
-
-======
 
 [discrete]
 [[indexes-create-a-point-index-specifying-the-index-configuration]]
@@ -805,11 +666,9 @@ The valid configuration settings are:
 
 Non-specified settings have their respective default values.
 
+The following statement will create a point index specifying the `spatial.cartesian.min` and `spatial.cartesian.max` settings.
 
-.+Creating a point index with index configuration+
-======
-
-.Query
+.Creating a point index with index configuration
 [source, cypher]
 ----
 CREATE POINT INDEX point_index_with_config
@@ -821,14 +680,6 @@ OPTIONS {
   }
 }
 ----
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
 
 Specifying the index configuration can be combined with specifying index provider.
 Though only one valid value exists for the index provider, `point-1.0`, which is the default value.
@@ -873,24 +724,14 @@ Token lookup indexes have only one index provider available, `token-lookup-1.0`,
 Only one node label lookup index can exist at the time.
 ====
 
-.+Creating a named node label lookup index for all nodes with one or more labels+
-======
-The following statement will create a named node label lookup index on all nodes with labels:
+The following statement will create a named node label lookup index on all nodes with one or more labels:
 
 // Lookup indexes exist by default, recreating them would raise an error
-.Query
+.Creating a node label lookup index
 [source, cypher, role=test-skip]
 ----
 CREATE LOOKUP INDEX node_label_lookup_index FOR (n) ON EACH labels(n)
 ----
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
 
 [discrete]
 [[indexes-create-a-relationship-type-lookup-index]]
@@ -901,24 +742,14 @@ Added 1 index.
 Only one relationship type lookup index can exist at the time.
 ====
 
-.+Creating a named relationship type lookup index for all relationships with any relationship type+
-======
-The following statement will create a named relationship type lookup index on all relationships:
+The following statement will create a named relationship type lookup index on all relationships with any relationship type.
 
 // Lookup indexes exist by default, recreating them would raise an error
-.Query
+.Creating a relationship type lookup index
 [source, cypher, role=test-skip]
 ----
 CREATE LOOKUP INDEX rel_type_lookup_index FOR ()-[r]-() ON EACH type(r)
 ----
-
-.Result
-[queryresult]
-----
-Added 1 index.
-----
-
-======
 
 [discrete]
 [[indexes-create-a-lookup-index-only-if-it-does-not-already-exist]]
@@ -926,28 +757,13 @@ Added 1 index.
 
 If it is not known whether an index exists or not, add `IF NOT EXISTS` to ensure it does.
 
-.+Creating a node label index with `IF NOT EXISTS`+
-======
-The following statement will attempt to create a named node label lookup index on all nodes with labels:
-
-.Query
+.Creating a node label lookup index with `IF NOT EXISTS`
 [source, cypher]
 ----
 CREATE LOOKUP INDEX node_label_lookup IF NOT EXISTS FOR (n) ON EACH labels(n)
 ----
 
-[NOTE]
-====
 The index will not be created if there already exists an index with the same schema and type, same name or both.
-====
-
-.Result
-[queryresult]
-----
-(no changes, no records)
-----
-
-======
 
 
 [[indexes-create-conflicting-index]]
@@ -964,9 +780,6 @@ The index will not be created if there already exists an index with the same sch
 
 Create an index on the property `title` on nodes with the `Book` label, when that index already exists.
 
-.+Creating a duplicated index+
-======
-
 ////
 [source, cypher, role=test-setup]
 ----
@@ -974,7 +787,7 @@ CREATE INDEX example_index FOR (n:Book) ON (n.title)
 ----
 ////
 
-.Query
+.Creating a duplicated index
 [source, cypher, role=test-fail]
 ----
 CREATE INDEX bookTitleIndex FOR (book:Book) ON (book.title)
@@ -988,18 +801,12 @@ In this case the index can not be created because it already exists.
 There already exists an index (:Book {title}).
 ----
 
-======
-
 [discrete]
 [[indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-index]]
 ==== Failure to create an index with the same name as an already existing index
 
 Create a named index on the property `numberOfPages` on nodes with the `Book` label, when an index with the given name already exists.
 The index type of the existing index does not matter.
-
-
-.+Creating an index with a duplicated name+
-======
 
 ////
 [source, cypher, role=test-setup]
@@ -1008,7 +815,7 @@ CREATE TEXT INDEX indexOnBooks FOR (b:Label1) ON (b.prop1)
 ----
 ////
 
-.Query
+.Creating an index with a duplicated name
 [source, cypher, role=test-fail]
 ----
 CREATE INDEX indexOnBooks FOR (book:Book) ON (book.numberOfPages)
@@ -1022,17 +829,12 @@ In this case the index can't be created because there already exists an index wi
 There already exists an index called 'indexOnBooks'.
 ----
 
-======
-
 [discrete]
 [[indexes-failure-to-create-an-index-when-a-constraint-already-exists]]
 ==== Failure to create an index when a constraint already exists
 
 Create an index on the property `isbn` on nodes with the `Book` label, when an index-backed constraint already exists on that schema.
 This is only relevant for range indexes.
-
-.+Creating a range index on same schema as existing index-backed constraint+
-======
 
 ////
 [source, cypher, role=test-setup]
@@ -1041,7 +843,7 @@ CREATE CONSTRAINT uniqueBookIsbn FOR (book:Book) REQUIRE (book.isbn) IS UNIQUE
 ----
 ////
 
-.Query
+.Creating a range index on same schema as existing index-backed constraint
 [source, cypher, role=test-fail]
 ----
 CREATE INDEX bookIsbnIndex FOR (book:Book) ON (book.isbn)
@@ -1055,17 +857,11 @@ In this case the index can not be created because an index-backed constraint alr
 There is a uniqueness constraint on (:Book {isbn}), so an index is already created that matches this.
 ----
 
-======
-
 [discrete]
 [[indexes-failure-to-create-an-index-with-the-same-name-as-an-already-existing-constraint]]
 ==== Failure to create an index with the same name as an already existing constraint
 
 Create a named index on the property `numberOfPages` on nodes with the `Book` label, when a constraint with the given name already exists.
-
-
-.+Creating an index with same name as an existing constraint+
-======
 
 ////
 [source, cypher, role=test-setup]
@@ -1074,7 +870,7 @@ CREATE CONSTRAINT bookRecommendations FOR (book:Book) REQUIRE (book.recommend) I
 ----
 ////
 
-.Query
+.Creating an index with same name as an existing constraint
 [source, cypher, role=test-fail]
 ----
 CREATE INDEX bookRecommendations FOR (book:Book) ON (book.recommendations)
@@ -1087,8 +883,6 @@ In this case the index can not be created because there already exists a constra
 ----
 There already exists a constraint called 'bookRecommendations'.
 ----
-
-======
 
 
 [[indexes-list-indexes]]
@@ -1193,18 +987,11 @@ Listing indexes require xref::administration/access-control/database-administrat
 To list all indexes with the default output columns, the `SHOW INDEXES` command can be used.
 If all columns are required, use `SHOW INDEXES YIELD *`.
 
-
-.+Showing all indexes+
-======
-
-.Query
+.Showing all indexes
 [source, cypher, role=test-result-skip]
 ----
 SHOW INDEXES
 ----
-
-One of the output columns from `SHOW INDEXES` is the name of the index.
-This can be used to drop the index with the xref::indexes-for-search-performance.adoc#indexes-drop-an-index[`DROP INDEX` command].
 
 // SHOW INDEXES default outputs
 // 4.4: id, name, state, populationPercent, uniqueness, type, entityType, labelsOrTypes, properties, indexProvider
@@ -1235,7 +1022,8 @@ This can be used to drop the index with the xref::indexes-for-search-performance
 15 rows
 ----
 
-======
+One of the output columns from `SHOW INDEXES` is the name of the index.
+This can be used to drop the index with the xref::indexes-for-search-performance.adoc#indexes-drop-an-index[`DROP INDEX` command].
 
 
 [discrete]
@@ -1249,23 +1037,12 @@ For example, to show only range indexes, use `SHOW RANGE INDEXES`.
 Another more flexible way of filtering the output is to use the `WHERE` clause.
 An example is to only show indexes not belonging to constraints.
 
+To show only range indexes that does not belong to a constraint we can combine the filtering versions.
 
-.+Showing range indexes+
-======
-
-.Query
+.Showing range indexes
 [source, cypher, role=test-result-skip]
 ----
 SHOW RANGE INDEXES WHERE owningConstraint IS NULL
-----
-
-This will only return the default output columns.
-
-To get all columns, use:
-
-[source, syntax, role="noheader"]
-----
-SHOW INDEXES YIELD * WHERE ...
 ----
 
 .Result
@@ -1283,7 +1060,14 @@ SHOW INDEXES YIELD * WHERE ...
 5 rows
 ----
 
-======
+This will only return the default output columns.
+
+To get all columns, use:
+
+[source, syntax, role="noheader"]
+----
+SHOW RANGE INDEXES YIELD * WHERE owningConstraint IS NULL
+----
 
 
 [[indexes-drop-indexes]]
@@ -1317,23 +1101,15 @@ Dropping an index requires xref::administration/access-control/database-administ
 [[indexes-drop-an-index]]
 ==== Drop an index
 
+The following statement will attempt to drop the index named `example_index`.
 
-.+Dropping an index+
-======
-
-.Query
+.Dropping an index
 [source, cypher]
 ----
 DROP INDEX example_index
 ----
 
-.Result
-[queryresult]
-----
-Removed 1 index.
-----
-
-======
+If an index with that name exists it is removed, if not the command fails.
 
 
 [discrete]
@@ -1342,23 +1118,15 @@ Removed 1 index.
 
 If it is uncertain if an index exists and you want to drop it if it does but not get an error should it not, use `IF EXISTS`.
 
+The following statement will attempt to drop the index named `missing_index_name`.
 
-.+Dropping an index with `IF NOT EXISTS`+
-======
-
-.Query
+.Dropping an index with `IF EXISTS`
 [source, cypher]
 ----
 DROP INDEX missing_index_name IF EXISTS
 ----
 
-.Result
-[queryresult]
-----
-(no changes, no records)
-----
-
-======
+If an index with that name exists it is removed, if not the command does nothing.
 
 
 [[indexes-single-vs-composite-index]]

--- a/modules/ROOT/pages/keyword-glossary.adoc
+++ b/modules/ROOT/pages/keyword-glossary.adoc
@@ -76,35 +76,35 @@ Typically used when modifying or importing large amounts of data.
 | Schema
 | Create a fulltext index on relationships.
 
-| xref::indexes-for-search-performance.adoc#administration-indexes-syntax[CREATE LOOKUP INDEX [name\] [IF NOT EXISTS\] FOR (n) ON EACH labels(n) [OPTIONS {optionKey: optionValue[, ...\]}\]]
+| xref::indexes-for-search-performance.adoc#indexes-syntax[CREATE LOOKUP INDEX [name\] [IF NOT EXISTS\] FOR (n) ON EACH labels(n) [OPTIONS {optionKey: optionValue[, ...\]}\]]
 | Schema
 | Create an index on all nodes with any label.
 
-| xref::indexes-for-search-performance.adoc#administration-indexes-syntax[CREATE LOOKUP INDEX [name\] [IF NOT EXISTS\] FOR ()-"["r"\]"-() ON [EACH\] type(r) [OPTIONS {optionKey: optionValue[, ...\]}\]]
+| xref::indexes-for-search-performance.adoc#indexes-syntax[CREATE LOOKUP INDEX [name\] [IF NOT EXISTS\] FOR ()-"["r"\]"-() ON [EACH\] type(r) [OPTIONS {optionKey: optionValue[, ...\]}\]]
 | Schema
 | Create an index on all relationships with any relationship type.
 
-| xref::indexes-for-search-performance.adoc#administration-indexes-syntax[CREATE POINT INDEX [name\] [IF NOT EXISTS\] FOR (n:Label) ON (n.property) [OPTIONS {optionKey: optionValue[, ...\]}\]]
+| xref::indexes-for-search-performance.adoc#indexes-syntax[CREATE POINT INDEX [name\] [IF NOT EXISTS\] FOR (n:Label) ON (n.property) [OPTIONS {optionKey: optionValue[, ...\]}\]]
 | Schema
 | Create a point index on nodes.
 
-| xref::indexes-for-search-performance.adoc#administration-indexes-syntax[CREATE POINT INDEX [name\] [IF NOT EXISTS\] FOR ()-"["r:TYPE"\]"-() ON (r.property) [OPTIONS {optionKey: optionValue[, ...\]}\]]
+| xref::indexes-for-search-performance.adoc#indexes-syntax[CREATE POINT INDEX [name\] [IF NOT EXISTS\] FOR ()-"["r:TYPE"\]"-() ON (r.property) [OPTIONS {optionKey: optionValue[, ...\]}\]]
 | Schema
 | Create a point index on relationships.
 
-| xref::indexes-for-search-performance.adoc#administration-indexes-syntax[CREATE [RANGE\] INDEX [name\] [IF NOT EXISTS\] FOR (n:Label) ON (n.property[, ..., n.propertyN\]) [OPTIONS {optionKey: optionValue[, ...\]}\]]
+| xref::indexes-for-search-performance.adoc#indexes-syntax[CREATE [RANGE\] INDEX [name\] [IF NOT EXISTS\] FOR (n:Label) ON (n.property[, ..., n.propertyN\]) [OPTIONS {optionKey: optionValue[, ...\]}\]]
 | Schema
 | Create a range index on nodes.
 
-| xref::indexes-for-search-performance.adoc#administration-indexes-syntax[CREATE [RANGE\] INDEX [name\] [IF NOT EXISTS\] FOR ()-"["r:TYPE"\]"-() ON (r.property[, ..., r.propertyN\]) [OPTIONS {optionKey: optionValue[, ...\]}\]]
+| xref::indexes-for-search-performance.adoc#indexes-syntax[CREATE [RANGE\] INDEX [name\] [IF NOT EXISTS\] FOR ()-"["r:TYPE"\]"-() ON (r.property[, ..., r.propertyN\]) [OPTIONS {optionKey: optionValue[, ...\]}\]]
 | Schema
 | Create a range index on relationships.
 
-| xref::indexes-for-search-performance.adoc#administration-indexes-syntax[CREATE TEXT INDEX [name\] [IF NOT EXISTS\] FOR (n:Label) ON (n.property) [OPTIONS {optionKey: optionValue[, ...\]}\]]
+| xref::indexes-for-search-performance.adoc#indexes-syntax[CREATE TEXT INDEX [name\] [IF NOT EXISTS\] FOR (n:Label) ON (n.property) [OPTIONS {optionKey: optionValue[, ...\]}\]]
 | Schema
 | Create a text index on nodes.
 
-| xref::indexes-for-search-performance.adoc#administration-indexes-syntax[CREATE TEXT INDEX [name\] [IF NOT EXISTS\] FOR ()-"["r:TYPE"\]"-() ON (r.property) [OPTIONS {optionKey: optionValue[, ...\]}\]]
+| xref::indexes-for-search-performance.adoc#indexes-syntax[CREATE TEXT INDEX [name\] [IF NOT EXISTS\] FOR ()-"["r:TYPE"\]"-() ON (r.property) [OPTIONS {optionKey: optionValue[, ...\]}\]]
 | Schema
 | Create a text index on relationships.
 
@@ -124,7 +124,7 @@ All associated relationships will automatically be deleted.
 | Schema
 | Drop a constraint using the name.
 
-| xref::indexes-for-search-performance.adoc#administration-indexes-syntax[DROP INDEX name [IF EXISTS\]]
+| xref::indexes-for-search-performance.adoc#indexes-syntax[DROP INDEX name [IF EXISTS\]]
 | Schema
 | Drop an index using the name.
 
@@ -186,7 +186,7 @@ Either the pattern already exists, or it needs to be created.
 List constraints in the database, either all or filtered on type.
 Also allows `WHERE` and `YIELD` clauses.
 
-| xref::indexes-for-search-performance.adoc#administration-indexes-list-indexes[SHOW [ALL\|FULLTEXT\|LOOKUP\|POINT\|RANGE\|TEXT\] INDEX[ES\]]
+| xref::indexes-for-search-performance.adoc#indexes-list-indexes[SHOW [ALL\|FULLTEXT\|LOOKUP\|POINT\|RANGE\|TEXT\] INDEX[ES\]]
 | Schema
 |
 List indexes in the database, either all or filtered on fulltext, lookup, point, range, or text indexes.

--- a/modules/ROOT/pages/query-tuning/indexes.adoc
+++ b/modules/ROOT/pages/query-tuning/indexes.adoc
@@ -642,7 +642,7 @@ Total database accesses: 2, total allocated memory: 184
 A query containing equality comparisons for all the properties of a composite index will automatically be backed by the same index.
 However, the query does not need to have equality on all properties.
 It can have ranges and existence predicates as well.
-But in these cases rewrites might happen depending on which properties have which predicates, see xref::indexes-for-search-performance.adoc#administration-indexes-single-vs-composite-index[composite index limitations].
+But in these cases rewrites might happen depending on which properties have which predicates, see xref::indexes-for-search-performance.adoc#indexes-single-vs-composite-index[composite index limitations].
 
 ////
 [source, cypher, role=test-setup]
@@ -730,7 +730,7 @@ Total database accesses: 2, total allocated memory: 184
 
 Composite indexes are also automatically used for inequality (range) comparisons of indexed properties in the `WHERE` clause.
 Equality or list membership check predicates may precede the range predicate.
-However, predicates after the range predicate may be rewritten as an existence check predicate and a filter as described in xref::indexes-for-search-performance.adoc#administration-indexes-single-vs-composite-index[composite index limitations].
+However, predicates after the range predicate may be rewritten as an existence check predicate and a filter as described in xref::indexes-for-search-performance.adoc#indexes-single-vs-composite-index[composite index limitations].
 
 ////
 [source, cypher, role=test-setup]
@@ -1019,7 +1019,7 @@ CREATE RANGE INDEX node_text_firstname_surname FOR (p:Person) ON (p.firstname, p
 The `STARTS WITH` predicate on `person.firstname` in the following query will use the `Person(firstname,surname)` index, if it exists.
 Any (non-existence check) predicate on `person.surname` will be rewritten as existence check with a filter.
 However, if the predicate on `person.firstname` is a equality check then a `STARTS WITH` on `person.surname` would also use the index (without rewrites).
-More information about how the rewriting works can be found in xref::indexes-for-search-performance.adoc#administration-indexes-single-vs-composite-index[composite index limitations].
+More information about how the rewriting works can be found in xref::indexes-for-search-performance.adoc#indexes-single-vs-composite-index[composite index limitations].
 
 .Query
 [source, cypher]
@@ -1103,7 +1103,7 @@ Text indexes only index String values and therefore do not find other values.
 The `ENDS WITH` predicate on `r.metIn` in the following query uses the `KNOWS(metIn, lastMetIn)` index, if it exists.
 However, it is rewritten as existence check and a filter due to the index not supporting actual suffix searches for composite indexes, this is still faster than not using an index in the first place.
 Any (non-existence check) predicate on `KNOWS.lastMetIn` is also rewritten as existence check with a filter.
-More information about how the rewriting works can be found in xref::indexes-for-search-performance.adoc#administration-indexes-single-vs-composite-index[composite index limitations].
+More information about how the rewriting works can be found in xref::indexes-for-search-performance.adoc#indexes-single-vs-composite-index[composite index limitations].
 
 ////
 [source, cypher, role=test-setup]
@@ -1190,7 +1190,7 @@ Text indexes only index String values and therefore do not find other values.
 The `CONTAINS` predicate on `person.country` in the following query will use the `Person(country,age)` index, if it exists.
 However, it will be rewritten as existence check and a filter due to the index not supporting actual suffix searches for composite indexes, this is still faster than not using an index in the first place.
 Any (non-existence check) predicate on `person.age` will also be rewritten as existence check with a filter.
-More information about how the rewriting works can be found in xref::indexes-for-search-performance.adoc#administration-indexes-single-vs-composite-index[composite index limitations].
+More information about how the rewriting works can be found in xref::indexes-for-search-performance.adoc#indexes-single-vs-composite-index[composite index limitations].
 
 .Query
 [source, cypher]

--- a/modules/ROOT/pages/syntax/spatial.adoc
+++ b/modules/ROOT/pages/syntax/spatial.adoc
@@ -247,7 +247,7 @@ RETURN
 == Point index
 // POINT INDEX new in Neo4j 5.0
 
-If there is a xref::indexes-for-search-performance.adoc#administration-indexes-create-a-node-point-index[index] on a particular `:Label(property)` combination, and a spatial point is assigned to that property on a node with that label, the node will be indexed in a point index.
+If there is a xref::indexes-for-search-performance.adoc#indexes-create-a-node-point-index[index] on a particular `:Label(property)` combination, and a spatial point is assigned to that property on a node with that label, the node will be indexed in a point index.
 
 For point indexing, Neo4j uses space filling curves in 2D or 3D over an underlying generalized B+Tree.
 Points will be stored in up to four different trees, one for each of the xref::syntax/spatial.adoc#cypher-spatial-crs[four coordinate reference systems].


### PR DESCRIPTION
This will hopefully remove some confusion for users around just showing off the command vs an example as well as removing examples for index providers when only one provider exists.

It also updates the links to not mention `administration` as the index chapter does not live in the administration chapter.