### PR TITLE
Mark Cypher first usage on every page

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@neo4j-antora/mark-terms": "1.0.0",
     "@neo4j-documentation/macros": "^1.0.2",
     "@neo4j-documentation/remote-include": "^1.0.0",
-    "asciidoctor-kroki": "^0.17.0"
+    "asciidoctor-kroki": "^0.16.0"
   },
   "devDependencies": {
     "express": "^4.17.1",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "author": "Neo4j",
   "license": "ISC",
   "dependencies": {
-    "@antora/cli": "^3.1.1",
-    "@antora/site-generator-default": "^3.1.1",
+    "@antora/cli": "^3.1.3",
+    "@antora/site-generator-default": "^3.1.3",
     "@neo4j-antora/antora-add-notes": "^0.1.6",
     "@neo4j-antora/antora-modify-sitemaps": "^0.4.4",
     "@neo4j-antora/antora-page-roles": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@neo4j-antora/antora-modify-sitemaps": "^0.4.4",
     "@neo4j-antora/antora-page-roles": "^0.3.1",
     "@neo4j-antora/antora-table-footnotes": "^0.3.2",
-    "@neo4j-antora/mark-terms": "1.0.0",
+    "@neo4j-antora/mark-terms": "1.1.0",
     "@neo4j-documentation/macros": "^1.0.2",
     "@neo4j-documentation/remote-include": "^1.0.0",
     "asciidoctor-kroki": "^0.16.0"

--- a/package.json
+++ b/package.json
@@ -25,9 +25,10 @@
     "@neo4j-antora/antora-modify-sitemaps": "^0.4.4",
     "@neo4j-antora/antora-page-roles": "^0.3.1",
     "@neo4j-antora/antora-table-footnotes": "^0.3.2",
+    "@neo4j-antora/mark-terms": "1.0.0",
     "@neo4j-documentation/macros": "^1.0.2",
     "@neo4j-documentation/remote-include": "^1.0.0",
-    "asciidoctor-kroki": "^0.16.0"
+    "asciidoctor-kroki": "^0.17.0"
   },
   "devDependencies": {
     "express": "^4.17.1",

--- a/preview.yml
+++ b/preview.yml
@@ -36,6 +36,7 @@ asciidoc:
   - "@neo4j-antora/antora-add-notes"
   - "@neo4j-antora/antora-page-roles"
   - "@neo4j-antora/antora-table-footnotes"
+  - "@neo4j-antora/mark-terms"
   - asciidoctor-kroki
   attributes:
     page-theme: docs
@@ -48,6 +49,7 @@ asciidoc:
     page-origin-private: true
     page-hide-toc: false
     page-mixpanel: 4bfb2414ab973c741b6f067bf06d5575
+    page-terms-to-mark: Cypher
     includePDF: false
     nonhtmloutput: ""
     experimental: ''


### PR DESCRIPTION
Add the `mark-terms` extension to mark the first instance of Cypher on every page.