### PR TITLE
Add docs for the new nullIf() function

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -16,6 +16,30 @@ New features are added to the language continuously, and occasionally, some feat
 This section lists all of the features that have been removed, deprecated, added, or extended in different Cypher versions.
 Replacement syntax for deprecated and removed features are also indicated.
 
+[[cypher-deprecations-additions-removals-5.14]]
+== Version 5.14
+
+=== New features
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:new[]
+
+[source, cypher, role=noheader]
+----
+RETURN nullIf(v1, v2)
+----
+
+| Introduction of a xref::functions/scalar.adoc#functions-nullIf[nullIf()] function.
+This function returns null if the two given parameters are equivalent, otherwise returns the value of the first parameter.
+
+|===
+
 [[cypher-deprecations-additions-removals-5.13]]
 == Neo4j 5.13
 

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -126,6 +126,10 @@ label:new[Introduced in 5.13]
 | `length(input :: PATH) :: INTEGER`
 | Returns the length of a `PATH`.
 
+1.1+| xref::functions/scalar.adoc#functions-nullIf[`nullIf()`]
+| `nullIf(v1 :: ANY, v2 :: ANY) :: ANY`
+| Returns null if the two given parameters are equivalent, otherwise returns the value of the first parameter.
+
 1.3+| xref::functions/scalar.adoc#functions-properties[`properties()`]
 | `properties(input :: MAP) :: MAP`
 | Returns a `MAP` containing all the properties of a `MAP`.

--- a/modules/ROOT/pages/functions/scalar.adoc
+++ b/modules/ROOT/pages/functions/scalar.adoc
@@ -688,6 +688,87 @@ The length of the path `p` is returned.
 ======
 
 
+[[functions-nullIf]]
+== nullIf()
+
+The function `nullIf()` returns null if the two given parameters are equivalent, otherwise returns the value of the first parameter.
+
+*Syntax:*
+
+[source, syntax, role="noheader"]
+----
+nullIf(v1, v2)
+----
+
+*Returns:*
+
+|===
+
+| `ANY`
+
+|===
+
+*Arguments:*
+
+[options="header"]
+|===
+| Name | Description
+
+| `v1`
+| An expression that returns `ANY`.
+
+| `v2`
+| An expression that returns `ANY`.
+
+|===
+
+.+nullIf()+
+======
+
+.Query
+[source, cypher, indent=0]
+----
+RETURN nullIf(4, 4)
+----
+
+The null value is returned as the two parameters are equivalent.
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| +nullIf(4, 4)+
+| +null+
+1+d|Rows: 1
+
+|===
+
+======
+
+.+nullIf()+
+======
+
+.Query
+[source, cypher, indent=0]
+----
+RETURN nullIf("abc", "def")
+----
+
+The first parameter, "abc", is returned, as the two parameters are not equivalent.
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| +nullIf("abc", "def")+
+| +"abc"+
+1+d|Rows: 1
+
+|===
+
+======
+
+
 [[functions-properties]]
 == properties()
 


### PR DESCRIPTION
NullIf can be useful for handling special values like 0 or empty strings by replacing them with null, it can also be used in combination with coalesce to substitute the null values with something else. Another use case is to avoid division by zero errors, this is because division by null returns null, whereas division by 0 will error! It is a handy shorthand that SQL users will be familiar with.