### PR TITLE
UNION combines `any` queries

### DIFF
--- a/modules/ROOT/pages/clauses/union.adoc
+++ b/modules/ROOT/pages/clauses/union.adoc
@@ -8,7 +8,7 @@
 The `UNION` clause is used to combine the result of multiple queries.
 --
 
-`UNION` combines the results of two or more queries into a single result set that includes all the rows that belong to all queries in the union.
+`UNION` combines the results of two or more queries into a single result set that includes all the rows that belong to any queries in the union.
 
 The number and the names of the columns must be identical in all queries combined by using `UNION`.
 


### PR DESCRIPTION
The UNION clause combines results that match `any` of the queries and not `all` queries. The current explanation seems to be incorrect.