### PR TITLE
Update clauses page

### DIFF
--- a/modules/ROOT/pages/clauses/index.adoc
+++ b/modules/ROOT/pages/clauses/index.adoc
@@ -3,91 +3,27 @@
 [[query-clause]]
 = Clauses
 
-[abstract]
---
 This section contains information on all the clauses in the Cypher query language.
---
 
+[[reading-clauses]]
+== Reading clauses
 
-[[administration-clauses]]
-== Administration clauses
+These comprise clauses that read data from the database.
 
-These comprise clauses used to manage databases, schema and security; further details can found in xref::administration/databases.adoc[Database management] and xref::administration/access-control/index.adoc[Access control].
-
-[options="header"]
-|===
-| Clause | Description
-
-m| xref::administration/databases.adoc[CREATE \| DROP \| START \| STOP DATABASE]
-| Create, drop, start or stop a database.
-
-m| xref::indexes-for-search-performance.adoc#indexes-syntax[CREATE \| DROP INDEX]
-| Create or drop an index on all nodes with a particular label and property.
-
-m| xref::constraints/syntax.adoc[CREATE \| DROP CONSTRAINT]
-| Create or drop a constraint pertaining to either a node label or relationship type, and a property.
-
-| xref::administration/access-control/index.adoc[Access control]
-| Manage users, roles, and privileges for database, graph and sub-graph access control.
-
-|===
-
-[[configuration-commands]]
-== Configuration Commands
+The flow of data within a Cypher query is an unordered sequence of maps with key-value pairs -- a set of possible bindings between the variables in the query and values derived from the database.
+This set is refined and augmented by subsequent parts of the query.
 
 [options="header"]
 |===
 | Clause | Description
 
-m| xref:clauses/listing-settings.adoc[SHOW SETTINGS]
-| List configuration settings.
+m| xref::clauses/match.adoc[MATCH]
+| Specify the patterns to search for in the database.
+
+m| xref::clauses/optional-match.adoc[OPTIONAL MATCH]
+| Specify the patterns to search for in the database while using `nulls` for missing parts of the pattern.
 
 |===
-
-[[importing-clauses]]
-== Importing data
-
-[options="header"]
-|===
-| Clause | Description
-
-m| xref::clauses/load-csv.adoc[LOAD CSV]
-| Use when importing data from CSV files.
-
-m| xref::clauses/call-subquery.adoc#subquery-call-in-transactions[CALL { ... } IN TRANSACTIONS]
-| This clause may be used to prevent an out-of-memory error from occurring when importing large amounts of data using `LOAD CSV`.
-
-|===
-
-
-[[listing-functions-and-procedures]]
-== Listing functions and procedures
-
-[options="header"]
-|===
-| Clause | Description
-
-m| xref::clauses/listing-functions.adoc[SHOW FUNCTIONS]
-| List the available functions.
-
-m| xref::clauses/listing-procedures.adoc[SHOW PROCEDURES]
-| List the available procedures.
-
-|===
-
-
-[[multiple-graphs-clauses]]
-== Multiple graphs
-
-[options="header"]
-|===
-| Clause | Description
-
-m| xref::clauses/use.adoc[USE]
-| Determines which graph a query, or query part, is executed against. label:fabric[]
-
-|===
-
 
 [[projecting-clauses]]
 == Projecting clauses
@@ -110,53 +46,6 @@ m| xref::clauses/unwind.adoc[UNWIND ... [AS]]
 
 |===
 
-
-[[reading-clauses]]
-== Reading clauses
-
-These comprise clauses that read data from the database.
-
-The flow of data within a Cypher query is an unordered sequence of maps with key-value pairs -- a set of possible bindings between the variables in the query and values derived from the database.
-This set is refined and augmented by subsequent parts of the query.
-
-[options="header"]
-|===
-| Clause | Description
-
-m| xref::clauses/match.adoc[MATCH]
-| Specify the patterns to search for in the database.
-
-m| xref::clauses/optional-match.adoc[OPTIONAL MATCH]
-| Specify the patterns to search for in the database while using `nulls` for missing parts of the pattern.
-
-|===
-
-
-[[reading-hints]]
-== Reading hints
-
-These comprise clauses used to specify planner hints when tuning a query.
-More details regarding the usage of these -- and query tuning in general -- can be found in xref::query-tuning/using.adoc[Planner hints and the USING keyword].
-
-[options="header"]
-|===
-| Hint | Description
-
-m| xref::query-tuning/using.adoc#query-using-index-hint[USING INDEX]
-| Index hints are used to specify which index, if any, the planner should use as a starting point.
-
-m| xref::query-tuning/using.adoc#query-using-index-hint[USING INDEX SEEK]
-| Index seek hint instructs the planner to use an index seek for this clause.
-
-m| xref::query-tuning/using.adoc#query-using-scan-hint[USING SCAN]
-| Scan hints are used to force the planner to do a label scan (followed by a filtering operation) instead of using an index.
-
-m| xref::query-tuning/using.adoc#query-using-join-hint[USING JOIN]
-| Join hints are used to enforce a join operation at specified points.
-
-|===
-
-
 [[reading-sub-clauses]]
 == Reading sub-clauses
 
@@ -177,84 +66,6 @@ m| xref::clauses/skip.adoc[SKIP]
 
 m| xref::clauses/limit.adoc[LIMIT]
 | Constrains the number of rows in the output.
-
-|===
-
-
-[[reading-writing-clauses]]
-== Reading/Writing clauses
-
-These comprise clauses that both read data from and write data to the database.
-
-[options="header"]
-|===
-| Clause | Description
-
-m| xref::clauses/merge.adoc[MERGE]
-| Ensures that a pattern exists in the graph. Either the pattern already exists, or it needs to be created.
-
-m| --- xref::clauses/merge.adoc#query-merge-on-create-on-match[ON CREATE]
-| Used in conjunction with `MERGE`, this write sub-clause specifies the actions to take if the pattern needs to be created.
-
-m| --- xref::clauses/merge.adoc#query-merge-on-create-on-match[ON MATCH]
-| Used in conjunction with `MERGE`, this write sub-clause specifies the actions to take if the pattern already exists.
-
-m| xref::clauses/call.adoc[CALL ... [YIELD ... ]]
-| Invokes a procedure deployed in the database and return any results.
-
-|===
-
-
-[[set-operations-clauses]]
-== Set operations
-
-[options="header"]
-|===
-|Clause |Description
-
-m| xref::clauses/union.adoc[UNION]
-a|
-Combines the result of multiple queries into a single result set.
-Duplicates are removed.
-
-m| xref::clauses/union.adoc[UNION ALL]
-a|
-Combines the result of multiple queries into a single result set.
-Duplicates are retained.
-
-|===
-
-
-[[subquery-clauses]]
-== Subquery clauses
-
-[options="header"]
-|===
-|Clause |Description
-
-m| xref::clauses/call-subquery.adoc[CALL { ... }]
-| Evaluates a subquery, typically used for post-union processing or aggregations.
-
-m| xref::clauses/call-subquery.adoc#subquery-call-in-transactions[CALL { ... } IN TRANSACTIONS]
-a|
-Evaluates a subquery in separate transactions.
-Typically used when modifying or importing large amounts of data.
-
-|===
-
-
-[[transaction-commands]]
-== Transaction Commands
-
-[options="header"]
-|===
-| Clause | Description
-
-m| xref:clauses/transaction-clauses.adoc#query-listing-transactions[SHOW TRANSACTIONS]
-| List the available transactions.
-
-m| xref:clauses/transaction-clauses.adoc#query-terminate-transactions[TERMINATE TRANSACTIONS]
-| Terminate transactions by their IDs.
 
 |===
 
@@ -291,3 +102,196 @@ m| xref::clauses/foreach.adoc[FOREACH]
 
 |===
 
+[[reading-writing-clauses]]
+== Reading/Writing clauses
+
+These comprise clauses that both read data from and write data to the database.
+
+[options="header"]
+|===
+| Clause | Description
+
+m| xref::clauses/merge.adoc[MERGE]
+| Ensures that a pattern exists in the graph. Either the pattern already exists, or it needs to be created.
+
+m| --- xref::clauses/merge.adoc#query-merge-on-create-on-match[ON CREATE]
+| Used in conjunction with `MERGE`, this write sub-clause specifies the actions to take if the pattern needs to be created.
+
+m| --- xref::clauses/merge.adoc#query-merge-on-create-on-match[ON MATCH]
+| Used in conjunction with `MERGE`, this write sub-clause specifies the actions to take if the pattern already exists.
+
+m| xref::clauses/call.adoc[CALL ... [YIELD ... ]]
+| Invokes a procedure deployed in the database and return any results.
+
+|===
+
+[[subquery-clauses]]
+== Subquery clauses
+
+[options="header"]
+|===
+|Clause |Description
+
+m| xref::clauses/call-subquery.adoc[CALL { ... }]
+| Evaluates a subquery, typically used for post-union processing or aggregations.
+
+m| xref::clauses/call-subquery.adoc#subquery-call-in-transactions[CALL { ... } IN TRANSACTIONS]
+a|
+Evaluates a subquery in separate transactions.
+Typically used when modifying or importing large amounts of data.
+
+|===
+
+[[set-operations-clauses]]
+== Set operations
+
+[options="header"]
+|===
+|Clause |Description
+
+m| xref::clauses/union.adoc[UNION]
+a|
+Combines the result of multiple queries into a single result set.
+Duplicates are removed.
+
+m| xref::clauses/union.adoc[UNION ALL]
+a|
+Combines the result of multiple queries into a single result set.
+Duplicates are retained.
+
+|===
+
+[[multiple-graphs-clauses]]
+== Multiple graphs
+
+[options="header"]
+|===
+| Clause | Description
+
+m| xref::clauses/use.adoc[USE]
+| Determines which graph a query, or query part, is executed against. label:fabric[]
+
+|===
+
+[[importing-clauses]]
+== Importing data
+
+[options="header"]
+|===
+| Clause | Description
+
+m| xref::clauses/load-csv.adoc[LOAD CSV]
+| Use when importing data from CSV files.
+
+m| xref::clauses/call-subquery.adoc#subquery-call-in-transactions[CALL { ... } IN TRANSACTIONS]
+| This clause may be used to prevent an out-of-memory error from occurring when importing large amounts of data using `LOAD CSV`.
+
+|===
+
+[[listing-functions-and-procedures]]
+== Listing functions and procedures
+[options="header"]
+|===
+| Clause | Description
+
+m| xref::clauses/listing-functions.adoc[SHOW FUNCTIONS]
+| List the available functions.
+
+m| xref::clauses/listing-procedures.adoc[SHOW PROCEDURES]
+| List the available procedures.
+
+|===
+
+[[configuration-commands]]
+== Configuration Commands
+
+[options="header"]
+|===
+| Clause | Description
+
+m| xref:clauses/listing-settings.adoc[SHOW SETTINGS]
+| List configuration settings.
+
+|===
+
+[[transaction-commands]]
+== Transaction Commands
+
+[options="header"]
+|===
+| Clause | Description
+
+m| xref:clauses/transaction-clauses.adoc#query-listing-transactions[SHOW TRANSACTIONS]
+| List the available transactions.
+
+m| xref:clauses/transaction-clauses.adoc#query-terminate-transactions[TERMINATE TRANSACTIONS]
+| Terminate transactions by their IDs.
+
+|===
+
+
+[[reading-hints]]
+== Reading hints
+
+These comprise clauses used to specify planner hints when tuning a query.
+More details regarding the usage of these -- and query tuning in general -- can be found in xref::query-tuning/using.adoc[Planner hints and the USING keyword].
+
+[options="header"]
+|===
+| Hint | Description
+
+m| xref::query-tuning/using.adoc#query-using-index-hint[USING INDEX]
+| Index hints are used to specify which index, if any, the planner should use as a starting point.
+
+m| xref::query-tuning/using.adoc#query-using-index-hint[USING INDEX SEEK]
+| Index seek hint instructs the planner to use an index seek for this clause.
+
+m| xref::query-tuning/using.adoc#query-using-scan-hint[USING SCAN]
+| Scan hints are used to force the planner to do a label scan (followed by a filtering operation) instead of using an index.
+
+m| xref::query-tuning/using.adoc#query-using-join-hint[USING JOIN]
+| Join hints are used to enforce a join operation at specified points.
+
+|===
+
+[[index-and-constraint-clauses]]
+== Index and constraint clauses
+
+These comprise clauses to create, show, and drop indexes and constraints.
+
+[options="header"]
+|===
+| Clause | Description
+
+m| xref::indexes-for-search-performance.adoc#indexes-syntax[CREATE \| SHOW  \| DROP INDEX]
+| Create, show or drop an index.
+
+m| xref::constraints/syntax.adoc[CREATE \| SHOW \| DROP CONSTRAINT]
+| Create, show or drop a constraint.
+|===
+
+[[administration-clauses]]
+== Administration clauses
+
+These comprise clauses used to manage databases, schema and security; further details can found in xref::administration/databases.adoc[Database management] and xref::administration/access-control/index.adoc[Access control].
+
+[options="header"]
+|===
+| Clause | Description
+
+m| xref::administration/databases.adoc[CREATE \| SHOW \| START \| ALTER \| DROP \|STOP [COMPOSITE\] DATABASE]
+| Create, show, start, alter, drop or stop a standard or composite database.
+
+m| xref::administration/aliases.adoc[CREATE \| SHOW \| ALTER \| DROP ALIAS]
+| Create, show, alter or drop a local or remote database alias.
+
+m| xref::administration/servers.adoc[ENABLE \| SHOW \| RENAME \| ALTER \| DROP SERVER]
+| Enable, show, rename, alter or drop a server.
+
+m| xref::administration/servers.adoc#server-management-reallocate[REALLOCATE \| DEALLOCATE DATABASES]
+| Reallocates databases in, or deallocates databases from, a server.
+
+| xref::administration/access-control/index.adoc[Access control]
+| Manage users, roles, and privileges for database, graph and sub-graph access control.
+
+|===

--- a/modules/ROOT/pages/clauses/index.adoc
+++ b/modules/ROOT/pages/clauses/index.adoc
@@ -273,13 +273,14 @@ m| xref::constraints/syntax.adoc[CREATE \| SHOW \| DROP CONSTRAINT]
 [[administration-clauses]]
 == Administration clauses
 
-These comprise clauses used to manage databases, schema and security; further details can found in xref::administration/databases.adoc[Database management] and xref::administration/access-control/index.adoc[Access control].
+These comprise clauses used to manage databases, aliases, servers, and role-based access control. 
+More information about these topics can be found in the xref::administration/index.adoc[Administration] chapter. 
 
 [options="header"]
 |===
 | Clause | Description
 
-m| xref::administration/databases.adoc[CREATE \| SHOW \| START \| ALTER \| DROP \|STOP [COMPOSITE\] DATABASE]
+m| xref::administration/databases.adoc[CREATE \| SHOW \| START \| ALTER \| STOP \| DROP [COMPOSITE\] DATABASE]
 | Create, show, start, alter, drop or stop a standard or composite database.
 
 m| xref::administration/aliases.adoc[CREATE \| SHOW \| ALTER \| DROP ALIAS]


### PR DESCRIPTION
This PR:

- reorders the clauses on the clauses/intro page to align with the order in the rest of the chapter/Manual (e.g. administration clauses moved from first to last in the list). 
- adds new clauses where necessary (e.g. SHOW and ALTER to admin commands, ALIAS & SERVER management clauses)
- adds new section: Index & constraint clauses (previously in administration section)

Trello: https://trello.com/c/9CajbCCo/5015-missing-docs-on-admin-clauses