### PR TITLE
Add link to notification docs in privilege docs

### DIFF
--- a/modules/ROOT/pages/administration/access-control/database-administration.adoc
+++ b/modules/ROOT/pages/administration/access-control/database-administration.adoc
@@ -182,6 +182,10 @@ REVOKE [IMMUTABLE] database-privilege ON { HOME DATABASE \| DATABASE[S] { * \| n
 Use `REVOKE` if you want to remove a privilege.
 ====
 
+Common errors such as misspellings or attempting to grant privileges to roles where either does not exist will lead to notifications.
+Some of these notifications may be replaced with errors in a future major version of neo4j.
+See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Neo4j Status Codes v5 -> Notification codes] for details on Notifications.
+
 The hierarchy between the different database privileges is shown in the image below.
 
 image::privileges_hierarchy_database.svg[title="Database privileges hierarchy"]

--- a/modules/ROOT/pages/administration/access-control/database-administration.adoc
+++ b/modules/ROOT/pages/administration/access-control/database-administration.adoc
@@ -182,9 +182,9 @@ REVOKE [IMMUTABLE] database-privilege ON { HOME DATABASE \| DATABASE[S] { * \| n
 Use `REVOKE` if you want to remove a privilege.
 ====
 
-Common errors such as misspellings or attempting to revoke a privileges that have not been granted or denied will lead to notifications.
-Some of these notifications may be replaced with errors in a future major version of neo4j.
-See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Neo4j Status Codes v5 -> Notification codes] for details on Notifications.
+Common errors, such as misspellings or attempts to revoke privileges that have not been granted or denied, will lead to notifications.
+Some of these notifications may be replaced with errors in a future major version of Neo4j.
+See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Notification codes] for details on notifications.
 
 The hierarchy between the different database privileges is shown in the image below.
 

--- a/modules/ROOT/pages/administration/access-control/database-administration.adoc
+++ b/modules/ROOT/pages/administration/access-control/database-administration.adoc
@@ -182,7 +182,7 @@ REVOKE [IMMUTABLE] database-privilege ON { HOME DATABASE \| DATABASE[S] { * \| n
 Use `REVOKE` if you want to remove a privilege.
 ====
 
-Common errors such as misspellings or attempting to grant privileges to roles where either does not exist will lead to notifications.
+Common errors such as misspellings or attempting to revoke a privileges that have not been granted or denied will lead to notifications.
 Some of these notifications may be replaced with errors in a future major version of neo4j.
 See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Neo4j Status Codes v5 -> Notification codes] for details on Notifications.
 

--- a/modules/ROOT/pages/administration/access-control/manage-privileges.adoc
+++ b/modules/ROOT/pages/administration/access-control/manage-privileges.adoc
@@ -183,9 +183,9 @@ REVOKE [IMMUTABLE] graph-privilege ON { HOME GRAPH \| GRAPH[S] { * \| name[, ...
 Use `REVOKE` if you want to remove a privilege.
 ====
 
-Common errors such as misspellings or attempting to revoke privileges that have not been granted or denied will result in notifications.
-Some of these notifications may be replaced with errors in a future major version of neo4j.
-See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Neo4j Status Codes v5 -> Notification codes] for details on Notifications.
+Common errors, such as misspellings or attempts to revoke privileges that have not been granted or denied, will result in notifications.
+Some of these notifications may be replaced with errors in a future major version of Neo4j.
+See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Notification codes] for details on notifications.
 
 The general `GRANT` and `DENY` syntaxes are illustrated in the following image:
 

--- a/modules/ROOT/pages/administration/access-control/manage-privileges.adoc
+++ b/modules/ROOT/pages/administration/access-control/manage-privileges.adoc
@@ -183,6 +183,10 @@ REVOKE [IMMUTABLE] graph-privilege ON { HOME GRAPH \| GRAPH[S] { * \| name[, ...
 Use `REVOKE` if you want to remove a privilege.
 ====
 
+Common errors such as misspellings or attempting to revoke privileges that have not been granted or denied will result in notifications.
+Some of these notifications may be replaced with errors in a future major version of neo4j.
+See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Neo4j Status Codes v5 -> Notification codes] for details on Notifications.
+
 The general `GRANT` and `DENY` syntaxes are illustrated in the following image:
 
 image::privileges_grant_and_deny_syntax.svg[title="GRANT and DENY Syntax"]

--- a/modules/ROOT/pages/administration/access-control/manage-roles.adoc
+++ b/modules/ROOT/pages/administration/access-control/manage-roles.adoc
@@ -706,6 +706,9 @@ SHOW USERS
 5+a|Rows: 5
 |===
 
+Common errors such as misspellings or attempting to grant roles to users where either does not exist will lead to notifications.
+Some of these notifications may be replaced with errors in a future Major version of neo4j.
+See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Neo4j Status Codes v5 -> Notification codes] for details on Notifications.
 
 [[access-control-revoke-roles]]
 == Revoking roles from users
@@ -773,6 +776,9 @@ It is possible to revoke multiple roles from multiple users in one command:
 REVOKE ROLES role1, role2 FROM user1, user2, user3
 ----
 
+Common errors such as misspellings or attempting to revoke roles from users who have not been granted the role will lead to notifications.
+Some of these notifications may be replaced with errors in a future major version of neo4j.
+See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Neo4j Status Codes v5 -> Notification codes] for details on Notifications.
 
 [[access-control-drop-roles]]
 == Deleting roles

--- a/modules/ROOT/pages/administration/access-control/manage-roles.adoc
+++ b/modules/ROOT/pages/administration/access-control/manage-roles.adoc
@@ -706,7 +706,7 @@ SHOW USERS
 5+a|Rows: 5
 |===
 
-Common errors such as misspellings or attempting to grant roles to users who already have the role will lead to notifications.
+Common errors such as attempting to grant roles to users who already have the role will lead to notifications.
 Some of these notifications may be replaced with errors in a future Major version of neo4j.
 See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Neo4j Status Codes v5 -> Notification codes] for details on Notifications.
 

--- a/modules/ROOT/pages/administration/access-control/manage-roles.adoc
+++ b/modules/ROOT/pages/administration/access-control/manage-roles.adoc
@@ -706,7 +706,7 @@ SHOW USERS
 5+a|Rows: 5
 |===
 
-Common errors such as attempting to grant roles to users who already have the role will lead to notifications.
+Common errors, such as attempts to grant roles to users who have already been granted those roles, will lead to notifications.
 Some of these notifications may be replaced with errors in a future major version of Neo4j.
 See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Notification codes] for details on notifications.
 

--- a/modules/ROOT/pages/administration/access-control/manage-roles.adoc
+++ b/modules/ROOT/pages/administration/access-control/manage-roles.adoc
@@ -706,7 +706,7 @@ SHOW USERS
 5+a|Rows: 5
 |===
 
-Common errors such as misspellings or attempting to grant roles to users where either does not exist will lead to notifications.
+Common errors such as misspellings or attempting to grant roles to users who already have the role will lead to notifications.
 Some of these notifications may be replaced with errors in a future Major version of neo4j.
 See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Neo4j Status Codes v5 -> Notification codes] for details on Notifications.
 

--- a/modules/ROOT/pages/administration/access-control/manage-roles.adoc
+++ b/modules/ROOT/pages/administration/access-control/manage-roles.adoc
@@ -707,8 +707,8 @@ SHOW USERS
 |===
 
 Common errors such as attempting to grant roles to users who already have the role will lead to notifications.
-Some of these notifications may be replaced with errors in a future Major version of neo4j.
-See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Neo4j Status Codes v5 -> Notification codes] for details on Notifications.
+Some of these notifications may be replaced with errors in a future major version of Neo4j.
+See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Notification codes] for details on notifications.
 
 [[access-control-revoke-roles]]
 == Revoking roles from users
@@ -776,9 +776,9 @@ It is possible to revoke multiple roles from multiple users in one command:
 REVOKE ROLES role1, role2 FROM user1, user2, user3
 ----
 
-Common errors such as misspellings or attempting to revoke roles from users who have not been granted the role will lead to notifications.
-Some of these notifications may be replaced with errors in a future major version of neo4j.
-See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Neo4j Status Codes v5 -> Notification codes] for details on Notifications.
+Common errors, such as misspellings or attempts to revoke roles from users who have not been granted those roles, will lead to notifications.
+Some of these notifications may be replaced with errors in a future major version of Neo4j.
+See link:{neo4j-docs-base-uri}/status-codes/{page-version}/notifications/all-notifications[Status Codes -> Notification codes] for details on notifications.
 
 [[access-control-drop-roles]]
 == Deleting roles


### PR DESCRIPTION
Adds short references to GRANT/DENY/REVOKE ROLES/PRIVILEGES about them returning notifications. Mostly just links to the notification docs.