### PR TITLE
Add docs for valueType function

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -16,6 +16,7 @@ New features are added to the language continuously, and occasionally, some feat
 This section lists all of the features that have been removed, deprecated, added, or extended in different Cypher versions.
 Replacement syntax for deprecated and removed features are also indicated.
 
+
 [[cypher-deprecations-additions-removals-5.13]]
 == Version 5.13
 
@@ -36,7 +37,7 @@ RETURN valueType(expr)
 ----
 
 | Introduction of a xref::functions/scalar.adoc#functions-valueType[valueType()] function.
-This function returns a string representation of the most precise value xref::values-and-types/property-structural-constructed.adoc#types-synonyms[type] that the given expression evaluates to.
+This function returns a `STRING` representation of the most precise value xref::values-and-types/property-structural-constructed.adoc#types-synonyms[type] that the given expression evaluates to.
 
 |===
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -16,6 +16,30 @@ New features are added to the language continuously, and occasionally, some feat
 This section lists all of the features that have been removed, deprecated, added, or extended in different Cypher versions.
 Replacement syntax for deprecated and removed features are also indicated.
 
+[[cypher-deprecations-additions-removals-5.13]]
+== Version 5.13
+
+=== New features
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:new[]
+
+[source, cypher, role=noheader]
+----
+RETURN valueType(expr)
+----
+
+| Introduction of a xref::functions/scalar.adoc#functions-valueType[valueType()] function.
+This function returns a string representation of the most precise value xref::values-and-types/property-structural-constructed.adoc#types-synonyms[type] that the given expression evaluates to.
+
+|===
+
 [[cypher-deprecations-additions-removals-5.12]]
 == Neo4j 5.12
 

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -182,7 +182,7 @@ These functions return a single value.
 
 1.1+| xref::functions/scalar.adoc#functions-valueType[`valueType()`]
 | `valueType(input :: ANY?) :: (STRING?)`
-| Returns a string representation of the most precise value type that the given expression evaluates to.
+| Returns a `STRING` representation of the most precise value type that the given expression evaluates to.
 
 |===
 

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -180,6 +180,10 @@ These functions return a single value.
 | `type(input :: RELATIONSHIP?) :: (STRING?)`
 | Returns a `STRING` representation of the `RELATIONSHIP` type.
 
+1.1+| xref::functions/scalar.adoc#functions-valueType[`valueType()`]
+| `valueType(input :: ANY?) :: (STRING?)`
+| Returns a string representation of the smallest precise type of the value that the given expression evaluates to.
+
 |===
 
 

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -182,7 +182,7 @@ These functions return a single value.
 
 1.1+| xref::functions/scalar.adoc#functions-valueType[`valueType()`]
 | `valueType(input :: ANY?) :: (STRING?)`
-| Returns a string representation of the smallest precise type of the value that the given expression evaluates to.
+| Returns a string representation of the most precise value type that the given expression evaluates to.
 
 |===
 

--- a/modules/ROOT/pages/functions/scalar.adoc
+++ b/modules/ROOT/pages/functions/scalar.adoc
@@ -1430,6 +1430,8 @@ The relationship type of `r` is returned.
 [[functions-valueType]]
 == valueType()
 
+_This feature was introduced in Neo4j 5.13._
+
 The function `valueType()` returns a `STRING` representation of the most precise value type that the given expression evaluates to.
 
 *Syntax:*
@@ -1464,7 +1466,8 @@ This can include the introduction of new types and subtypes of already supported
 If a new type is introduced, it will be returned by the valueType() function as soon as it is released.
 However, if a more precise subtype of a previously supported type is introduced, it would be considered a breaking change.
 As a result, any new subtypes introduced after the release of Neo4j 5.13 will not be returned by the valueType() function until the following major release (Neo4j 6.0).
-For example, the function currently returns `"FLOAT"`, but if a more specific `FLOAT` type was added, e.g. `FLOAT32` this would be considered more specific and not returned until Neo4j 6.0, and `"FLOAT"` would continue to be returned for any `FLOAT32` values.
+For example, the function currently returns `"FLOAT"`, but if a more specific `FLOAT` type was added, e.g. `FLOAT32`, this would be considered more specific and not be returned until Neo4j 6.0.
+As a result,`"FLOAT"` would continue to be returned for any `FLOAT32` values until the release of Neo4j 6.0.
 
 With this in mind, the below list contains all supported types (as of Neo4j 5.13) displayed by the `valueType()` function until the release of Neo4j 6.0:
 
@@ -1493,6 +1496,7 @@ With this in mind, the below list contains all supported types (as of Neo4j 5.13
 ** `ANY`
 
 This should be taken into account when relying on the output of the `valueType()` function.
+
 See the xref::syntax/expressions.adoc#type-predicate-expressions[type predicate expression] for an alternative way of testing type values.
 
 

--- a/modules/ROOT/pages/functions/scalar.adoc
+++ b/modules/ROOT/pages/functions/scalar.adoc
@@ -1461,6 +1461,9 @@ valueType(expression)
 
 It is possible that future releases of Cypher will include updates to the current type system.
 This makes it possible for more precise types to be added which would be returned instead.
+As this would be a breaking change to this function, they will not be returned until the following major release.
+For example the function currently returns `"FLOAT"`, but if a more specific `FLOAT` type was added, e.g. `FLOAT32` this would be considered more specific and not returned until the next major release, and `"FLOAT"` would continue to be returned for any `FLOAT32` values.
+Completely new types may still be added in minor versions.
 This should be taken into account when relying on the output of this function.
 See the xref::syntax/expressions.adoc#type-predicate-expressions[type predicate expression] as an alternative way of testing type values.
 

--- a/modules/ROOT/pages/functions/scalar.adoc
+++ b/modules/ROOT/pages/functions/scalar.adoc
@@ -1430,7 +1430,7 @@ The relationship type of `r` is returned.
 [[functions-valueType]]
 == valueType()
 
-The function `valueType()` returns a string representation of the smallest precise type of the value that the given expression evaluates to.
+The function `valueType()` returns a string representation of the most precise value type that the given expression evaluates to.
 
 *Syntax:*
 
@@ -1456,6 +1456,12 @@ valueType(expression)
 | `expression` | Any expression that returns a value.
 
 |===
+
+*Considerations:*
+
+It is possible that future releases of Cypher will include updates to the current type system.
+This makes it possible for more precise types to be added which would be returned instead.
+This should be taken into account when relying on the output of this function.
 
 
 .+valueType()+

--- a/modules/ROOT/pages/functions/scalar.adoc
+++ b/modules/ROOT/pages/functions/scalar.adoc
@@ -1464,9 +1464,10 @@ valueType(expression)
 
 It is possible that future releases of Cypher will include updates to the current type system.
 This can include the introduction of new types and subtypes of already supported types.
-If a new type is introduced, it will be returned by the valueType() function as soon as it is released.
+If a new type is introduced, it will be returned by the `valueType()` function as soon as it is released.
 However, if a more precise subtype of a previously supported type is introduced, it would be considered a breaking change.
-As a result, any new subtypes introduced after the release of Neo4j 5.13 will not be returned by the valueType() function until the following major release (Neo4j 6.0).
+As a result, any new subtypes introduced after the release of Neo4j 5.13 will not be returned by the `valueType()` function until the following major release (Neo4j 6.0).
+
 For example, the function currently returns `"FLOAT"`, but if a more specific `FLOAT` type was added, e.g. `FLOAT32`, this would be considered more specific and not be returned until Neo4j 6.0.
 As a result,`"FLOAT"` would continue to be returned for any `FLOAT32` values until the release of Neo4j 6.0.
 

--- a/modules/ROOT/pages/functions/scalar.adoc
+++ b/modules/ROOT/pages/functions/scalar.adoc
@@ -1430,7 +1430,7 @@ The relationship type of `r` is returned.
 [[functions-valueType]]
 == valueType()
 
-The function `valueType()` returns a string representation of the most precise value type that the given expression evaluates to.
+The function `valueType()` returns a `STRING` representation of the most precise value type that the given expression evaluates to.
 
 *Syntax:*
 
@@ -1443,7 +1443,7 @@ valueType(expression)
 
 |===
 
-| A String.
+| `STRING`
 
 |===
 
@@ -1462,10 +1462,10 @@ valueType(expression)
 It is possible that future releases of Cypher will include updates to the current type system.
 This makes it possible for more precise types to be added which would be returned instead.
 As this would be a breaking change to this function, they will not be returned until the following major release.
-For example the function currently returns `"FLOAT"`, but if a more specific `FLOAT` type was added, e.g. `FLOAT32` this would be considered more specific and not returned until the next major release, and `"FLOAT"` would continue to be returned for any `FLOAT32` values.
+For example, the function currently returns `"FLOAT"`, but if a more specific `FLOAT` type was added, e.g. `FLOAT32` this would be considered more specific and not returned until the next major release, and `"FLOAT"` would continue to be returned for any `FLOAT32` values.
 Completely new types may still be added in minor versions.
-This should be taken into account when relying on the output of this function.
-See the xref::syntax/expressions.adoc#type-predicate-expressions[type predicate expression] as an alternative way of testing type values.
+This should be taken into account when relying on the output of the `valueType() function.
+See the xref::syntax/expressions.adoc#type-predicate-expressions[type predicate expression] for an alternative way of testing type values.
 
 
 .+valueType()+

--- a/modules/ROOT/pages/functions/scalar.adoc
+++ b/modules/ROOT/pages/functions/scalar.adoc
@@ -1460,11 +1460,39 @@ valueType(expression)
 *Considerations:*
 
 It is possible that future releases of Cypher will include updates to the current type system.
-This makes it possible for more precise types to be added which would be returned instead.
-As this would be a breaking change to this function, they will not be returned until the following major release.
-For example, the function currently returns `"FLOAT"`, but if a more specific `FLOAT` type was added, e.g. `FLOAT32` this would be considered more specific and not returned until the next major release, and `"FLOAT"` would continue to be returned for any `FLOAT32` values.
-Completely new types may still be added in minor versions.
-This should be taken into account when relying on the output of the `valueType() function.
+This can include the introduction of new types and subtypes of already supported types.
+If a new type is introduced, it will be returned by the valueType() function as soon as it is released.
+However, if a more precise subtype of a previously supported type is introduced, it would be considered a breaking change.
+As a result, any new subtypes introduced after the release of Neo4j 5.13 will not be returned by the valueType() function until the following major release (Neo4j 6.0).
+For example, the function currently returns `"FLOAT"`, but if a more specific `FLOAT` type was added, e.g. `FLOAT32` this would be considered more specific and not returned until Neo4j 6.0, and `"FLOAT"` would continue to be returned for any `FLOAT32` values.
+
+With this in mind, the below list contains all supported types (as of Neo4j 5.13) displayed by the `valueType()` function until the release of Neo4j 6.0:
+
+*  Predefined types
+** `NOTHING`
+** `NULL`
+** `BOOLEAN`
+** `STRING`
+** `INTEGER`
+** `FLOAT`
+** `DATE`
+** `LOCAL TIME`
+** `ZONED TIME`
+** `LOCAL DATETIME`
+** `ZONED DATETIME`
+** `DURATION`
+** `POINT`
+** `NODE`
+** `RELATIONSHIP`
+* Constructed types
+** `MAP`
+** `LIST<INNER_TYPE>` (ordered by the inner type)
+** `PATH`
+* Dynamic union types
+** `INNER_TYPE_1 \| INNER_TYPE_2...` (ordered by specific rules for closed dynamic union type)
+** `ANY`
+
+This should be taken into account when relying on the output of the `valueType()` function.
 See the xref::syntax/expressions.adoc#type-predicate-expressions[type predicate expression] for an alternative way of testing type values.
 
 

--- a/modules/ROOT/pages/functions/scalar.adoc
+++ b/modules/ROOT/pages/functions/scalar.adoc
@@ -1427,3 +1427,60 @@ The relationship type of `r` is returned.
 
 ======
 
+[[functions-valueType]]
+== valueType()
+
+The function `valueType()` returns a string representation of the smallest precise type of the value that the given expression evaluates to.
+
+*Syntax:*
+
+[source, syntax, role="noheader"]
+----
+valueType(expression)
+----
+
+*Returns:*
+
+|===
+
+| A String.
+
+|===
+
+*Arguments:*
+
+[options="header"]
+|===
+| Name | Description
+
+| `expression` | Any expression that returns a value.
+
+|===
+
+
+.+valueType()+
+======
+
+.Query
+[source, cypher, indent=0]
+----
+UNWIND ["abc", 1, 2.0, true, [date()]] AS value
+RETURN valueType(value) AS result
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| +result+
+| +"STRING NOT NULL"+
+| +"INTEGER NOT NULL"+
+| +"FLOAT NOT NULL"+
+| +"BOOLEAN NOT NULL"+
+| +"LIST<DATE NOT NULL> NOT NULL"+
+1+d|Rows: 5
+
+|===
+
+======
+

--- a/modules/ROOT/pages/functions/scalar.adoc
+++ b/modules/ROOT/pages/functions/scalar.adoc
@@ -1433,6 +1433,7 @@ The relationship type of `r` is returned.
 _This feature was introduced in Neo4j 5.13._
 
 The function `valueType()` returns a `STRING` representation of the most precise value type that the given expression evaluates to.
+The output is deterministic and makes use of xref::values-and-types/property-structural-constructed.adoc#type-normalization[Type Normalization].
 
 *Syntax:*
 

--- a/modules/ROOT/pages/functions/scalar.adoc
+++ b/modules/ROOT/pages/functions/scalar.adoc
@@ -1462,6 +1462,7 @@ valueType(expression)
 It is possible that future releases of Cypher will include updates to the current type system.
 This makes it possible for more precise types to be added which would be returned instead.
 This should be taken into account when relying on the output of this function.
+See the xref::syntax/expressions.adoc#type-predicate-expressions[type predicate expression] as an alternative way of testing type values.
 
 
 .+valueType()+

--- a/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
+++ b/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
@@ -105,7 +105,7 @@ However, not all types can be used in all places.
 All Cypher types contain the `null` value. To make them not nullable, `NOT NULL` can be appended to the end of the type (e.g. `BOOLEAN NOT NULL`, `LIST<FLOAT NOT NULL>`).
 Note that closed dynamic types (`INNER_TYPE_1 | INNER_TYPE_2...`) cannot be appended with `NOT NULL`: all inner types must be nullable, or all appended with `NOT NULL`.
 
-[[type-normalization]]]
+[[type-normalization]]
 == Type Normalization
 
 Cypher runs a normalization algorithm on all input types, simplifying the given type to a deterministic representation for equivalent types.

--- a/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
+++ b/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
@@ -107,9 +107,8 @@ Note that closed dynamic types (`INNER_TYPE_1 | INNER_TYPE_2...`) cannot be appe
 
 == Type Normalization
 
-Cypher runs a normalization algorithm on all input types, simplifying the given type to the smallest precise representation.
-Types are simplified to their default name (e.g. `BOOL` is simplified to `BOOLEAN`), encompassing types are absorbed (e.g. `LIST<BOOLEAN> | LIST<BOOLEAN | INTEGER>` is normalized to `LIST<BOOLEAN | INTEGER>`) and they are ordered.
-The order is based on cardinality, with lower coming first (e.g. `BOOLEAN` comes before `STRING`).
+Cypher runs a normalization algorithm on all input types, simplifying the given type to a deterministic representation for equivalent types.
+Types are simplified to their default name (e.g. `BOOL` is simplified to `BOOLEAN`), encompassing types are absorbed (e.g. `LIST<BOOLEAN> | LIST<BOOLEAN | INTEGER>` is normalized to `LIST<BOOLEAN | INTEGER>`) and they are <<ordering-of-types, ordered>>.
 
 The type `PROPERTY VALUE` is expanded to a closed dynamic union of all valid property types, and if all types are represented, then the normalization would simplify to `ANY`.
 
@@ -117,6 +116,44 @@ For example, given the closed dynamic type `BOOL | LIST<INT> | BOOLEAN | LIST<FL
 
 This normalization is run on types input in xref::syntax/expressions.adoc#type-predicate-expressions[type predicate expressions] and in xref::constraints/examples.adoc#constraints-examples-node-property-type[node] and xref::constraints/examples.adoc#constraints-examples-relationship-property-type[relationship] property type constraints.
 It is also used to ensure the consistency of the output for the xref::functions/scalar.adoc#functions-valueType[valueType()] function.
+
+[[ordering-of-types]]
+=== Ordering of types
+The ordering of types is as follows:
+
+    *  Predefined types
+    ** `NOTHING`
+    ** `NULL`
+    ** `BOOLEAN`
+    ** `STRING`
+    ** `INTEGER`
+    ** `FLOAT`
+    ** `DATE`
+    ** `LOCAL TIME`
+    ** `ZONED TIME`
+    ** `LOCAL DATETIME`
+    ** `ZONED DATETIME`
+    ** `DURATION`
+    ** `POINT`
+    ** `NODE`
+    ** `RELATIONSHIP`
+    * Constructed types
+    ** `MAP`
+    ** `LIST<INNER_TYPE>` (ordered by the inner type)
+    ** `PATH`
+    * Dynamic union types
+    ** `INNER_TYPE_1 \| INNER_TYPE_2...` (ordered by specific rules for closed dynamic union type)
+    ** `ANY`
+
+Subtypes are always ordered before any enclosing types (e.g. `LIST<INTEGER>` is ordered before `LIST<INTEGER | FLOAT>`).
+This also means that the `NOT NULL` variants of each type comes before the nullable variant.
+
+The order between two closed dynamic unions `A` and `B` is determined as followed:
+
+    * If `A` has fewer inner types than `B`, `A` is ordered first.
+    * If `A` and `B` have the same number of inner types, they are ordered according to the order of the first inner type that differ (lexicographic order).
+
+The resulting order is deterministic.
 
 == Property type details
 

--- a/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
+++ b/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
@@ -73,6 +73,7 @@ For more details, see xref::values-and-types/working-with-null.adoc[working with
 
 The table below shows the types and their syntactic synonyms.
 These types (and their synonyms) can be used in xref::syntax/expressions.adoc#type-predicate-expressions[type predicate expressions] and in xref::constraints/examples.adoc#constraints-examples-node-property-type[node] and xref::constraints/examples.adoc#constraints-examples-relationship-property-type[relationship] property type constraints.
+They are also output as a `STRING` value from the xref::functions/scalar.adoc#functions-valueType[valueType()] function.
 However, not all types can be used in all places.
 
 [.synonyms, opts="header", cols="2a,2a"]
@@ -103,6 +104,19 @@ However, not all types can be used in all places.
 
 All Cypher types contain the `null` value. To make them not nullable, `NOT NULL` can be appended to the end of the type (e.g. `BOOLEAN NOT NULL`, `LIST<FLOAT NOT NULL>`).
 Note that closed dynamic types (`INNER_TYPE_1 | INNER_TYPE_2...`) cannot be appended with `NOT NULL`: all inner types must be nullable, or all appended with `NOT NULL`.
+
+== Type Normalization
+
+Cypher runs a normalization algorithm on all input types, simplifying the given type to the smallest precise representation.
+Types are simplified to their default name (e.g. `BOOL` is simplified to `BOOLEAN`), encompassing types are absorbed (e.g. `LIST<BOOLEAN> | LIST<BOOLEAN | INTEGER>` is normalized to `LIST<BOOLEAN | INTEGER>`) and they are ordered.
+The order is based on cardinality, with lower coming first (e.g. `BOOLEAN` comes before `STRING`).
+
+The type `PROPERTY VALUE` is expanded to a closed dynamic union of all valid property types, and if all types are represented, then the normalization would simplify to `ANY`.
+
+For example, given the closed dynamic type `BOOL | LIST<INT> | BOOLEAN | LIST<FLOAT | INT>`, the normalized type would be: `BOOLEAN | LIST<INTEGER | FLOAT>`.
+
+This normalization is run on types input in xref::syntax/expressions.adoc#type-predicate-expressions[type predicate expressions] and in xref::constraints/examples.adoc#constraints-examples-node-property-type[node] and xref::constraints/examples.adoc#constraints-examples-relationship-property-type[relationship] property type constraints.
+It is also used to ensure the consistency of the output for the xref::functions/scalar.adoc#functions-valueType[valueType()] function.
 
 == Property type details
 

--- a/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
+++ b/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
@@ -73,7 +73,7 @@ For more details, see xref::values-and-types/working-with-null.adoc[working with
 
 The table below shows the types and their syntactic synonyms.
 These types (and their synonyms) can be used in xref::syntax/expressions.adoc#type-predicate-expressions[type predicate expressions] and in xref::constraints/examples.adoc#constraints-examples-node-property-type[node] and xref::constraints/examples.adoc#constraints-examples-relationship-property-type[relationship] property type constraints.
-They are also output as a `STRING` value from the xref::functions/scalar.adoc#functions-valueType[valueType()] function.
+They are also returned as a `STRING` value when using the xref::functions/scalar.adoc#functions-valueType[valueType()] function.
 However, not all types can be used in all places.
 
 [.synonyms, opts="header", cols="2a,2a"]
@@ -108,14 +108,16 @@ Note that closed dynamic types (`INNER_TYPE_1 | INNER_TYPE_2...`) cannot be appe
 == Type Normalization
 
 Cypher runs a normalization algorithm on all input types, simplifying the given type to a deterministic representation for equivalent types.
-Types are simplified to their default name (e.g. `BOOL` is simplified to `BOOLEAN`), encompassing types are absorbed (e.g. `LIST<BOOLEAN> | LIST<BOOLEAN | INTEGER>` is normalized to `LIST<BOOLEAN | INTEGER>`) and they are <<ordering-of-types, ordered>>.
+Types are simplified to their default name (e.g. `BOOL` is simplified to `BOOLEAN`).
+Encompassing types are absorbed (e.g. `LIST<BOOLEAN> | LIST<BOOLEAN | INTEGER>` is normalized to `LIST<BOOLEAN | INTEGER>`).
+Types are also xref:values-and-types/property-structural-constructed.adoc#ordering-of-types[ordered].
 
 The type `PROPERTY VALUE` is expanded to a closed dynamic union of all valid property types, and if all types are represented, then the normalization would simplify to `ANY`.
 
 For example, given the closed dynamic type `BOOL | LIST<INT> | BOOLEAN | LIST<FLOAT | INT>`, the normalized type would be: `BOOLEAN | LIST<INTEGER | FLOAT>`.
 
-This normalization is run on types input in xref::syntax/expressions.adoc#type-predicate-expressions[type predicate expressions] and in xref::constraints/examples.adoc#constraints-examples-node-property-type[node] and xref::constraints/examples.adoc#constraints-examples-relationship-property-type[relationship] property type constraints.
-It is also used to ensure the consistency of the output for the xref::functions/scalar.adoc#functions-valueType[valueType()] function.
+This normalization is run on types used in xref::syntax/expressions.adoc#type-predicate-expressions[type predicate expressions], and in xref::constraints/examples.adoc#constraints-examples-node-property-type[node] and xref::constraints/examples.adoc#constraints-examples-relationship-property-type[relationship] property type constraints.
+Type normalization is also used to ensure the consistency of the output for the xref::functions/scalar.adoc#functions-valueType[valueType()] function.
 
 [[ordering-of-types]]
 === Ordering of types

--- a/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
+++ b/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
@@ -105,6 +105,7 @@ However, not all types can be used in all places.
 All Cypher types contain the `null` value. To make them not nullable, `NOT NULL` can be appended to the end of the type (e.g. `BOOLEAN NOT NULL`, `LIST<FLOAT NOT NULL>`).
 Note that closed dynamic types (`INNER_TYPE_1 | INNER_TYPE_2...`) cannot be appended with `NOT NULL`: all inner types must be nullable, or all appended with `NOT NULL`.
 
+[[type-normalization]]]
 == Type Normalization
 
 Cypher runs a normalization algorithm on all input types, simplifying the given type to a deterministic representation for equivalent types.


### PR DESCRIPTION
5.12 will bring the introduction of a new function, valueType(), which returns a STRING representation of the smallest precise type. 