### PR TITLE
Add docs for new ALL keyword

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -32,9 +32,9 @@ label:deprecated[]
 RETURN 1 as my\u0085identifier
 ----
 a|
-The Unicode character \`\u0085` is deprecated for unescaped identifiers and will be considered as a whitespace character in the future. 
+The Unicode character \`\u0085` is deprecated for unescaped identifiers and will be considered as a whitespace character in the future.
 To continue using it, escape the identifier by adding backticks around the identifier.
-This applies to all unescaped identifiers in Cypher, such as label expressions, properties, variable names or parameters. 
+This applies to all unescaped identifiers in Cypher, such as label expressions, properties, variable names or parameters.
 In the given example, the quoted identifier would be \`my�identifier`.
 
 a|
@@ -63,6 +63,27 @@ The following Unicode Characters are deprecated in identifiers:
 '\u2067', '\u2068', '\u2069', '\u206A', '\u206B', '\u206C', '\u206D', '\u206E',
 '\u206F', '\u2E2F', '\uFEFF', '\uFFF9', '\uFFFA', '\uFFFB'
 
+|===
+
+=== Updated features
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:updated[]
+
+[source, cypher, role=noheader]
+----
+MATCH (n)
+RETURN count(ALL n.prop)
+----
+
+| Added a new keyword `ALL`, explicitly defining that the aggregate function is not `DISTINCT`.
+This is a mirror of the already existing keyword `DISTINCT`.
 |===
 
 [[cypher-deprecations-additions-removals-5.14]]

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -65,7 +65,7 @@ The following Unicode Characters are deprecated in identifiers:
 
 |===
 
-=== Updated features
+=== New features
 
 [cols="2", options="header"]
 |===
@@ -74,7 +74,7 @@ The following Unicode Characters are deprecated in identifiers:
 
 a|
 label:functionality[]
-label:updated[]
+label:new[]
 
 [source, cypher, role=noheader]
 ----
@@ -82,8 +82,8 @@ MATCH (n)
 RETURN count(ALL n.prop)
 ----
 
-| Added a new keyword `ALL`, explicitly defining that the aggregate function is not `DISTINCT`.
-This is a mirror of the already existing keyword `DISTINCT`.
+| Added a new keyword xref::functions/aggregating.adoc#counting_with_and_without_duplicates[ALL], explicitly defining that the aggregate function is not `DISTINCT`.
+This is a mirror of the already existing keyword `DISTINCT` for functions.
 |===
 
 [[cypher-deprecations-additions-removals-5.14]]

--- a/modules/ROOT/pages/functions/aggregating.adoc
+++ b/modules/ROOT/pages/functions/aggregating.adoc
@@ -371,10 +371,14 @@ The number of nodes with the label `Person` and a property `age` is returned:
 [[counting_with_and_without_duplicates]]
 === Counting with and without duplicates
 
-This example tries to find all friends of friends of `Keanu Reeves` and count them. 
+The default behavior of the `count` function is to count all matching results, including duplicates.
+To avoid counting duplicates, use the `DISTINCT` keyword.
 
-`count(DISTINCT friendOfFriend)`:: Will only count a `friendOfFriend` once, as `DISTINCT` removes the duplicates.
-`count(ALL friendOfFriend)` or `count(friendOfFriend)`:: Will consider the same `friendOfFriend` multiple times (Including `ALL` is functionally the same as using no aggregation operator)  label:new[Introduced in 5.15]
+As of Neo4j 5.15, it is also possible to use the `ALL` keyword with aggregating functions.
+This will count all results, including duplicates, and is functionally the same as not using the `DISTINCT` keyword.
+
+This example tries to find all friends of friends of `Keanu Reeves` and count them.
+It shows the behavior of using both the `ALL` and the `DISTINCT` keywords:
 
 .+count()+
 ======
@@ -384,18 +388,18 @@ This example tries to find all friends of friends of `Keanu Reeves` and count th
 ----
 MATCH (p:Person)-->(friend:Person)-->(friendOfFriend:Person)
 WHERE p.name = 'Keanu Reeves'
-RETURN friendOfFriend.name, count(DISTINCT friendOfFriend), count(friendOfFriend)
+RETURN friendOfFriend.name, count(friendOfFriend), count(ALL friendOfFriend), count(DISTINCT friendOfFriend)
 ----
 
 The nodes `Carrie Anne Moss` and `Liam Neeson` both have an outgoing `KNOWS` relationship to `Guy Pearce`.
 The `Guy Pearce` node will, therefore, get counted twice when not using `DISTINCT`.
 
 .Result
-[role="queryresult",options="header,footer",cols="3*<m"]
+[role="queryresult",options="header,footer",cols="4*<m"]
 |===
 
-| +friendOfFriend.name+ | +count(DISTINCT friendOfFriend)+ | +count(friendOfFriend)+
-| +"Guy Pearce"+ | +1+ | +2+
+| friendOfFriend.name  | count(friendOfFriend) | count(ALL friendOfFriend)    | count(DISTINCT friendOfFriend)
+| "Guy Pearce" | 2 | 2 | 1
 2+d|Rows: 1
 
 |===

--- a/modules/ROOT/pages/functions/aggregating.adoc
+++ b/modules/ROOT/pages/functions/aggregating.adoc
@@ -374,7 +374,7 @@ The number of nodes with the label `Person` and a property `age` is returned:
 This example tries to find all friends of friends of `Keanu Reeves` and count them. 
 
 `count(DISTINCT friendOfFriend)`:: Will only count a `friendOfFriend` once, as `DISTINCT` removes the duplicates.
-`count(friendOfFriend)`:: Will consider the same `friendOfFriend` multiple times.
+`count(ALL friendOfFriend)` or `count(friendOfFriend)`:: Will consider the same `friendOfFriend` multiple times.
 
 .+count()+
 ======

--- a/modules/ROOT/pages/functions/aggregating.adoc
+++ b/modules/ROOT/pages/functions/aggregating.adoc
@@ -368,13 +368,13 @@ The number of nodes with the label `Person` and a property `age` is returned:
 
 ======
 
-
+[[counting_with_and_without_duplicates]]
 === Counting with and without duplicates
 
 This example tries to find all friends of friends of `Keanu Reeves` and count them. 
 
 `count(DISTINCT friendOfFriend)`:: Will only count a `friendOfFriend` once, as `DISTINCT` removes the duplicates.
-`count(ALL friendOfFriend)` or `count(friendOfFriend)`:: Will consider the same `friendOfFriend` multiple times.
+`count(ALL friendOfFriend)` or `count(friendOfFriend)`:: Will consider the same `friendOfFriend` multiple times (Including `ALL` is functionally the same as using no aggregation operator)  label:new[Introduced in 5.15]
 
 .+count()+
 ======


### PR DESCRIPTION
ALL is a mirror of DISTINCT, and works the same as omitting it in aggregation functions.