### PR TITLE
docs: fix typos

### DIFF
--- a/modules/ROOT/pages/administration/access-control/dbms-administration.adoc
+++ b/modules/ROOT/pages/administration/access-control/dbms-administration.adoc
@@ -1288,7 +1288,7 @@ GRANT SERVER MANAGEMENT
 GRANT SHOW SERVERS
   ON DBMS
   TO role[, ...]
-| Enables the specfied roles to show servers.
+| Enables the specified roles to show servers.
 |===
 
 

--- a/modules/ROOT/pages/clauses/call.adoc
+++ b/modules/ROOT/pages/clauses/call.adoc
@@ -223,7 +223,7 @@ Cypher allows the omission of parentheses for procedures with arity-n (n argumen
 [NOTE]
 ====
 Best practice is to use parentheses for procedures.
-Omission of parantheses is available only in a so-called standalone procedure call, when the whole query consists of a single `CALL` clause.
+Omission of parentheses is available only in a so-called standalone procedure call, when the whole query consists of a single `CALL` clause.
 ====
 
 

--- a/modules/ROOT/pages/constraints/index.adoc
+++ b/modules/ROOT/pages/constraints/index.adoc
@@ -80,7 +80,7 @@ Databases containing one of these constraint types cannot be opened using Neo4j 
 
 Some constraint types are allowed on the same label/relationship type and property combination.
 For example, it is possible to have a uniqueness and an existence constraint on the same label/relationship type and property combination, though this would be the equivalent of having a node or relationship key constraint.
-A more useful example would be to combine a property type and an existance constraint to ensure that the property exists and has the given type.
+A more useful example would be to combine a property type and an existence constraint to ensure that the property exists and has the given type.
 
 == Implications on indexes
 

--- a/modules/ROOT/pages/execution-plans/shortestpath-planning.adoc
+++ b/modules/ROOT/pages/execution-plans/shortestpath-planning.adoc
@@ -29,7 +29,7 @@ Therefore, in these cases, it is recommended to set `cypher.forbid_exhaustive_sh
 == Shortest path -- fast algorithm
 
 
-.Query evaluated with the fast algorith
+.Query evaluated with the fast algorithm
 ======
 
 ////

--- a/modules/ROOT/pages/values-and-types/lists.adoc
+++ b/modules/ROOT/pages/values-and-types/lists.adoc
@@ -290,7 +290,7 @@ RETURN keanu.resume
 1+d|Rows: 1
 |===
 
-It is not, however, possible to store heterogenous lists as properties.
+It is not, however, possible to store heterogeneous lists as properties.
 For example, the following query, which tries to set a list including both the `title` and the `released` properties as the `resume` property of `Keanu Reeves` will fail. 
 This is because the `title` property values are stored as strings, while the `released` property values are stored as integers. 
 


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `modules/ROOT/pages/administration/access-control/dbms-administration.adoc`
1 typo in `modules/ROOT/pages/clauses/call.adoc`
1 typo in `modules/ROOT/pages/constraints/index.adoc`
1 typo in `modules/ROOT/pages/execution-plans/shortestpath-planning.adoc`
1 typo in `modules/ROOT/pages/values-and-types/lists.adoc`


Best!