### PR TITLE
Creating a database without specifying topology

### DIFF
--- a/modules/ROOT/pages/administration/databases.adoc
+++ b/modules/ROOT/pages/administration/databases.adoc
@@ -582,6 +582,11 @@ For more details on primary and secondary server roles, see link:{neo4j-docs-bas
 Composite databases are always available on all servers.
 ====
 
+[NOTE]
+====
+If `TOPOLOGY` is not specified, the database is created according to `initial.dbms.default_primaries_count` and `initial.dbms.default_secondaries_count` specified in `neo4j.conf`.
+After cluster startup these values can be overwritten by using the 'dbms.setDefaultAllocationNumbers' procedure.
+====
 
 [role=enterprise-edition not-on-aura]
 [[administration-databases-create-composite-database]]

--- a/modules/ROOT/pages/administration/databases.adoc
+++ b/modules/ROOT/pages/administration/databases.adoc
@@ -585,7 +585,7 @@ Composite databases are always available on all servers.
 [NOTE]
 ====
 If `TOPOLOGY` is not specified, the database is created according to `initial.dbms.default_primaries_count` and `initial.dbms.default_secondaries_count` specified in _neo4j.conf_.
-After cluster startup these values can be overwritten by using the 'dbms.setDefaultAllocationNumbers' procedure.
+After cluster startup, these values can be overwritten using the `dbms.setDefaultAllocationNumbers` procedure.
 ====
 
 [role=enterprise-edition not-on-aura]

--- a/modules/ROOT/pages/administration/databases.adoc
+++ b/modules/ROOT/pages/administration/databases.adoc
@@ -584,7 +584,7 @@ Composite databases are always available on all servers.
 
 [NOTE]
 ====
-If `TOPOLOGY` is not specified, the database is created according to `initial.dbms.default_primaries_count` and `initial.dbms.default_secondaries_count` specified in `neo4j.conf`.
+If `TOPOLOGY` is not specified, the database is created according to `initial.dbms.default_primaries_count` and `initial.dbms.default_secondaries_count` specified in _neo4j.conf_.
 After cluster startup these values can be overwritten by using the 'dbms.setDefaultAllocationNumbers' procedure.
 ====
 


### PR DESCRIPTION
Adds a note on what allocation numbers are used if `TOPOLOGY` is not set.