### PR TITLE
Add docs for new normalize function.

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -70,6 +70,25 @@ For more information, see the link:{neo4j-docs-base-uri}/operations-manual/{page
 
 |===
 
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:new[]
+
+[source, cypher, role=noheader]
+----
+RETURN normalize("string", NFC)
+----
+
+| Introduction of a xref::functions/string.adoc#functions-normalize[normalize()] function.
+Normalize a `STRING` according to the specified normalization form, which can be of type `NFC`, `NFD`, `NFKC` or `NFKD`.
+
+|===
+
 [[cypher-deprecations-additions-removals-5.15]]
 == Neo4j 5.15
 
@@ -146,7 +165,7 @@ label:updated[]
 MATCH (n:Label) WHERE $param IS :: STRING NOT NULL AND n.prop = $param
 ----
 
-| `IS :: STRING NOT NULL` is now an xref:indexes/search-performance-indexes/using-indexes.adoc#text-indexes-type-predicate-expressions[index-compatible predicate]. 
+| `IS :: STRING NOT NULL` is now an xref:indexes/search-performance-indexes/using-indexes.adoc#text-indexes-type-predicate-expressions[index-compatible predicate].
 
 |===
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -16,6 +16,30 @@ New features are added to the language continuously, and occasionally, some feat
 This section lists all of the features that have been removed, deprecated, added, or extended in different Cypher versions.
 Replacement syntax for deprecated and removed features are also indicated.
 
+[[cypher-deprecations-additions-removals-5.17]]
+== Neo4j 5.17
+
+=== New features
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:new[]
+
+[source, cypher, role=noheader]
+----
+RETURN normalize("string", NFC)
+----
+
+| Introduction of a xref::functions/string.adoc#functions-normalize[normalize()] function.
+This function normalizes a `STRING` according to the specified normalization form, which can be of type `NFC`, `NFD`, `NFKC`, or `NFKD`.
+
+|===
+
 [[cypher-deprecations-additions-removals-5.16]]
 == Neo4j 5.16
 
@@ -67,25 +91,6 @@ DENY LOAD ON CIDR "::1/128" TO role
 ----
 | Added the ability to grant or deny `LOAD` privilege on a CIDR range.
 For more information, see the link:{neo4j-docs-base-uri}/operations-manual/{page-version}/authentication-authorization/load-privileges/#access-control-load-cidr[Operations Manual -> The CIDR privilege].
-
-|===
-
-[cols="2", options="header"]
-|===
-| Feature
-| Details
-
-a|
-label:functionality[]
-label:new[]
-
-[source, cypher, role=noheader]
-----
-RETURN normalize("string", NFC)
-----
-
-| Introduction of a xref::functions/string.adoc#functions-normalize[normalize()] function.
-Normalize a `STRING` according to the specified normalization form, which can be of type `NFC`, `NFD`, `NFKC` or `NFKD`.
 
 |===
 

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -507,7 +507,7 @@ These functions are used to manipulate strings or to create a string representat
 
 1.2+| xref::functions/string.adoc#functions-normalize[`normalize()`]
 | `normalize(input :: STRING) :: STRING`
-| Returns the given `STRING` normalized using the normal form 'NFC'.
+| Returns the given `STRING` normalized using the normal form `NFC`.
 | `normalize(input :: STRING, normalForm = NFC :: [NFC, NFD, NFKC, NFKD]) :: STRING`
 | Returns the given `STRING` normalized according to the specified normalization form.
 

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -507,9 +507,9 @@ These functions are used to manipulate strings or to create a string representat
 
 1.2+| xref::functions/string.adoc#functions-normalize[`normalize()`]
 | `normalize(input :: STRING) :: STRING`
-| Returns the given `STRING` normalized according to the normalization form `NFC`.
+| Returns the given `STRING` normalized according to the normalization form `NFC`. label:new[Introduced in 5.17]
 | `normalize(input :: STRING, normalForm = NFC :: [NFC, NFD, NFKC, NFKD]) :: STRING`
-| Returns the given `STRING` normalized according to the specified normalization form.
+| Returns the given `STRING` normalized according to the specified normalization form. label:new[Introduced in 5.17]
 
 1.1+| xref::functions/string.adoc#functions-replace[`replace()`]
 | `replace(original :: STRING, search :: STRING, replace :: STRING) :: STRING`
@@ -779,7 +779,7 @@ Graph functions provide information about the constituent graphs in composite da
 |===
 | Function | Signature | Description
 1.1+| xref:functions/graph.adoc#functions-graph-by-elementid[`graph.byElementId()`]  | `USE graph.byElementId(elementId :: STRING)` | Resolves the constituent graph to which a given element id belongs.
-label:new[Introduced in Neo4j 5.13]
+label:new[Introduced in 5.13]
 1.1+| xref:functions/graph.adoc#functions-graph-byname[`graph.byName()`]  | `USE graph.byName(name :: STRING)` | Resolves a constituent graph by name.
 1.1+| xref:functions/graph.adoc#functions-graph-names[`graph.names()`]  | `graph.names() :: LIST<STRING>` | Returns a list containing the names of all graphs in the current composite database.
 1.1+| xref:functions/graph.adoc#functions-graph-names[`graph.propertiesByName()`]  | `graph.propertiesByName(name :: STRING) :: MAP` | Returns a map containing the properties associated with the given graph.

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -507,7 +507,7 @@ These functions are used to manipulate strings or to create a string representat
 
 1.2+| xref::functions/string.adoc#functions-normalize[`normalize()`]
 | `normalize(input :: STRING) :: STRING`
-| Returns the given `STRING` normalized using the normal form `NFC`.
+| Returns the given `STRING` normalized according to the normalization form `NFC`.
 | `normalize(input :: STRING, normalForm = NFC :: [NFC, NFD, NFKC, NFKD]) :: STRING`
 | Returns the given `STRING` normalized according to the specified normalization form.
 

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -505,6 +505,12 @@ These functions are used to manipulate strings or to create a string representat
 | `ltrim(input :: STRING) :: STRING`
 | Returns the given `STRING` with leading whitespace removed.
 
+1.2+| xref::functions/string.adoc#functions-normalize[`normalize()`]
+| `normalize(input :: STRING) :: STRING`
+| Returns the given `STRING` normalized using the normal form 'NFC'.
+| `normalize(input :: STRING, normalForm = NFC :: [NFC, NFD, NFKC, NFKD]) :: STRING`
+| Returns the given `STRING` normalized according to the specified normalization form.
+
 1.1+| xref::functions/string.adoc#functions-replace[`replace()`]
 | `replace(original :: STRING, search :: STRING, replace :: STRING) :: STRING`
 | Returns a `STRING` in which all occurrences of a specified search `STRING` in the given `STRING` have been replaced by another (specified) replacement `STRING`.

--- a/modules/ROOT/pages/functions/string.adoc
+++ b/modules/ROOT/pages/functions/string.adoc
@@ -164,8 +164,10 @@ For more information, see the documentation for link:https://unicode.org/reports
 The `normalize()` function is useful for converting `STRING` values into comparable forms.
 When comparing two `STRING` values, it is their Unicode codepoints that are compared.
 In Unicode, a codepoint for a character that looks the same may be represented by two, or more, different codepoints.
-For example, the character `<` can be represented as `\uFE64` (﹤) or `\u003C` (<). Visually, the character may look the same,
-but if compared, Cypher will return false as `\uFE64` does not equal `\u003C`. Using the `normalize()` function, it is possible to
+For example, the character `<` can be represented as `\uFE64` (﹤) or `\u003C` (<).
+To the human eye, the characters may appear identical.
+However,  if compared, Cypher will return false as `\uFE64` does not equal `\u003C`.
+Using the `normalize()` function, it is possible to
 normalize the codepoint `\uFE64` to `\u003C`, creating a single codepoint representation, allowing them to be successfully compared.
 
 *Syntax:*
@@ -251,7 +253,7 @@ For example, the Greek Upsilon with Acute and Hook Symbol `ϓ` can be represente
 * Normalized in `NFKC`: `\u038E` Greek Capital Letter Upsilon with Tonos (Ύ)
 * Normalized in `NFKD`: `\u03A5\u0301` Greek Capital Letter Upsilon + Combining Acute Accent (Ύ)
 
-In the compatibility normalization forms (`NFKC` and `NFKD`) the character looks visually different as it no longer contains the hook symbol.
+In the compatibility normalization forms (`NFKC` and `NFKD`) the character is visibly different as it no longer contains the hook symbol.
 
 *Syntax:*
 

--- a/modules/ROOT/pages/functions/string.adoc
+++ b/modules/ROOT/pages/functions/string.adoc
@@ -155,6 +155,13 @@ RETURN ltrim('   hello')
 
 `normalize()` returns the given `STRING` normalized using the `NFC` normalization form.
 
+The `normalize()` function is useful for converting `STRING` values into comparable forms.
+When comparing two `STRING` values, it is their Unicode codepoints that are compared.
+In Unicode, a codepoint for a character that looks the same may actually be represented by two, or more, different codepoints.
+For example, the character `<` can be represented as `\uFE64` or `\u003C`. Visually, the character may look the same,
+but if compared, Cypher will return false as `\uFE64` does not equal `\u003C`. Using the `normalize()` function one can
+normalize the codepoint `\uFE64` to `\u003C`, creating a single codepoint representation, allowing them to be successfully compared.
+
 *Syntax:*
 
 [source, syntax, role="noheader"]
@@ -217,6 +224,26 @@ RETURN normalize('\u212B') = '\u00C5' AS result
 
 `normalize()` returns the given `STRING` normalized using the specified normalization form.
 The normalization form can be of type `NFC`, `NFD`, `NFKC` or `NFKD`.
+
+There are two main types of normalization forms. One is based on the concept of canonical equivalence, and the other is based on compatibility.
+
+The two forms `NFC` (default) and `NFD` are forms of canonical equivalence. This means that codepoints which represent the same abstract character will
+be normalized to the same codepoint. The same abstract character means that the character has the same visual appearance and behavior.
+The difference between `NFC` and `NFD` is that `NFC` form will always give the *composed* canonical form, one where combined codes are replaced with the single representation, if possible.
+Whereas, `NFD` gives the *decomposed* form, this is the opposite of composed, converting combined codepoints into the split form if possible.
+
+The two forms `NFKC` and `NFKD` are forms of compatibility normalization. All canonically equivalent sequences are compatible, but not all compatible sequences are canonical.
+This means that a character normalized in `NFC` or `NFD` should also be normalized in `NFKC` and `NFKD`, and other characters that may have a slightly different visual appearance,
+but are considered close enough in appearance to be compatibly equivalent.
+
+For example, the Greek Upsilon with Acute and Hook Symbol `ϓ` can be represented by the Unicode codepoint: `\u03D3`.
+
+* Normalized in `NFC`: `\u03D3` Greek Upsilon with Acute and Hook Symbol (ϓ)
+* Normalized in `NFD`: `\u03D2\u0301` Greek Upsilon with Hook Symbol + Combining Acute Accent (ϓ)
+* Normalized in `NFKC`: `\u038E` Greek Capital Letter Upsilon with Tonos (Ύ)
+* Normalized in `NFKD`: `\u03A5\u0301` Greek Capital Letter Upsilon + Combining Acute Accent (Ύ)
+
+In the compatibility normalization forms (`NFKC` and `NFKD`) the character looks visually different as it no longer contains the hook symbol.
 
 *Syntax:*
 

--- a/modules/ROOT/pages/functions/string.adoc
+++ b/modules/ROOT/pages/functions/string.adoc
@@ -148,6 +148,136 @@ RETURN ltrim('   hello')
 
 ======
 
+
+
+[[functions-normalize]]
+== normalize()
+
+`normalize()` returns the given `STRING` normalized using the `NFC` normalization form.
+
+*Syntax:*
+
+[source, syntax, role="noheader"]
+----
+normalize(input)
+----
+
+*Returns:*
+
+|===
+
+| `STRING`
+
+|===
+
+*Arguments:*
+
+[options="header"]
+|===
+| Name | Description
+
+| `input`
+| An expression that returns a `STRING`.
+
+|===
+
+*Considerations:*
+
+|===
+
+| `normalize(null)` returns `null`.
+
+|===
+
+
+.+normalize()+
+======
+
+.Query
+[source, cypher, indent=0]
+----
+RETURN normalize('\u212B') = '\u00C5' AS result
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| +result+
+| +true+
+1+d|Rows: 1
+
+|===
+
+======
+
+
+[[functions-normalize-with-normal-form]]
+== normalize(), with specified normal form
+
+`normalize()` returns the given `STRING` normalized using the specified normalization form.
+The normalization form can be of type `NFC`, `NFD`, `NFKC` or `NFKD`.
+
+*Syntax:*
+
+[source, syntax, role="noheader"]
+----
+normalize(input, normalForm)
+----
+
+*Returns:*
+
+|===
+
+| `STRING`
+
+|===
+
+*Arguments:*
+
+[options="header"]
+|===
+| Name | Description
+
+| `input`
+| An expression that returns a `STRING`.
+
+
+| `normalForm`
+| A keyword specifying the normal form, can be `NFC`, `NFD`, `NFKC` or `NFKD`.
+
+|===
+
+*Considerations:*
+
+|===
+
+| `normalize(null, NFC)` returns `null`.
+
+|===
+
+
+.+normalize()+
+======
+
+.Query
+[source, cypher, indent=0]
+----
+RETURN normalize('\uFE64', NFKC) = '\u003C' AS result
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| +result+
+| +true+
+1+d|Rows: 1
+
+|===
+
+======
+
 [[functions-replace]]
 == replace()
 

--- a/modules/ROOT/pages/functions/string.adoc
+++ b/modules/ROOT/pages/functions/string.adoc
@@ -153,13 +153,19 @@ RETURN ltrim('   hello')
 [[functions-normalize]]
 == normalize()
 
-`normalize()` returns the given `STRING` normalized using the `NFC` normalization form.
+`normalize()` returns the given `STRING` normalized using the `NFC` Unicode normalization form.
+
+[NOTE]
+====
+Unicode normalization is a process that transforms different representations of the same string into a standardized form.
+For more information, see the documentation for link:https://unicode.org/reports/tr15/#Norm_Forms[Unicode normalization forms].
+====
 
 The `normalize()` function is useful for converting `STRING` values into comparable forms.
 When comparing two `STRING` values, it is their Unicode codepoints that are compared.
-In Unicode, a codepoint for a character that looks the same may actually be represented by two, or more, different codepoints.
-For example, the character `<` can be represented as `\uFE64` or `\u003C`. Visually, the character may look the same,
-but if compared, Cypher will return false as `\uFE64` does not equal `\u003C`. Using the `normalize()` function one can
+In Unicode, a codepoint for a character that looks the same may be represented by two, or more, different codepoints.
+For example, the character `<` can be represented as `\uFE64` (﹤) or `\u003C` (<). Visually, the character may look the same,
+but if compared, Cypher will return false as `\uFE64` does not equal `\u003C`. Using the `normalize()` function, it is possible to
 normalize the codepoint `\uFE64` to `\u003C`, creating a single codepoint representation, allowing them to be successfully compared.
 
 *Syntax:*
@@ -225,16 +231,18 @@ RETURN normalize('\u212B') = '\u00C5' AS result
 `normalize()` returns the given `STRING` normalized using the specified normalization form.
 The normalization form can be of type `NFC`, `NFD`, `NFKC` or `NFKD`.
 
-There are two main types of normalization forms. One is based on the concept of canonical equivalence, and the other is based on compatibility.
+There are two main types of normalization forms:
 
-The two forms `NFC` (default) and `NFD` are forms of canonical equivalence. This means that codepoints which represent the same abstract character will
-be normalized to the same codepoint. The same abstract character means that the character has the same visual appearance and behavior.
-The difference between `NFC` and `NFD` is that `NFC` form will always give the *composed* canonical form, one where combined codes are replaced with the single representation, if possible.
-Whereas, `NFD` gives the *decomposed* form, this is the opposite of composed, converting combined codepoints into the split form if possible.
+*  *Canonical equivalence*: The `NFC` (default) and `NFD` are forms of canonical equivalence.
+This means that codepoints that represent the same abstract character will
+be normalized to the same codepoint (and have the same appearance and behavior).
+The `NFC` form will always give the *composed* canonical form (in which the combined codes are replaced with a single representation, if possible).
+The`NFD` form gives the *decomposed* form (the opposite of the composed form, which converts the combined codepoints into a split form if possible).
 
-The two forms `NFKC` and `NFKD` are forms of compatibility normalization. All canonically equivalent sequences are compatible, but not all compatible sequences are canonical.
-This means that a character normalized in `NFC` or `NFD` should also be normalized in `NFKC` and `NFKD`, and other characters that may have a slightly different visual appearance,
-but are considered close enough in appearance to be compatibly equivalent.
+* *Compatability normalization*: `NFKC` and `NFKD` are forms of compatibility normalization.
+All canonically equivalent sequences are compatible, but not all compatible sequences are canonical.
+This means that a character normalized in `NFC` or `NFD` should also be normalized in `NFKC` and `NFKD`.
+Other characters with only slight differences in appearance should be compatibly equivalent.
 
 For example, the Greek Upsilon with Acute and Hook Symbol `ϓ` can be represented by the Unicode codepoint: `\u03D3`.
 

--- a/modules/ROOT/pages/functions/string.adoc
+++ b/modules/ROOT/pages/functions/string.adoc
@@ -153,6 +153,8 @@ RETURN ltrim('   hello')
 [[functions-normalize]]
 == normalize()
 
+_This feature was introduced in Neo4j 5.17._
+
 `normalize()` returns the given `STRING` normalized using the `NFC` Unicode normalization form.
 
 [NOTE]
@@ -229,6 +231,8 @@ RETURN normalize('\u212B') = '\u00C5' AS result
 
 [[functions-normalize-with-normal-form]]
 == normalize(), with specified normal form
+
+_This feature was introduced in Neo4j 5.17._
 
 `normalize()` returns the given `STRING` normalized using the specified normalization form.
 The normalization form can be of type `NFC`, `NFD`, `NFKC` or `NFKD`.


### PR DESCRIPTION
The normalize function normalizes a string based on the normalization form. It is useful for converting unicode representations of characters that look the same to be the same unicode sequence, allowing for easier comparisons.