### PR TITLE
Add a clearer deprecation message for replacing the user of paths in the size() function.

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -3308,12 +3308,12 @@ size()
 ----
 a|
 Only works for strings, lists and pattern comprehensions, and no longer works for paths.
-For versions above 5.0 use a `COUNT` expression:
+For versions above 5.0, use a `COUNT` expression instead:
 [source, cypher, role="noheader"]
 ----
 RETURN COUNT { (a)-[]->(b) }
 ----
-For versions below 5.0 use a pattern comprehension:
+For versions below 5.0, use a pattern comprehension instead:
 [source, cypher, role="noheader"]
 ----
 RETURN size([ (a)-[]->(b) \| a ])

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -3307,7 +3307,7 @@ label:restricted[]
 size()
 ----
 a|
-Only works for strings, lists and pattern comprehensions.
+Only works for strings, lists and pattern comprehensions, and no longer works for paths.
 For versions above 5.0 use a `COUNT` expression:
 [source, cypher, role="noheader"]
 ----
@@ -3318,7 +3318,7 @@ For versions below 5.0 use a pattern comprehension:
 ----
 RETURN size([ (a)-[]->(b) \| a ])
 ----
-See xref:functions/scalar.adoc#functions-size[size()] and xref:syntax/expressions.adoc#count-subqueries[Count Expressions] for more details.
+See xref:functions/scalar.adoc#functions-size[size()] and xref:syntax/expressions.adoc#count-subqueries[Count Subqueries] for more details.
 |===
 
 === Updated features

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -3307,7 +3307,18 @@ label:restricted[]
 size()
 ----
 a|
-No longer works for paths. Only works for strings, lists and pattern expressions. See xref:functions/scalar.adoc#functions-size[size()] for more details.
+Only works for strings, lists and pattern comprehensions.
+For versions above 5.0 use a `COUNT` expression:
+[source, cypher, role="noheader"]
+----
+RETURN COUNT { (a)-[]->(b) }
+----
+For versions below 5.0 use a pattern comprehension:
+[source, cypher, role="noheader"]
+----
+RETURN size([ (a)-[]->(b) \| a ])
+----
+See xref:functions/scalar.adoc#functions-size[size()] and xref:syntax/expressions.adoc#count-subqueries[Count Expressions] for more details.
 |===
 
 === Updated features


### PR DESCRIPTION
Size() cannot accept a path anymore (as of 4.0), but can take pattern comprehension and could now be replaced with 5.0 feature, COUNT. This PR makes this replacement clearer to the users.