### PR TITLE
Creating a database without specifying topology (#565)

### DIFF
--- a/modules/ROOT/pages/administration/databases.adoc
+++ b/modules/ROOT/pages/administration/databases.adoc
@@ -582,6 +582,11 @@ For more details on primary and secondary server roles, see link:{neo4j-docs-bas
 Composite databases are always available on all servers.
 ====
 
+[NOTE]
+====
+If `TOPOLOGY` is not specified, the database is created according to `initial.dbms.default_primaries_count` and `initial.dbms.default_secondaries_count` specified in _neo4j.conf_.
+After cluster startup, these values can be overwritten using the `dbms.setDefaultAllocationNumbers` procedure.
+====
 
 [role=enterprise-edition not-on-aura]
 [[administration-databases-create-composite-database]]


### PR DESCRIPTION
Adds a note on what allocation numbers are used if `TOPOLOGY` is not set.

---------
Cherry-picked from #565 