### PR TITLE
Add operator NodeByElementIdSeek

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -377,6 +377,24 @@ The property uniqueness constraint type filter now allow both `UNIQUE` and `UNIQ
 
 |===
 
+=== New features 
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a| 
+label:functionality[]
+label:new[]
+
+New operator: `NodeByElementIdSeek`
+
+a| 
+The `NodeByElementIdSeek` operator reads one or more nodes by ID from the node store, specified via the function xref::functions/scalar.adoc#functions-elementid[elementId()].
+More information can be found xref::execution-plans/operators.adoc#query-plan-node-by-elementid-seek[here].
+
+|===
 
 [[cypher-deprecations-additions-removals-5.2]]
 == Version 5.2

--- a/modules/ROOT/pages/execution-plans/operator-summary.adoc
+++ b/modules/ROOT/pages/execution-plans/operator-summary.adoc
@@ -322,11 +322,17 @@ Tests for the presence of a pattern predicate in queries containing multiple pat
 |
 |
 
-| xref::execution-plans/operators.adoc#query-plan-node-by-id-seek[NodeByIdSeek]
-| Reads one or more nodes by ID from the node store.
+| xref::execution-plans/operators.adoc#query-plan-node-by-elementid-seek[NodeByElementIdSeek]
+| Reads one or more nodes by ID from the node store, specified via the function xref::functions/scalar.adoc#functions-elementid[elementId()].
 | label:yes[]
 |
+| 
+
+| xref::execution-plans/operators.adoc#query-plan-node-by-id-seek[NodeByIdSeek]
+| Reads one or more nodes by ID from the node store, specified via the function xref::functions/scalar.adoc#functions-id[id()].
+| label:yes[]
 |
+| 
 
 | xref::execution-plans/operators.adoc#query-plan-node-by-label-scan[NodeByLabelScan]
 | Fetches all nodes with a specific label from the node label index.

--- a/modules/ROOT/pages/execution-plans/operators.adoc
+++ b/modules/ROOT/pages/execution-plans/operators.adoc
@@ -1017,15 +1017,15 @@ Total database accesses: 14, total allocated memory: 184
 
 ======
 
+[[query-plan-node-by-elementid-seek]]
+== Node By ElementId Seek
+// NodeByElementIdSeek
 
-[[query-plan-node-by-id-seek]]
-== Node By Id Seek
-// NodeByIdSeek
+_This feature was introduced in Neo4j 5.3._
 
-The `NodeByIdSeek` operator reads one or more nodes by id from the node store.
+The `NodeByElementIdSeek` operator reads one or more nodes by ID from the node store, specified via the function xref::functions/scalar.adoc#functions-elementid[elementId()].
 
-
-.NodeByIdSeek
+.NodeByElementIdSeek
 ======
 
 .Query
@@ -1055,6 +1055,49 @@ Batch size 128
 | |                      +-----------------------------------+----------------+------+---------+----------------+------------------------+-----------+----------------------                        |           |                     |
 | +NodeByElementIdSeek   | n WHERE elementId(n) = $autoint_0 |              1 |    1 |       1 |            120 |                    3/0 |     2.108 | Fused in Pipeline 0 |
 +------------------------+-----------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+
+Total database accesses: 1, total allocated memory: 184
+----
+
+======
+
+[[query-plan-node-by-id-seek]]
+== Node By Id Seek
+// NodeByIdSeek
+
+The `NodeByIdSeek` operator reads one or more nodes by ID from the node store, specified via the function xref::functions/scalar.adoc#functions-id[id()].
+
+
+.NodeByIdSeek
+======
+
+.Query
+[source, cypher]
+----
+PROFILE
+MATCH (n)
+WHERE Id(n) = 0
+RETURN n
+----
+
+.Query Plan
+[role="queryplan", subs="attributes+"]
+----
+Planner COST
+
+Runtime PIPELINED
+
+Runtime version {neo4j-version-minor}
+
+Batch size 128
+
++-----------------+----+----------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| Operator        | Id | Details                    | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
++-----------------+----+----------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| +ProduceResults |  0 | n                          |              1 |    1 |       2 |                |                        |           |                     |
+| |               +----+----------------------------+----------------+------+---------+----------------+                        |           |                     |
+| +NodeByIdSeek   |  1 | n WHERE id(n) = $autoint_0 |              1 |    1 |       1 |            248 |                    2/0 |     0.257 | Fused in Pipeline 0 |
++-----------------+----+----------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
 
 Total database accesses: 1, total allocated memory: 184
 ----


### PR DESCRIPTION
Add information about `NodeByElementIdSeek` operator, and update of query plan for `NodeByIdSeek`. 

Trello: https://trello.com/c/q5lG0oIp/5012-request-update-to-https-neo4jcom-docs-cypher-manual-current-execution-plans-operator-summary-so-as-to-include-nodebyelementidsee