### PR TITLE
Expand documentation on the ordering of lists and maps

### DIFF
--- a/modules/ROOT/pages/syntax/operators.adoc
+++ b/modules/ROOT/pages/syntax/operators.adoc
@@ -407,10 +407,14 @@ For example, `1 > b` and `1 < b` are both false when b is NaN.
   *** xref::queries/expressions.adoc#boolean[`BOOLEAN`]
   *** Numbers: xref::queries/expressions.adoc#numerical[`INTEGER`, `FLOAT`]
  ** The value `null` is ordered after all other values.
-* *Ordering* of constructed type values:
- ** For the xref::values-and-types/property-structural-constructed.adoc#constructed-types[constructed types] (e.g. maps and lists), elements of the containers are compared pairwise for ordering and thus determine the ordering of two container types.
-For example, `[1, 'foo', 3]` is ordered before `[1, 2, 'bar']` since `'foo'` is ordered before `2`.
-
+* *Ordering* of xref::values-and-types/property-structural-constructed.adoc#constructed-types[constructed type] values:
+ ** Lists are compared in dictionary order, also known as lexicographic order:
+  *** Elements are compared pairwise from the start of the list to the end. The order of the two lists is defined by the order of the first pair where the two elements differ. For example, `[1, 'foo', 3]` is less than `[1, 2, 'bar']` since `'foo'` is less than `2`.
+  *** If a list is shorter than the other one, it is padded with the empty element which is considered to be less than any other value (including null values). For example, `[1, 'foo']` is less than `[1, 'foo', 3]`, and `[1]` is less than `[1, null]`.
+  ** Maps are ordered by size, keys, and values:
+   *** Maps are primarily compared by size: the smallest map is the one with the smallest number of entries. For example `{a: 1}` is less than `{a: 0, b: 'foo'}`.
+   *** The order of maps of equal size are then defined by comparing their respective lists of keys sorted in alphabetical order. For example `{b: 100, a: 'foo'}` is less than `{a: '', c: null}` since `['a', 'b']` is less than `['a', 'c']`.
+   *** Finally, the order of maps with identical key sets is based on comparing their values pairwise, having first sorted the entries by keys in alphabetical order. For example `{b: 100, a: 'foo'}` is less than `{a: 'foo', b: null}` since `['foo', 100]` is less than `['foo', null]`.
 
 [[cypher-operations-chaining]]
 === Chaining comparison operations


### PR DESCRIPTION
The documentation for the ordering of _constrcuted types_ was a bit light.
It did not cover lists of different length, and maps were essentially missing.
Note that the ordering of maps is "unspecified and left to implementations" according to openCypher.