### PR TITLE
Fix formatting on constraints main page

### DIFF
--- a/modules/ROOT/pages/constraints/index.adoc
+++ b/modules/ROOT/pages/constraints/index.adoc
@@ -18,9 +18,7 @@ Unique node property constraints, or node property uniqueness constraints, ensur
 For property uniqueness constraints on multiple properties, the combination of the property values is unique.
 Node property uniqueness constraints do not require all nodes to have a unique value for the properties listed (nodes without all properties on which the constraint exists are not subject to this rule).
 
-*Unique relationship property constraints*::
-_This feature was introduced in Neo4j 5.7._
-+
+*Unique relationship property constraints* label:new[Introduced in 5.7]::
 Unique relationship property constraints, or relationship property uniqueness constraints, ensure that property values are unique for all relationships with a specific type.
 For property uniqueness constraints on multiple properties, the combination of the property values is unique.
 Relationship property uniqueness constraints do not require all relationships to have a unique value for the properties listed (relationships without all properties on which the constraint exists are not subject to this rule).
@@ -35,16 +33,12 @@ Relationship property existence constraints ensure that a property exists for al
 All queries that try to create relationships of the specified type, but without this property, will fail.
 The same is true for queries that try to remove the mandatory property.
 
-*Node property type constraints* label:enterprise-edition[]::
-_This feature was introduced in Neo4j 5.9._
-+
+*Node property type constraints* label:new[Introduced in 5.9] label:enterprise-edition[]::
 Node property type constraints ensure that a property have the required property type for all nodes with a specific label.
 Queries that try to add or modify this property to nodes of the specified label, but with a different property type, will fail.
 Node property type constraints do not require all nodes to have the property (nodes without the property on which the constraint exists are not subject to this rule).
 
-*Relationship property type constraints* label:enterprise-edition[]::
-_This feature was introduced in Neo4j 5.9._
-+
+*Relationship property type constraints* label:new[Introduced in 5.9] label:enterprise-edition[]::
 Relationship property type constraints ensure that a property have the required property type for all relationships with a specific type.
 Queries that try to add or modify this property to relationships of the specified type, but with a different property type, will fail.
 Relationship property type constraints do not require all relationships to have the property (relationships without the property on which the constraint exists are not subject to this rule).
@@ -63,9 +57,7 @@ Queries attempting to do any of the following will fail:
 * Remove one of the mandatory properties.
 * Update the properties so that the combination of property values is no longer unique.
 
-*Relationship key constraints* label:enterprise-edition[]::
-_This feature was introduced in Neo4j 5.7._
-+
+*Relationship key constraints* label:new[Introduced in 5.7] label:enterprise-edition[]::
 Relationship key constraints ensure that, for a given type and set of properties:
 +
 [lowerroman]


### PR DESCRIPTION
There currently is an error on the main page of the Constraints page. 
<img width="866" alt="Screenshot 2023-06-15 at 14 29 16" src="https://github.com/neo4j/docs-cypher/assets/112686610/b9b85361-cb3b-451f-bfed-d5b9fe395ec8">

It is caused by the `+` in following example, but I do not know why: 

```
*Node property type constraints* label:enterprise-edition[]::
_This feature was introduced in Neo4j 5.9._
+
Node property type constraints
```

This PR suggests to replace the inline notice of minor release with a label. 

