### PR TITLE
[TESTING] Ensure string type results are surrounded by quotes

### DIFF
--- a/modules/ROOT/pages/administration/aliases.adoc
+++ b/modules/ROOT/pages/administration/aliases.adoc
@@ -329,8 +329,8 @@ SHOW ALIASES FOR DATABASE
 
 | +name+ | +database+ | +location+ | +url+ | +user+
 | +"films"+ | +"movies"+ | +"local"+ | +<null>+ | +<null>+
-| +"library.romance"+ | +romance-books"+ | +"remote"+ | +"neo4j+s://location:7687"+ |  +"alice"+
-| +"library.sci-fi"+ | +sci-fi-books"+ | +"local"+ | +<null>+ |  +<null>+
+| +"library.romance"+ | +"romance-books""+ | +"remote"+ | +"neo4j+s://location:7687"+ |  +"alice"+
+| +"library.sci-fi"+ | +"sci-fi-books"+ | +"local"+ | +<null>+ |  +<null>+
 | +"motion pictures"+ | +"movies"+ | +"local"+ | +<null>+ | +<null>+
 | +"movie scripts"+ | +"scripts"+ | +"remote"+ | +"neo4j+s://location:7687"+ | +"alice"+
 5+d|Rows: 5

--- a/modules/ROOT/pages/administration/databases.adoc
+++ b/modules/ROOT/pages/administration/databases.adoc
@@ -288,7 +288,7 @@ SHOW DATABASES
 |===
 
 | +name+ | +type+ | +aliases+ | +access+ | +address+ | +role+ | +writer+ | +requestedStatus+ | +currentStatus+ | +statusMessage+ | +default+ | +home+ | +constituents+
-| +"movies"+ | +standard+ | +["films","motion pictures"]+ | +"read-write"+ | +"localhost:7687"+ | +"primary"+ | +true+ | +"online"+ | +"online"+ | +""+ | +false+ | +false+ | +[]+
+| +"movies"+ | +"standard"+ | +["films","motion pictures"]+ | +"read-write"+ | +"localhost:7687"+ | +"primary"+ | +true+ | +"online"+ | +"online"+ | +""+ | +false+ | +false+ | +[]+
 | +"neo4j"+ | +"standard"+ | +[]+ | +"read-write"+ | +"localhost:7687"+ | +"primary"+ | +true+ | +"online"+ | +"online"+ | +""+ | +true+ | +true+ | +[]+
 | +"system"+ | +"system"+ | +[]+ | +"read-write"+ | +"localhost:7687"+ | +"primary"+ | +true+ | +"online"+ | +"online"+ | +""+ | +false+ | +false+ | +[]+
 13+d|Rows: 3
@@ -630,7 +630,7 @@ SHOW DATABASES YIELD name, type, access, role, writer, constituents
 | +"movies"+ | +"standard"+ | +"read-write"+ | +"primary"+ | +true+ | +[]+
 | +"neo4j"+ | +"standard"+ | +"read-write"+ | +"primary"+ | +true+ | +[]+
 | +"romance"+ | +"standard"+ | +"read-write"+ | +"primary"+ | +true+ | +[]+
-| +"sci-fi-books"+ | +"standard"+ | +"read-write"+ | +"primary"+ | +true+ | +[]+
+| +"sci-fi"+ | +"standard"+ | +"read-write"+ | +"primary"+ | +true+ | +[]+
 | +"system"+ | +"system"+ | +"read-write"+ | +"primary"+ | +true+ | +[]+
 | +"topology-example"+ | +"standard"+ | +"read-write"+ | +"primary"+ | +true+ | +[]+
 6+d|Rows: 8

--- a/modules/ROOT/pages/clauses/return.adoc
+++ b/modules/ROOT/pages/clauses/return.adoc
@@ -5,7 +5,7 @@
 
 [[return-introduction]]
 == Introduction
-The `RETURN` clause defines the parts of a pattern (nodes, relationships, and/or properties) to be included in the query result. 
+The `RETURN` clause defines the parts of a pattern (nodes, relationships, and/or properties) to be included in the query result.
 
 [[return-example-graph]]
 == Example graph
@@ -62,8 +62,8 @@ RETURN type(r)
 .Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
-| +type(r)+ 
-| +:ACTED_IN+
+| +type(r)+
+| +"ACTED_IN"+
 1+d|Rows: 1
 |===
 
@@ -107,7 +107,7 @@ MATCH p = (keanu:Person {name: 'Keanu Reeves'})-[r]->(m)
 RETURN *
 ----
 
-This returns the two nodes, and the two possible paths between them. 
+This returns the two nodes, and the two possible paths between them.
 
 .Result
 [role="queryresult",options="header,footer",cols="4*<m"]
@@ -179,7 +179,7 @@ MATCH (n)
 RETURN n.bornIn
 ----
 
-This example returns the `bornIn` properties for nodes that has that property, and `null` for  those nodes missing the property. 
+This example returns the `bornIn` properties for nodes that has that property, and `null` for  those nodes missing the property.
 
 .Result
 [role="queryresult",options="header,footer",cols="1*<m"]
@@ -194,7 +194,7 @@ This example returns the `bornIn` properties for nodes that has that property, a
 [[return-other-expressions]]
 == Other expressions
 
-Any expression can be used as a return item -- literals, predicates, properties, functions, and so on. 
+Any expression can be used as a return item -- literals, predicates, properties, functions, and so on.
 
 .Query
 [source, cypher]

--- a/modules/ROOT/pages/clauses/set.adoc
+++ b/modules/ROOT/pages/clauses/set.adoc
@@ -163,7 +163,7 @@ The `name` property is now missing.
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +n.name+ | +n.age+
-| +<null>+ | +36+
+| +<null>+ | +"36"+
 2+d|Rows: 1 +
 Properties set: 1
 |===

--- a/modules/ROOT/pages/functions/predicate.adoc
+++ b/modules/ROOT/pages/functions/predicate.adoc
@@ -3,7 +3,7 @@
 [[query-functions-predicate]]
 = Predicate functions
 
-== Introduction 
+== Introduction
 
 Predicates are boolean functions that return `true` or `false` for a given set of non-`null` input.
 They are most commonly used to filter out paths in the `WHERE` part of a query.
@@ -308,12 +308,12 @@ This query returns every `Person` node in the graph with a set `nationality` pro
 .Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
-| +p.name+ | +p.nationality+
-| +Keanu Reeves+ | +Canadian+
-| +Carrie Anne Moss+ | +American+
-| +Liam Neeson+ | +Northern Irish+
-| +Guy Pearce+ | +Australian+
-| +Kathryn Bigelow+ | +American+
+| p.name | p.nationality
+| "Keanu Reeves" | "Canadian"
+| "Carrie Anne Moss" | "American"
+| "Liam Neeson" | "Northern Irish"
+| "Guy Pearce" | "Australian"
+| "Kathryn Bigelow" | "American"
 2+d|Rows: 5
 |===
 
@@ -405,7 +405,7 @@ WHERE isEmpty(p.address)
 RETURN p.name AS name
 ----
 
-The `name` property of each node that has an empty (empty string) `address` property is returned: 
+The `name` property of each node that has an empty (empty string) `address` property is returned:
 
 .Result
 [role="queryresult",options="header,footer",cols="1*<m"]


### PR DESCRIPTION
Testing infrastructure now checks that strings are ... really strings! Meaning they need to be surrounded by some form of quotes (either single or double). Couple of other mistakes fixed along the way.