### PR TITLE
Reorder deprecations, additions and removals file to have consistent order on the subsections

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -3,6 +3,12 @@
 :description: all of the features that have been removed, deprecated, added, or extended in different Cypher versions.
 :test-skip: true  // all deprecations would fail.
 
+// Order of subsections:
+//  1. Removed features
+//  2. Deprecated features
+//  3. Restricted features
+//  4. Updated features
+//  5. New features
 
 Cypher is a language that is constantly evolving.
 New features are added to the language continuously, and occasionally, some features become deprecated and are subsequently removed.
@@ -13,24 +19,6 @@ Replacement syntax for deprecated and removed features are also indicated.
 [[cypher-deprecations-additions-removals-5.8]]
 == Version 5.8
 
-=== New features 
-
-[cols="2", options="header"]
-|===
-| Feature
-| Details
-
-a| 
-label:functionality[]
-label:new[]
-
-New operator: `AssertSameRelationship`
-
-a| 
-The `AssertSameRelationship` operator is used to ensure that no relationship property uniqueness constraints are violated in the slotted and interpreted runtime.
-More information can be found xref::execution-plans/operators.adoc#query-plan-assert-same-relationship[here].
-
-|===
 ===  Updated features
 
 [cols="2", options="header"]
@@ -55,41 +43,28 @@ The `trackedSince` column returns the time when usage statistics tracking starte
 
 |===
 
-[[cypher-deprecations-additions-removals-5.7]]
-== Version 5.7
-
-=== New features
+=== New features 
 
 [cols="2", options="header"]
 |===
 | Feature
 | Details
 
-a|
+a| 
 label:functionality[]
 label:new[]
-[source, syntax, role=noheader]
-----
-CALL { 
-  <inner>
-} IN TRANSACTIONS [ OF <num> ROWS ]
-  [ ON ERROR CONTINUE / BREAK / FAIL ]
-  [ REPORT STATUS AS <v> ]
-----
 
-a|
-New fine-grained control mechanism to control how an inner transaction impacts subsequent inner and/or outer transactions.
+New operator: `AssertSameRelationship`
 
-* `ON ERROR CONTINUE` - will ignore errors and continue with the execution of subsequent inner transactions when one of them fails.
-
-* `ON ERROR BREAK` - will ignore an error and stop the execution of subsequent inner transactions.
-
-* `ON ERROR FAIL` - will fail in case of an error. 
-
-*  `REPORT STATUS AS <v>` - reports the execution status of the inner transaction (a map value including the fields `started` `committed`, `transactionId`, and `errorMessage`). This flag is disallowed for `ON ERROR FAIL`.
+a| 
+The `AssertSameRelationship` operator is used to ensure that no relationship property uniqueness constraints are violated in the slotted and interpreted runtime.
+More information can be found xref::execution-plans/operators.adoc#query-plan-assert-same-relationship[here].
 
 |===
 
+
+[[cypher-deprecations-additions-removals-5.7]]
+== Version 5.7
 
 === Deprecated features
 
@@ -116,7 +91,6 @@ The Cypher query option `connectComponentsPlanner` is deprecated and will be rem
 The product's default behavior of using a cost-based IDP search algorithm when combining sub-plans will be kept.
 
 |===
-
 
 ===  Updated features
 
@@ -173,9 +147,41 @@ The existing `UNIQUENESS` filter will now return both node and relationship prop
 
 |===
 
+=== New features
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:new[]
+[source, syntax, role=noheader]
+----
+CALL { 
+  <inner>
+} IN TRANSACTIONS [ OF <num> ROWS ]
+  [ ON ERROR CONTINUE / BREAK / FAIL ]
+  [ REPORT STATUS AS <v> ]
+----
+
+a|
+New fine-grained control mechanism to control how an inner transaction impacts subsequent inner and/or outer transactions.
+
+* `ON ERROR CONTINUE` - will ignore errors and continue with the execution of subsequent inner transactions when one of them fails.
+
+* `ON ERROR BREAK` - will ignore an error and stop the execution of subsequent inner transactions.
+
+* `ON ERROR FAIL` - will fail in case of an error. 
+
+*  `REPORT STATUS AS <v>` - reports the execution status of the inner transaction (a map value including the fields `started` `committed`, `transactionId`, and `errorMessage`). This flag is disallowed for `ON ERROR FAIL`.
+
+|===
+
+
 [[cypher-deprecations-additions-removals-5.6]]
 == Version 5.6
-
 
 === New features
 
@@ -193,13 +199,6 @@ label:new[]
 
 a| New functionality to change tags at runtime via `ALTER SERVER`.
 More information can be found xref::administration/servers.adoc#server-management-alter-server[here].
-
-|===
-
-[cols="2", options="header"]
-|===
-| Feature
-| Details
 
 a|
 label:functionality[]
@@ -250,25 +249,6 @@ New privilege that controls a user's access to desired configuration settings.
 [[cypher-deprecations-additions-removals-5.5]]
 == Version 5.5
 
-=== New features
-
-[cols="2", options="header"]
-|===
-| Feature
-| Details
-
-a| 
-label:functionality[]
-label:new[]
-
-New operator: `IntersectionNodeByLabelsScan`
-
-a| 
-The `IntersectionNodeByLabelsScan` operator fetches all nodes that have all of the provided labels from the node label index.
-More information can be found xref::execution-plans/operators.adoc#query-plan-intersection-node-by-labels-scan[here].
-
-|===
-
 === Deprecated features
 
 [cols="2", options="header"]
@@ -311,6 +291,26 @@ RETURN 'val' as one, 'val' as two
 ----
 
 |===
+
+=== New features
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a| 
+label:functionality[]
+label:new[]
+
+New operator: `IntersectionNodeByLabelsScan`
+
+a| 
+The `IntersectionNodeByLabelsScan` operator fetches all nodes that have all of the provided labels from the node label index.
+More information can be found xref::execution-plans/operators.adoc#query-plan-intersection-node-by-labels-scan[here].
+
+|===
+
 
 [[cypher-deprecations-additions-removals-5.3]]
 == Version 5.3
@@ -377,6 +377,7 @@ The property uniqueness constraint type filter now allow both `UNIQUE` and `UNIQ
 
 |===
 
+
 [[cypher-deprecations-additions-removals-5.2]]
 == Version 5.2
 
@@ -410,6 +411,7 @@ DRYRUN REALLOCATE\|DEALLOCATE DATABASES FROM <serverId>
 a| To preview of the result of either `REALLOCATE` or `DEALLOCATE` without executing, prepend the command with `DRYRUN`.
 
 |===
+
 
 [[cypher-deprecations-additions-removals-5.1]]
 == Version 5.1
@@ -454,6 +456,7 @@ A new text index provider is available, `text-2.0`.
 This is also the default provider if none is given.
 
 |===
+
 
 [[cypher-deprecations-additions-removals-5.0]]
 == Version 5.0
@@ -1519,6 +1522,7 @@ a|
 New syntax that enables inlining of `WHERE` clauses inside relationship patterns.
 
 |===
+
 
 [[cypher-deprecations-additions-removals-4.4]]
 == Version 4.4
@@ -2615,6 +2619,7 @@ New Cypher commands for listing functions.
 
 |===
 
+
 [[cypher-deprecations-additions-removals-4.2]]
 == Version 4.2
 
@@ -2873,9 +2878,9 @@ a|
 New Cypher command for administering privilege for listing constraints.
 |===
 
+
 [[cypher-deprecations-additions-removals-4.1.3]]
 == Version 4.1.3
-
 
 === New features
 
@@ -2925,6 +2930,7 @@ a|
 Makes constraint deletion idempotent. If no constraint with the name exists no error will be thrown.
 
 |===
+
 
 [[cypher-deprecations-additions-removals-4.1]]
 == Version 4.1
@@ -3111,6 +3117,7 @@ ON DEFAULT DATABASE
 a|
 New optional part of the Cypher commands for xref:administration/access-control/database-administration.adoc[database privileges].
 |===
+
 
 [[cypher-deprecations-additions-removals-4.0]]
 == Version 4.0
@@ -3419,6 +3426,7 @@ The create constraint syntax can now include a name.
 The `IS NODE KEY` and `IS UNIQUE` versions of this command replace the procedures `db.createNodeKey` and `db.createUniquePropertyConstraint`, respectively.
 
 |===
+
 === New features
 
 [cols="2", options="header"]


### PR DESCRIPTION
An order was introduced when it was restructured, might be good to keep that order.

Affects sections:
- 5.8
- 5.7
- 5.6 (was for some reason split in two tables where it should have been one)
- 5.5