### PR TITLE
Remove reference to `dbms.cluster.overview`

### DIFF
--- a/modules/ROOT/pages/administration/databases.adoc
+++ b/modules/ROOT/pages/administration/databases.adoc
@@ -176,7 +176,7 @@ The default for a standalone database is `neo4j://localhost:7687`. label:default
 | STRING
 
 | writer
-|`true` for the database node that accepts writes (this node is the leader for this database in a cluster or this is a standalone instance). label:default-output[]
+|`true` for the instance that accepts writes for this database (this instance is the leader for this database in a cluster or this is a standalone instance). label:default-output[]
 | BOOLEAN
 
 | requestedStatus
@@ -707,7 +707,7 @@ Controls how the system handles existing data on disk when creating the database
 Currently this is only supported with `existingDataSeedInstance` and must be set to `use` which indicates the existing data files should be used for the new database.
 
 | `existingDataSeedInstance`
-| server ID of the cluster node
+| ID of the cluster server
 |
 Defines which server is used for seeding the data of the created database.
 The server ID can be found in the `serverId` column after running `SHOW SERVERS`.

--- a/modules/ROOT/pages/administration/databases.adoc
+++ b/modules/ROOT/pages/administration/databases.adoc
@@ -707,10 +707,11 @@ Controls how the system handles existing data on disk when creating the database
 Currently this is only supported with `existingDataSeedInstance` and must be set to `use` which indicates the existing data files should be used for the new database.
 
 | `existingDataSeedInstance`
-| instance ID of the cluster node
+| server ID of the cluster node
 |
-Defines which instance is used for seeding the data of the created database.
-The instance id can be taken from the id column of the `dbms.cluster.overview()` procedure. Can only be used in clusters.
+Defines which server is used for seeding the data of the created database.
+The server ID can be found in the `serverId` column after running `SHOW SERVERS`.
+
 
 | `seedURI`
 | URI to a backup or a dump from an existing database.

--- a/modules/ROOT/pages/administration/databases.adoc
+++ b/modules/ROOT/pages/administration/databases.adoc
@@ -712,7 +712,6 @@ Currently this is only supported with `existingDataSeedInstance` and must be set
 Defines which server is used for seeding the data of the created database.
 The server ID can be found in the `serverId` column after running `SHOW SERVERS`.
 
-
 | `seedURI`
 | URI to a backup or a dump from an existing database.
 |


### PR DESCRIPTION
Users should now use `SHOW SERVERS` as of 5.x.