### PR TITLE
Remove 4.2 from Query Option table 

### DIFF
--- a/modules/ROOT/pages/query-tuning/query-options.adoc
+++ b/modules/ROOT/pages/query-tuning/query-options.adoc
@@ -27,10 +27,6 @@ Here we detail the available versions:
 | This will force the query to use Neo4j Cypher 3.5.
 |
 
-| 4.2
-| This will force the query to use Neo4j Cypher 4.2.
-|
-
 | 4.3
 | This will force the query to use Neo4j Cypher 4.3.
 |

--- a/modules/ROOT/pages/query-tuning/query-options.adoc
+++ b/modules/ROOT/pages/query-tuning/query-options.adoc
@@ -44,7 +44,7 @@ As this is the default version, it is not necessary to use this option explicitl
 [WARNING]
 ====
 In Neo4j {neo4j-version}, the support for Cypher 3.5 and Cypher 4.3 is provided only at the parser level.
-The consequence is that some underlying features available in Neo4j 3.5 is no longer available and will result in runtime errors.
+The consequence is that some underlying features available in Neo4j 3.5 are no longer available and will result in runtime errors.
 
 Please refer to the discussion in xref::deprecations-additions-removals-compatibility.adoc#cypher-compatibility[Cypher Compatibility] for more information on which features are affected.
 ====

--- a/modules/ROOT/pages/query-tuning/query-options.adoc
+++ b/modules/ROOT/pages/query-tuning/query-options.adoc
@@ -43,8 +43,8 @@ As this is the default version, it is not necessary to use this option explicitl
 
 [WARNING]
 ====
-In Neo4j {neo4j-version}, the support for Cypher 3.5 is provided only at the parser level.
-The consequence is that some underlying features available in Neo4j 3.5 are no longer available and will result in runtime errors.
+In Neo4j {neo4j-version}, the support for Cypher 3.5 and Cypher 4.3 is provided only at the parser level.
+The consequence is that some underlying features available in Neo4j 3.5 is no longer available and will result in runtime errors.
 
 Please refer to the discussion in xref::deprecations-additions-removals-compatibility.adoc#cypher-compatibility[Cypher Compatibility] for more information on which features are affected.
 ====


### PR DESCRIPTION
Trello card: https://trello.com/c/TwCeljF0/5003-inconsistent-documentation-regarding-cypher-versions