### PR TITLE
Update unwind.adoc

### DIFF
--- a/modules/ROOT/pages/clauses/unwind.adoc
+++ b/modules/ROOT/pages/clauses/unwind.adoc
@@ -145,7 +145,7 @@ This has value in cases such as `UNWIND v`, where `v` is a variable from an earl
 [source, cypher, indent=0]
 ----
 UNWIND [] AS empty
-RETURN empty, 'literal_that_is_not_returned'
+RETURN 'literal_that_is_not_returned'
 ----
 
 .Result


### PR DESCRIPTION
Better illustration that `UNWIND [] AS empty` stops executing the query...

Because `empty` is also part of the RETURN statement, it could be falsely assumed that that is the reason why the query returns an empty list.