### PR TITLE
Add example of list syntax to server management commands

### DIFF
--- a/modules/ROOT/pages/administration/servers.adoc
+++ b/modules/ROOT/pages/administration/servers.adoc
@@ -311,17 +311,17 @@ The possible options allowed when enabling a server are:
 `None` means there is no constraint and any mode is allowed.
 
 | allowedDatabases
-| list of database names
+| list of database names, e.g. `["db1", "db2"]`
 | Only databases matching the specified names may be hosted on the server.
 This may not be specified in combination with `deniedDatabases`.
 
 | deniedDatabases
-| list of database names
+| list of database names, e.g. `["db1", "db2"]`
 | Only databases **not** matching the specified names may be hosted on the server.
 This may not be specified in combination with `allowedDatabases`.
 
 | tags
-| list of server tags
+| list of server tags, e.g. `["tag1", "tag2"]`
 | List of server tags used during database allocation and for load balancing and routing policies. 
 label:new[Introduced in 5.6]
 |===
@@ -358,17 +358,17 @@ The possible options allowed when altering a server are:
 `None` means there is no constraint and any mode is allowed.
 
 | allowedDatabases
-| list of database names
+| list of database names, e.g. `["db1", "db2"]`
 | Only databases matching the specified names may be hosted on the server.
 This may not be specified in combination with `deniedDatabases`.
 
 | deniedDatabases
-| list of database names
+| list of database names, e.g. `["db1", "db2"]`
 | Only databases **not** matching the specified names may be hosted on the server.
 This may not be specified in combination with `allowedDatabases`.
 
 | tags
-| list of server tags
+| list of server tags, e.g. `["tag1", "tag2"]`
 | List of server tags used during database allocation and for load balancing and routing policies. 
 label:new[Introduced in 5.6]
 |===


### PR DESCRIPTION
Had a user try to use the SET OPTIONS { tags:foo,bar,baz }, so being a little more helpful in description.
Cherry-picked from #631 