### PR TITLE
Type predicate expressions iteration 2

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -16,6 +16,51 @@ New features are added to the language continuously, and occasionally, some feat
 This section lists all of the features that have been removed, deprecated, added, or extended in different Cypher versions.
 Replacement syntax for deprecated and removed features are also indicated.
 
+[[cypher-deprecations-additions-removals-5.10]]
+== Version 5.10
+
+===  Updated features
+
+a|
+label:functionality[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+IS [NOT] :: <TYPE>
+----
+a|
+
+Added xref:syntax/expressions.adoc#type-predicate-expressions[type predicate expressions].
+The newly supported types are:
+
+* `NOTHING`
+* `NULL`
+* `BOOLEAN NOT NULL`
+* `STRING NOT NULL`
+* `INTEGER NOT NULL`
+* `FLOAT NOT NULL`
+* `DATE NOT NULL`
+* `LOCAL TIME NOT NULL`
+* `ZONED TIME NOT NULL`
+* `LOCAL DATETIME NOT NULL`
+* `ZONED DATETIME NOT NULL`
+* `DURATION NOT NULL`
+* `POINT NOT NULL`
+* `NODE`
+* `NODE NOT NULL`
+* `RELATIONSHIP`
+* `RELATIONSHIP NOT NULL`
+* `MAP`
+* `MAP NOT NULL`
+* `LIST<TYPE>`
+* `LIST<TYPE> NOT NULL`
+* `PATH`
+* `PATH NOT NULL`
+* `PROPERTY VALUE`
+* `PROPERTY VALUE NOT NULL`
+* `ANY`
+* `ANY NOT NULL`
+
 [[cypher-deprecations-additions-removals-5.9]]
 == Version 5.9
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -30,7 +30,7 @@ IS [NOT] :: <TYPE>
 ----
 a|
 
-Added xref:syntax/expressions.adoc#type-predicate-expressions[type predicate expressions].
+Extended xref:syntax/expressions.adoc#type-predicate-expressions[type predicate expressions].
 The newly supported types are:
 
 * `NOTHING`

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -21,6 +21,11 @@ Replacement syntax for deprecated and removed features are also indicated.
 
 ===  Updated features
 
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
 a|
 label:functionality[]
 label:updated[]
@@ -60,6 +65,8 @@ The newly supported types are:
 * `PROPERTY VALUE NOT NULL`
 * `ANY`
 * `ANY NOT NULL`
+
+|===
 
 [[cypher-deprecations-additions-removals-5.9]]
 == Version 5.9

--- a/modules/ROOT/pages/syntax/expressions.adoc
+++ b/modules/ROOT/pages/syntax/expressions.adoc
@@ -147,7 +147,6 @@ END
 |===
 
 
-.Query
 [source, cypher]
 ----
 MATCH (n)
@@ -159,7 +158,6 @@ CASE n.eyes
 END AS result
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +result+
@@ -204,7 +202,6 @@ END
 | If no match is found, `default` is returned.
 |===
 
-.Query
 [source, cypher]
 ----
 MATCH (n)
@@ -216,7 +213,6 @@ CASE
 END AS result
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +result+
@@ -235,7 +231,6 @@ END AS result
 Owing to the close similarity between the syntax of the two forms, sometimes it may not be clear at the outset as to which form to use.
 We illustrate this scenario by means of the following query, in which there is an expectation that `age_10_years_ago` is `-1` if `n.age` is `null`:
 
-.Query
 [source, cypher]
 ----
 MATCH (n)
@@ -251,7 +246,6 @@ This is because a comparison is made between `n.age` and `n.age IS NULL`.
 As `n.age IS NULL` is a boolean value, and `n.age` is an integer value, the `WHEN n.age IS NULL THEN -1` branch is never taken.
 This results in the `ELSE n.age - 10` branch being taken instead, returning `null`.
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +n.name+ | +age_10_years_ago+
@@ -265,7 +259,6 @@ This results in the `ELSE n.age - 10` branch being taken instead, returning `nul
 
 The corrected query, behaving as expected, is given by the following generic `CASE` form:
 
-.Query
 [source, cypher]
 ----
 MATCH (n)
@@ -278,7 +271,6 @@ END AS age_10_years_ago
 
 We now see that the `age_10_years_ago` correctly returns `-1` for the node named `Daniel`.
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +n.name+ | +age_10_years_ago+
@@ -298,7 +290,6 @@ You can use the result of `CASE` to set properties on a node or relationship.
 For example, instead of specifying the node directly, you can set a property for a node selected by an expression:
 
 
-.Query
 [source, cypher]
 ----
 MATCH (n)
@@ -313,7 +304,6 @@ SET n.colourCode = colourCode
 
 For more information about using the `SET` clause, see xref::clauses/set.adoc[SET].
 
-.Result
 [role="queryresult",options="footer",cols="1*<m"]
 |===
 1+|(empty result)
@@ -333,7 +323,6 @@ When using the simple `CASE` form, it is useful to remember that in Cypher `null
 
 For example, you might expect `age_10_years_ago` to be `-1` for the node named `Daniel`:
 
-.Query
 [source, cypher]
 ----
 MATCH (n)
@@ -346,7 +335,6 @@ END AS age_10_years_ago
 
 However, as `null = null` does not yield `true`, the `WHEN null THEN -1` branch is never taken, resulting in the `ELSE n.age - 10` branch being taken instead, returning `null`.
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +n.name+ | +age_10_years_ago+
@@ -412,7 +400,6 @@ In this regard, `EXISTS` subqueries are different from `CALL` subqueries, xref::
 The following example shows this:
 
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -422,7 +409,6 @@ WHERE EXISTS {
 RETURN person.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -437,8 +423,6 @@ RETURN person.name AS name
 A `WHERE` clause can be used in conjunction to the `MATCH`.
 Variables introduced by the `MATCH` clause and the outside scope can be used in this scope.
 
-
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -449,7 +433,6 @@ WHERE EXISTS {
 RETURN person.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -466,7 +449,6 @@ The nesting also affects the scopes.
 That means that it is possible to access all variables from inside the subquery which are either from the outside scope or defined in the very same subquery.
 
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -480,7 +462,6 @@ WHERE EXISTS {
 RETURN person.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -495,7 +476,6 @@ RETURN person.name AS name
 Here the result is a boolean that shows whether the subquery can find the given pattern.
 
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -504,7 +484,6 @@ RETURN person.name AS name, EXISTS {
 } AS hasDog
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +name+ | +hasDog+
@@ -524,7 +503,6 @@ _This feature was introduced in Neo4j 5.3._
 It is worth noting that if one branch has a `RETURN` clause, then all branches require one.
 The below example demonstrates that if one of the `UNION` branches was to return at least one row, the entire `EXISTS` expression will evaluate to true.
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -537,7 +515,6 @@ RETURN
     } AS hasPet
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +name+        | +hasPet+
@@ -558,7 +535,6 @@ To avoid confusion, shadowing of these variables is not allowed.
 An outside scope variable is shadowed when a newly introduced variable within the inner scope is defined with the same variable.
 In the example below, the outer variable `name` is shadowed and will therefore throw an error.
 
-.Query
 [source, cypher, role=test-fail]
 ----
 WITH 'Peter' as name
@@ -581,7 +557,6 @@ New variables can be introduced into the subquery, as long as they use a differe
 In the example below, a `WITH` clause introduces a new variable.
 Note that the outer scope variable `person` referenced in the main query is still available after the `WITH` clause.
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -593,7 +568,6 @@ WHERE EXISTS {
 RETURN person.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -611,7 +585,6 @@ _This feature was introduced in Neo4j 5.3._
 need to be aliased, which is different compared to xref::clauses/call-subquery.adoc[`CALL` subqueries].
 Any variables returned in an `EXISTS` subquery will not be available after the subquery.
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -622,7 +595,6 @@ WHERE EXISTS {
 RETURN person.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -651,7 +623,6 @@ In this regard, `COUNT` subqueries are different from `CALL` subqueries, xref::c
 The following query exemplifies this and outputs the owners of more than one dog:
 
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -659,7 +630,6 @@ WHERE COUNT { (person)-[:HAS_DOG]->(:Dog) } > 1
 RETURN person.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -675,7 +645,6 @@ A `WHERE` clause can be used inside the `COUNT` pattern.
 Variables introduced by the `MATCH` clause and the outside scope can be used in this scope.
 
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -686,7 +655,6 @@ WHERE COUNT {
 RETURN person.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -703,7 +671,6 @@ _This feature was introduced in Neo4j 5.3._
 `UNION ALL` clauses do not require the `RETURN` clause. However, it is worth noting that if one branch has a `RETURN` clause, then all require one.
 The below example shows the count of pets each person has by using a `UNION` clause:
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -718,7 +685,6 @@ RETURN
     } AS numPets
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +name+        | +numPets+
@@ -739,7 +705,6 @@ To avoid confusion, shadowing of these variables is not allowed.
 An outside scope variable is shadowed when a newly introduced variable within the inner scope is defined with the same variable.
 In the example below, the outer variable `name` is shadowed and will therefore throw an error.
 
-.Query
 [source, cypher, role=test-fail]
 ----
 WITH 'Peter' as name
@@ -762,7 +727,6 @@ New variables can be introduced into the subquery, as long as they use a differe
 In the example below, a `WITH` clause introduces a new variable.
 Note that the outer scope variable `person` referenced in the main query is still available after the `WITH` clause.
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -774,7 +738,6 @@ WHERE COUNT {
 RETURN person.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -793,7 +756,6 @@ See a few examples below:
 ===== Using `COUNT` in `RETURN`
 
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -801,7 +763,6 @@ RETURN person.name, COUNT { (person)-[:HAS_DOG]->(:Dog) } as howManyDogs
 
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +person.name+ | +howManyDogs+
@@ -816,7 +777,6 @@ RETURN person.name, COUNT { (person)-[:HAS_DOG]->(:Dog) } as howManyDogs
 ===== Using `COUNT` in `SET`
 
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person) WHERE person.name ="Andy"
@@ -825,7 +785,6 @@ RETURN person.howManyDogs as howManyDogs
 
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +howManyDogs+
@@ -839,7 +798,6 @@ Properties set: 1
 ===== Using `COUNT` in `CASE`
 
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -851,7 +809,6 @@ RETURN
 
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +result+
@@ -869,7 +826,6 @@ The following query groups all persons by how many dogs they own,
 and then calculates the average age for each group.
 
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -879,7 +835,6 @@ RETURN COUNT { (person)-[:HAS_DOG]->(:Dog) } AS numDogs,
 
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +numDogs+ | +averageAge+
@@ -899,7 +854,6 @@ _This feature was introduced in Neo4j 5.3._
 This is a difference compared to from xref::clauses/call-subquery.adoc[`CALL` subqueries].
 Any variables returned in a `COUNT` subquery will not be available after the subquery.
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -910,7 +864,6 @@ WHERE COUNT {
 RETURN person.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -937,7 +890,6 @@ Variables introduced by the outside scope can be used in the `COLLECT` subquery 
 In this regard, `COLLECT` subqueries are different from `CALL` subqueries, xref::clauses/call-subquery.adoc#subquery-correlated-importing[which do require importing].
 The following query exemplifies this and outputs the owners of the dog named `Ozzy`:
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -945,7 +897,6 @@ WHERE 'Ozzy' IN COLLECT { MATCH (person)-[:HAS_DOG]->(dog:Dog) RETURN dog.name }
 RETURN person.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -960,7 +911,6 @@ RETURN person.name AS name
 A `WHERE` clause can be used inside the `COLLECT` pattern.
 Variables introduced by the `MATCH` clause and the outside scope can be used in the inner scope.
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -971,7 +921,6 @@ RETURN person.name as name, COLLECT {
 } as youngDogs
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +name+        | +youngDogs+
@@ -988,7 +937,6 @@ RETURN person.name as name, COLLECT {
 `COLLECT` can be used with a `UNION` clause.
 The below example shows the collection of pet names each person has by using a `UNION` clause:
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -1003,7 +951,6 @@ RETURN
     } AS petNames
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +name+        | +petNames+
@@ -1022,7 +969,6 @@ To avoid confusion, shadowing of these variables is not allowed.
 An outside scope variable is shadowed when a newly introduced variable within the inner scope is defined with the same variable.
 In the example below, the outer variable `name` is shadowed and will therefore throw an error.
 
-.Query
 [source, cypher, role=test-fail]
 ----
 WITH 'Peter' as name
@@ -1044,7 +990,6 @@ New variables can be introduced into the subquery, as long as they use a differe
 In the example below, a `WITH` clause introduces a new variable.
 Note that the outer scope variable `person` referenced in the main query is still available after the `WITH` clause.
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -1056,7 +1001,6 @@ RETURN person.name AS name, COLLECT {
 } as dogsOfTheYear
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +name+        | +dogsOfTheYear+
@@ -1077,7 +1021,6 @@ See a few examples below of how `COLLECT` can be used in different positions wit
 [[collect-subqueries-with-return]]
 ===== Using `COLLECT` in `RETURN`
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -1089,7 +1032,6 @@ RETURN person.name,
        } as toyNames
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +person.name+ | +toyNames+
@@ -1103,7 +1045,6 @@ RETURN person.name,
 [[collect-subqueries-with-set]]
 ===== Using `COLLECT` in `SET`
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person) WHERE person.name = "Peter"
@@ -1111,7 +1052,6 @@ SET person.dogNames = COLLECT { MATCH (person)-[:HAS_DOG]->(d:Dog) RETURN d.name
 RETURN person.dogNames as dogNames
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +dogNames+
@@ -1124,7 +1064,6 @@ Properties set: 1
 [[collect-subqueries-with-case]]
 ===== Using `COLLECT` in `CASE`
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -1135,7 +1074,6 @@ RETURN
    END AS result
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +result+
@@ -1152,7 +1090,6 @@ RETURN
 The following query collects all persons by their dogs' names,
 and then calculates the average age for each group.
 
-.Query
 [source, cypher]
 ----
 MATCH (person:Person)
@@ -1161,7 +1098,6 @@ RETURN COLLECT { MATCH (person)-[:HAS_DOG]->(d:Dog) RETURN d.name } AS dogNames,
  ORDER BY dogNames
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | +dogNames+         | +averageAge+
@@ -1182,14 +1118,12 @@ However, they can be removed by adding a filtering step in the subquery.
 
 The following queries illustrate these differences:
 
-.Query
 [source, cypher]
 ----
 MATCH (p:Person)
 RETURN collect(p.nickname) AS names
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +names+
@@ -1197,7 +1131,6 @@ RETURN collect(p.nickname) AS names
 1+d|Rows: 1
 |===
 
-.Query
 [source, cypher]
 ----
 RETURN COLLECT {
@@ -1206,7 +1139,6 @@ RETURN COLLECT {
       } AS names
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +names+
@@ -1214,7 +1146,6 @@ RETURN COLLECT {
 1+d|Rows: 1
 |===
 
-.Query
 [source, cypher]
 ----
 RETURN COLLECT {
@@ -1224,7 +1155,6 @@ RETURN COLLECT {
       } AS names
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -1248,14 +1178,12 @@ Where `<expr>` is any Cypher expression and `<TYPE>` is a Cypher Type.
 
 For all available Cypher types, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
 
-.Query
 [source, cypher]
 ----
 UNWIND [42, true, 'abc'] AS val
 RETURN val, val IS :: INTEGER AS isInteger
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | val | isInteger
@@ -1270,14 +1198,12 @@ RETURN val, val IS :: INTEGER AS isInteger
 
 It is also possible to verify that a Cypher expression is not of a certain type, using the negated type predicate expression `IS NOT ::`.
 
-.Query
 [source, cypher]
 ----
 UNWIND [42, true, 'abc'] AS val
 RETURN val, val IS NOT :: STRING AS notString
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | val | notString
@@ -1293,14 +1219,12 @@ RETURN val, val IS NOT :: STRING AS notString
 A Cypher type includes the `null` value unless it is explicitly appended with `NOT NULL`.
 Therefore, `IS ::` returns `true` for all expressions evaluating to `null`, unless they explicitly remove it.
 
-.Query
 [source, cypher]
 ----
 WITH toFloat(null) AS nullValue
 RETURN nullValue IS :: BOOLEAN AS isBoolean, nullValue IS :: BOOLEAN NOT NULL AS isNotNullBoolean
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | isBoolean | isNotNullBoolean
@@ -1310,14 +1234,12 @@ RETURN nullValue IS :: BOOLEAN AS isBoolean, nullValue IS :: BOOLEAN NOT NULL AS
 
 Likewise, `IS NOT ::` returns `false` for all expressions evaluating to `null`, unless the type is appended with `NOT NULL`.
 
-.Query
 [source, cypher]
 ----
 WITH (null + 1) AS nullValue
 RETURN nullValue IS NOT :: DATE AS isNotDate, nullValue IS NOT :: DATE NOT NULL AS isNotNotNullDate
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | isNotDate | isNotNotNullDate
@@ -1327,14 +1249,12 @@ RETURN nullValue IS NOT :: DATE AS isNotDate, nullValue IS NOT :: DATE NOT NULL 
 
 It is also possible to check whether a value is only the `null` value using the `NULL` type.
 
-.Query
 [source, cypher]
 ----
 WITH toFloat(null) AS nullValue
 RETURN nullValue IS :: NULL AS isNull
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | isNull
@@ -1363,7 +1283,6 @@ image:graph_expression_type_predicate.svg[]
 
 The following query finds all `Person` nodes with an `age` property that is an `INTEGER` with a greater value than `18`.
 
-.Query
 [source, cypher]
 ----
 MATCH (n:Person)
@@ -1371,7 +1290,6 @@ WHERE n.age IS :: INTEGER AND n.age > 18
 RETURN n.name AS name, n.age AS age
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | name | age
@@ -1390,13 +1308,11 @@ Cypher will therefore regard any exact numerical parameter as an `INTEGER` regar
 For example, an `INT16` or an `INT32` passed through from a client programming language will both be treated by Cypher as an `INTEGER`.
 Note that any exact numerical parameter used must fit within the range of an `INT 64`. 
 
-.Query
 [source, cypher, role=test-skip]
 ----
 RETURN $int16param IS :: INTEGER AS isInteger
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | isInteger
@@ -1434,13 +1350,11 @@ For verifying that an expression is not of a certain type, the following alterna
 The `ANY` type is a supertype which matches values of all types.
 The `NOTHING` type is however the type containing an empty set of values. This means that it will return `false` for all values.
 
-.Query
 [source, cypher]
 ----
 RETURN 42 IS :: ANY AS isOfTypeAny, 42 IS :: NOTHING AS isOfTypeNothing
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | isOfTypeAny | isOfTypeNothing
@@ -1456,14 +1370,12 @@ If the inner type is not relevant, then the `ANY` type may be used.
 
 For a `LIST` type check to return `true`, all values in the list must match the inner type.
 
-.Query
 [source, cypher]
 ----
 UNWIND [[42], [42, null], [42, 42.0]] as val
 RETURN val, val IS :: LIST<INTEGER> AS isIntList
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | val         | isIntList
@@ -1475,7 +1387,6 @@ RETURN val, val IS :: LIST<INTEGER> AS isIntList
 
 An empty list will match on all inner types, even the `NOTHING` type.
 
-.Query
 [source, cypher]
 ----
 RETURN
@@ -1484,7 +1395,6 @@ RETURN
     [] IS :: LIST<FLOAT NOT NULL> AS isFloatNotNullList
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="3*<m"]
 |===
 | isNothingList | isIntList | isFloatNotNullList
@@ -1762,14 +1672,12 @@ A node pattern without a label expression returns all nodes in the graph, includ
 .+Label expression+
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH (n)
 RETURN n.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -1797,14 +1705,12 @@ A node pattern with a single label returns the nodes that contain the specified 
 .+Label expression+
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH (n:A)
 RETURN n.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -1828,14 +1734,12 @@ A node pattern with an `AND` expression for the node label returns the nodes tha
 .+Label expression+
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH (n:A&B)
 RETURN n.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -1857,14 +1761,12 @@ A match with `OR` expressions for the node label returns the nodes that contain 
 .+Label expression+
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH (n:A|B)
 RETURN n.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -1890,14 +1792,12 @@ A node pattern with a `NOT` expression for the node label returns the nodes that
 .+Label expression+
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH (n:!A)
 RETURN n.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -1921,14 +1821,12 @@ A node pattern with a `Wildcard` expression for the node label returns all the n
 .+Label expression+
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH (n:%)
 RETURN n.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -1955,14 +1853,12 @@ A node pattern with nested label expressions returns the nodes for which the ful
 .+Label expression+
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH (n:(!A&!B)|C)
 RETURN n.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -1987,7 +1883,6 @@ A label expression can also be used as a predicate in the `WHERE` clause.
 .+Label expression+
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH (n)
@@ -1995,7 +1890,6 @@ WHERE n:A|B
 RETURN n.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -2021,14 +1915,12 @@ A label expression can also be used in a `WITH` or a `RETURN` clause.
 .+Label expression+
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH (n)
 RETURN n:A&B
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +n:A&B+
@@ -2184,14 +2076,12 @@ A relationship pattern without a relationship type expression returns all relati
 .Relationship type expressions
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH ()-[r]->()
 RETURN r.name as name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -2214,14 +2104,12 @@ A relationship pattern with a single relationship type returns the relationships
 .Relationship type expression
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH ()-[r:R1]->()
 RETURN r.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -2242,14 +2130,12 @@ A relationship pattern with an `OR` expression for the relationship type returns
 .Relationship type expression
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH ()-[r:R1|R2]->()
 RETURN r.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -2271,14 +2157,12 @@ A relationship pattern with a `NOT` expression for the relationship type returns
 .Relationship type expression
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH ()-[r:!R1]->()
 RETURN r.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -2300,14 +2184,12 @@ A relationship pattern with a nested relationship type expression returns all re
 .Relationship type expression
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH ()-[r:(!R1&!R2)|R3]->()
 RETURN r.name as name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -2328,7 +2210,6 @@ A relationship type expression can also be used as a predicate in the `WHERE` cl
 .Relationship type expression
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH (n)-[r]->(m)
@@ -2336,7 +2217,6 @@ WHERE r:R1|R2
 RETURN r.name AS name
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +name+
@@ -2358,14 +2238,12 @@ A relationship type expression can also be used in the `WITH` or `RETURN` clause
 .Relationship type expression
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH (n)-[r]->(m)
 RETURN r:R1|R2 AS result
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +result+
@@ -2388,7 +2266,6 @@ A relationship type expression and a label expression can also be used in `CASE`
 .Relationship type expression
 ======
 
-.Query
 [source, cypher]
 ----
 MATCH (n)-[r]->(m)
@@ -2400,7 +2277,6 @@ CASE
 END AS result
 ----
 
-.Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
 | +result+

--- a/modules/ROOT/pages/syntax/expressions.adoc
+++ b/modules/ROOT/pages/syntax/expressions.adoc
@@ -1165,7 +1165,7 @@ RETURN COLLECT {
 [[type-predicate-expressions]]
 == Type predicate expressions
 
-_This feature was introduced in Neo4j 5.9 and extended in 5.10_
+_This feature was introduced in Neo4j 5.9._
 
 A type predicate expression can be used to verify the type of a variable, literal, property or other Cypher expression.
 
@@ -1215,7 +1215,7 @@ RETURN val, val IS NOT :: STRING AS notString
 [[type-predicate-expressions-null]]
 === Type predicate expressions for null
 
-A Cypher type includes the `null` value unless it is explicitly appended with `NOT NULL`.
+As of Neo4j 5.10, a Cypher type includes the `null` value unless it is explicitly appended with `NOT NULL`.
 Therefore, `IS ::` returns `true` for all expressions evaluating to `null`, unless they explicitly remove it.
 
 [source, cypher]
@@ -1246,7 +1246,7 @@ RETURN nullValue IS NOT :: DATE AS isNotDate, nullValue IS NOT :: DATE NOT NULL 
 2+d|Rows: 1
 |===
 
-It is also possible to check whether a value is only the `null` value using the `NULL` type.
+It is also possible to check whether a value is the only `null` value using the `NULL` type.
 
 [source, cypher]
 ----
@@ -1346,8 +1346,11 @@ For verifying that an expression is not of a certain type, the following alterna
 [[type-predicate-expressions-any-and-nothing]]
 === Use of `ANY` and `NOTHING` types
 
-The `ANY` type is a supertype which matches values of all types.
-On the other hand, the `NOTHING` type is the type containing an empty set of values. This means that it returns `false` for all values.
+_This feature was introduced in Neo4j 5.10._
+
+`ANY` is a supertype which matches values of all types.
+`NOTHING` is a type containing an empty set of values.
+This means that it returns `false` for all values.
 
 [source, cypher]
 ----
@@ -1364,7 +1367,9 @@ RETURN 42 IS :: ANY AS isOfTypeAny, 42 IS :: NOTHING AS isOfTypeNothing
 [[type-predicate-expressions-lists]]
 === List Types
 
-Type predicate expressions can be used for `LIST` types, where the inner type of the list must be specified.
+_This feature was introduced in Neo4j 5.10._
+
+Type predicate expressions can be used for `LIST` types, where the inner type of the elements in the list must be specified.
 If the inner type is not relevant, then the `ANY` type may be used.
 
 For a `LIST` type check to return `true`, all values in the list must match the inner type.

--- a/modules/ROOT/pages/syntax/expressions.adoc
+++ b/modules/ROOT/pages/syntax/expressions.adoc
@@ -1244,29 +1244,7 @@ A type predicate expression can be used to verify the type of a variable, litera
 <expr> IS :: <TYPE>
 ----
 
-Where `<expr>` is any Cypher expression and `<TYPE>` is one of the following types:
-
-* `NOTHING`
-* `NULL`
-* `BOOLEAN`
-* `STRING`
-* `INTEGER`
-* `FLOAT`
-* `DATE`
-* `LOCAL TIME`
-* `ZONED TIME`
-* `LOCAL DATETIME`
-* `ZONED DATETIME`
-* `DURATION`
-* `POINT`
-* `NODE`
-* `RELATIONSHIP`
-* `MAP`
-* `LIST<INNER_TYPE>`
-* `PATH`
-* `PROPERTY VALUE`
-* `ANY`
-* `<TYPE> NOT NULL`
+Where `<expr>` is any Cypher expression and `<TYPE>` is a Cypher Type.
 
 For all available Cypher types, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
 
@@ -1312,7 +1290,7 @@ RETURN val, val IS NOT :: STRING AS notString
 [[type-predicate-expressions-null]]
 === Type predicate expressions for null
 
-A Cypher type will include the `null` value unless it is prepended explicitly with `NOT NULL`.
+A Cypher type will include the `null` value unless it is appended explicitly with `NOT NULL`.
 Therefore, `IS ::` will return `true` for all expressions evaluating to `null`, which do not explicitly remove it.
 
 .Query
@@ -1330,7 +1308,7 @@ RETURN nullValue IS :: BOOLEAN AS isBoolean, nullValue IS :: BOOLEAN NOT NULL AS
 2+d|Rows: 1
 |===
 
-Likewise, `IS NOT ::` will return `false` for all expressions evaluating to `null`, if the type is not prepended with `NOT NULL`.
+Likewise, `IS NOT ::` will return `false` for all expressions evaluating to `null`, if the type is not appended with `NOT NULL`.
 
 .Query
 [source, cypher]

--- a/modules/ROOT/pages/syntax/expressions.adoc
+++ b/modules/ROOT/pages/syntax/expressions.adoc
@@ -1175,7 +1175,6 @@ A type predicate expression can be used to verify the type of a variable, litera
 ----
 
 Where `<expr>` is any Cypher expression and `<TYPE>` is a Cypher Type.
-
 For all available Cypher types, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
 
 [source, cypher]
@@ -1348,7 +1347,7 @@ For verifying that an expression is not of a certain type, the following alterna
 === Use of `ANY` and `NOTHING` types
 
 The `ANY` type is a supertype which matches values of all types.
-The `NOTHING` type is however the type containing an empty set of values. This means that it will return `false` for all values.
+On the other hand, the `NOTHING` type is the type containing an empty set of values. This means that it returns `false` for all values.
 
 [source, cypher]
 ----

--- a/modules/ROOT/pages/syntax/expressions.adoc
+++ b/modules/ROOT/pages/syntax/expressions.adoc
@@ -1290,13 +1290,13 @@ RETURN val, val IS NOT :: STRING AS notString
 [[type-predicate-expressions-null]]
 === Type predicate expressions for null
 
-A Cypher type will include the `null` value unless it is appended explicitly with `NOT NULL`.
-Therefore, `IS ::` will return `true` for all expressions evaluating to `null`, which do not explicitly remove it.
+A Cypher type includes the `null` value unless it is explicitly appended with `NOT NULL`.
+Therefore, `IS ::` returns `true` for all expressions evaluating to `null`, unless they explicitly remove it.
 
 .Query
 [source, cypher]
 ----
-WITH (toFloat(null)) AS nullValue
+WITH toFloat(null) AS nullValue
 RETURN nullValue IS :: BOOLEAN AS isBoolean, nullValue IS :: BOOLEAN NOT NULL AS isNotNullBoolean
 ----
 
@@ -1308,7 +1308,7 @@ RETURN nullValue IS :: BOOLEAN AS isBoolean, nullValue IS :: BOOLEAN NOT NULL AS
 2+d|Rows: 1
 |===
 
-Likewise, `IS NOT ::` will return `false` for all expressions evaluating to `null`, if the type is not appended with `NOT NULL`.
+Likewise, `IS NOT ::` returns `false` for all expressions evaluating to `null`, unless the type is appended with `NOT NULL`.
 
 .Query
 [source, cypher]
@@ -1330,7 +1330,7 @@ It is also possible to check whether a value is only the `null` value using the 
 .Query
 [source, cypher]
 ----
-WITH (toFloat(null)) AS nullValue
+WITH toFloat(null) AS nullValue
 RETURN nullValue IS :: NULL AS isNull
 ----
 
@@ -1379,8 +1379,8 @@ RETURN n.name AS name, n.age AS age
 2+d|Rows: 1
 |===
 
-The type `PROPERTY VALUE` can also be used to check for whether a type is storable as a property.
-Non-storable properties, such as `MAP`, will return `false` when checked with `IS :: PROPERTY VALUE`.
+The type `PROPERTY VALUE` can also be used to check whether a type is storable as a property.
+Types not storable in properties, such as `MAP`, will return `false` when checked with `IS :: PROPERTY VALUE`.
 
 [[type-predicate-expressions-number-sizes]]
 === Type predicate expressions for numbers of different sizes
@@ -1429,9 +1429,9 @@ For verifying that an expression is not of a certain type, the following alterna
 ----
 
 [[type-predicate-expressions-any-and-nothing]]
-=== Use of Any and Nothing types
+=== Use of `ANY` and `NOTHING` types
 
-The `ANY` type is a supertype of all types and will therefore match on everything.
+The `ANY` type is a supertype which matches values of all types.
 The `NOTHING` type is however the type containing an empty set of values. This means that it will return `false` for all values.
 
 .Query

--- a/modules/ROOT/pages/syntax/expressions.adoc
+++ b/modules/ROOT/pages/syntax/expressions.adoc
@@ -1235,7 +1235,7 @@ RETURN COLLECT {
 [[type-predicate-expressions]]
 == Type predicate expressions
 
-_This feature was introduced in Neo4j 5.9._
+_This feature was introduced in Neo4j 5.9 and extended in 5.10_
 
 A type predicate expression can be used to verify the type of a variable, literal, property or other Cypher expression.
 
@@ -1246,6 +1246,8 @@ A type predicate expression can be used to verify the type of a variable, litera
 
 Where `<expr>` is any Cypher expression and `<TYPE>` is one of the following types:
 
+* `NOTHING`
+* `NULL`
 * `BOOLEAN`
 * `STRING`
 * `INTEGER`
@@ -1257,6 +1259,14 @@ Where `<expr>` is any Cypher expression and `<TYPE>` is one of the following typ
 * `ZONED DATETIME`
 * `DURATION`
 * `POINT`
+* `NODE`
+* `RELATIONSHIP`
+* `MAP`
+* `LIST<INNER_TYPE>`
+* `PATH`
+* `PROPERTY VALUE`
+* `ANY`
+* `<TYPE> NOT NULL`
 
 For all available Cypher types, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
 
@@ -1302,36 +1312,55 @@ RETURN val, val IS NOT :: STRING AS notString
 [[type-predicate-expressions-null]]
 === Type predicate expressions for null
 
-All Cypher types include the `null` value.
-Therefore, `IS ::` will return `true` for all expressions evaluating to `null`, regardless of the type.
+A Cypher type will include the `null` value unless it is prepended explicitly with `NOT NULL`.
+Therefore, `IS ::` will return `true` for all expressions evaluating to `null`, which do not explicitly remove it.
 
 .Query
 [source, cypher]
 ----
-RETURN (toFloat(null)) IS :: BOOLEAN AS isBoolean
+WITH (toFloat(null)) AS nullValue
+RETURN nullValue IS :: BOOLEAN AS isBoolean, nullValue IS :: BOOLEAN NOT NULL AS isNotNullBoolean
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="2*<m"]
+|===
+| isBoolean | isNotNullBoolean
+| true      | false
+2+d|Rows: 1
+|===
+
+Likewise, `IS NOT ::` will return `false` for all expressions evaluating to `null`, if the type is not prepended with `NOT NULL`.
+
+.Query
+[source, cypher]
+----
+WITH (null + 1) AS nullValue
+RETURN nullValue IS NOT :: DATE AS isNotDate, nullValue IS NOT :: DATE NOT NULL AS isNotNotNullDate
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="2*<m"]
+|===
+| isNotDate | isNotNotNullDate
+| false     | true
+2+d|Rows: 1
+|===
+
+It is also possible to check whether a value is only the `null` value using the `NULL` type.
+
+.Query
+[source, cypher]
+----
+WITH (toFloat(null)) AS nullValue
+RETURN nullValue IS :: NULL AS isNull
 ----
 
 .Result
 [role="queryresult",options="header,footer",cols="1*<m"]
 |===
-| isBoolean
+| isNull
 | true
-1+d|Rows: 1
-|===
-
-Likewise, `IS NOT ::` will return `false` for all expressions evaluating to `null`, regardless of the type.
-
-.Query
-[source, cypher]
-----
-RETURN (null + 1) IS NOT :: DATE AS isNotDate
-----
-
-.Result
-[role="queryresult",options="header,footer",cols="1*<m"]
-|===
-| isNotDate
-| false
 1+d|Rows: 1
 |===
 
@@ -1371,6 +1400,9 @@ RETURN n.name AS name, n.age AS age
 | Charlie | 21
 2+d|Rows: 1
 |===
+
+The type `PROPERTY VALUE` can also be used to check for whether a type is storable as a property.
+Non-storable properties, such as `MAP`, will return `false` when checked with `IS :: PROPERTY VALUE`.
 
 [[type-predicate-expressions-number-sizes]]
 === Type predicate expressions for numbers of different sizes
@@ -1418,6 +1450,69 @@ For verifying that an expression is not of a certain type, the following alterna
 <expr> IS NOT TYPED <TYPE>
 ----
 
+[[type-predicate-expressions-any-and-nothing]]
+=== Use of Any and Nothing types
+
+The `ANY` type is a supertype of all types and will therefore match on everything.
+The `NOTHING` type is however the type containing an empty set of values. This means that it will return `false` for all values.
+
+.Query
+[source, cypher]
+----
+RETURN 42 IS :: ANY AS isOfTypeAny, 42 IS :: NOTHING AS isOfTypeNothing
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="2*<m"]
+|===
+| isOfTypeAny | isOfTypeNothing
+| true        | false
+2+d|Rows: 1
+|===
+
+[[type-predicate-expressions-lists]]
+=== List Types
+
+Type predicate expressions can be used for `LIST` types, where the inner type of the list must be specified.
+If the inner type is not relevant, then the `ANY` type may be used.
+
+For a `LIST` type check to return `true`, all values in the list must match the inner type.
+
+.Query
+[source, cypher]
+----
+UNWIND [[42], [42, null], [42, 42.0]] as val
+RETURN val, val IS :: LIST<INTEGER> AS isIntList
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="2*<m"]
+|===
+| val         | isIntList
+| [42]        | true
+| [42, null]  | true
+| [42, 42.0]  | false
+2+d|Rows: 3
+|===
+
+An empty list will match on all inner types, even the `NOTHING` type.
+
+.Query
+[source, cypher]
+----
+RETURN
+    [] IS :: LIST<NOTHING> AS isNothingList,
+    [] IS :: LIST<INTEGER> AS isIntList,
+    [] IS :: LIST<FLOAT NOT NULL> AS isFloatNotNullList
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="3*<m"]
+|===
+| isNothingList | isIntList | isFloatNotNullList
+| true          | true      | true
+3+d|Rows: 1
+|===
 
 [[label-expressions]]
 == Label expressions

--- a/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
+++ b/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
@@ -20,6 +20,7 @@ The following data types are included in the property types category: `BOOLEAN`,
 * Property types can be constructed with xref::syntax/expressions.adoc[Cypher literals].
 
 Homogeneous lists of simple types can be stored as properties, although lists in general (see xref::values-and-types/property-structural-constructed.adoc#constructed-types[Constructed types]) cannot be stored as properties.
+Lists stored as properties cannot contain `null` values.
 
 Cypher also provides pass-through support for byte arrays, which can be stored as property values.
 Byte arrays are supported for performance reasons, since using Cypher's generic data type, `LIST<INTEGER>` (where each `INTEGER` has a 64-bit representation), would be too costly.
@@ -99,8 +100,7 @@ However, not all types can be used in all places.
 | `ZONED TIME` | `TIME WITH TIMEZONE`
 |===
 
-All Cypher Types contain the `null` value, in order to make them not nullable `NOT NULL` can be appended to the end of the type.
-e.g `BOOLEAN NOT NULL`, `LIST<FLOAT NOT NULL>`
+All Cypher Types contain the `null` value, in order to make them not nullable `NOT NULL` can be appended to the end of the type, e.g `BOOLEAN NOT NULL`, `LIST<FLOAT NOT NULL>`.
 
 == Property type details
 

--- a/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
+++ b/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
@@ -73,12 +73,11 @@ For more details, see xref::values-and-types/working-with-null.adoc[working with
 The table below shows the types and their syntactic synonyms.
 These types (and their synonyms) can be used in xref::syntax/expressions.adoc#type-predicate-expressions[type predicate expressions] and in xref::constraints/examples.adoc#constraints-examples-node-property-type[node] and xref::constraints/examples.adoc#constraints-examples-relationship-property-type[relationship] property type constraints.
 However, not all types can be used in all places.
-Some of these types are not yet supported in either type predicate expressions or property type constraints.
-// TODO: Remove sentence about type not being supported once all types are allowed
 
 [.synonyms, opts="header", cols="2a,2a"]
 |===
 | Type | Synonyms
+| `ANY` | `ANY VALUE`
 | `BOOLEAN` | `BOOL`
 | `DATE` |
 | `DURATION` |
@@ -88,14 +87,20 @@ Some of these types are not yet supported in either type predicate expressions o
 | `LOCAL DATETIME` | `TIMESTAMP WITHOUT TIMEZONE`
 | `LOCAL TIME` | `TIME WITHOUT TIMEZONE`
 | `MAP` |
-| `NODE` | `VERTEX`
+| `NODE` | `ANY NODE`, `VERTEX`, `ANY VERTEX`
+| `NOTHING` |
+| `NULL` |
 | `PATH` |
 | `POINT` |
-| `RELATIONSHIP` | `EDGE`
+| `PROPERTY VALUE` | `ANY PROPERTY VALUE`
+| `RELATIONSHIP` | `ANY RELATIONSHIP`, `EDGE`, `ANY EDGE`
 | `STRING` | `VARCHAR`
 | `ZONED DATETIME` | `TIMESTAMP WITH TIMEZONE`
 | `ZONED TIME` | `TIME WITH TIMEZONE`
 |===
+
+All Cypher Types contain the `null` value, in order to make them not nullable `NOT NULL` can be appended to the end of the type.
+e.g `BOOLEAN NOT NULL`, `LIST<FLOAT NOT NULL>`
 
 == Property type details
 

--- a/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
+++ b/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
@@ -100,7 +100,7 @@ However, not all types can be used in all places.
 | `ZONED TIME` | `TIME WITH TIMEZONE`
 |===
 
-All Cypher Types contain the `null` value, in order to make them not nullable `NOT NULL` can be appended to the end of the type, e.g `BOOLEAN NOT NULL`, `LIST<FLOAT NOT NULL>`.
+All Cypher types contain the `null` value. To make them not nullable, `NOT NULL` can be appended to the end of the type (e.g. `BOOLEAN NOT NULL`, `LIST<FLOAT NOT NULL>`).
 
 == Property type details
 


### PR DESCRIPTION
Type predicate expressions now contain non-property value types as well as NOT NULL variants and LISTs.