### PR TITLE
Add deprecation for identifier characters

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -16,6 +16,43 @@ New features are added to the language continuously, and occasionally, some feat
 This section lists all of the features that have been removed, deprecated, added, or extended in different Cypher versions.
 Replacement syntax for deprecated and removed features are also indicated.
 
+[[cypher-deprecations-additions-removals-5.15]]
+== Neo4j 5.15
+
+=== Deprecated features
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:deprecated[]
+[source, cypher, role="noheader"]
+----
+RETURN 1 as my$Identifier
+----
+a|
+The character with the Unicode representation \`\u0024` is deprecated for unescaped identifiers and will not be supported in the future. To continue using it, escape the identifier by adding backticks around the identifier.
+This applies to all unescaped identifiers in Cypher, such as label expressions, properties, variable names or parameters. In the given example, the quoted identifier would be \`my$identifier`.
+
+The following Unicode Characters are deprecated in identifiers:
+'\u0000', '\u0001', '\u0002', '\u0003', '\u0004', '\u0005', '\u0006', '\u0007',
+'\u0008', '\u000E', '\u000F', '\u0010', '\u0011', '\u0012', '\u0013', '\u0014',
+'\u0015', '\u0016', '\u0017', '\u0018', '\u0019', '\u001A', '\u001B', '\u007F',
+'\u0080', '\u0081', '\u0082', '\u0083', '\u0084', '\u0086', '\u0087', '\u0088',
+'\u0089', '\u008A', '\u008B', '\u008C', '\u008D', '\u008E', '\u008F', '\u0090',
+'\u0091', '\u0092', '\u0093', '\u0094', '\u0095', '\u0096', '\u0097', '\u0098',
+'\u0099', '\u009A', '\u009B', '\u009C', '\u009D', '\u009E', '\u009F', '\u0024',
+'\u00A2', '\u00A3', '\u00A4', '\u00A5', '\u00AD', '\u0600', '\u0601', '\u0602',
+'\u0603', '\u0604', '\u0605', '\u061C', '\u06DD', '\u070F', '\u08E2', '\u180E',
+'\u200B', '\u200C', '\u200D', '\u200E', '\u200F', '\u202A', '\u202B', '\u202C',
+'\u202D', '\u202E', '\u2060', '\u2061', '\u2062', '\u2063', '\u2064', '\u2066',
+'\u2067', '\u2068', '\u2069', '\u206A', '\u206B', '\u206C', '\u206D', '\u206E',
+'\u206F', '\u2E2F', '\uFEFF', '\uFFF9', '\uFFFA', '\uFFFB'
+
+|===
+
 [[cypher-deprecations-additions-removals-5.14]]
 == Neo4j 5.14
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -24,6 +24,18 @@ Replacement syntax for deprecated and removed features are also indicated.
 |===
 | Feature
 | Details
+a|
+label:functionality[]
+label:deprecated[]
+[source, cypher, role="noheader"]
+----
+RETURN 1 as my\u0085identifier
+----
+a|
+The Unicode character \`\u0085` is deprecated for unescaped identifiers and will be considered as a whitespace character in the future. 
+To continue using it, escape the identifier by adding backticks around the identifier.
+This applies to all unescaped identifiers in Cypher, such as label expressions, properties, variable names or parameters. 
+In the given example, the quoted identifier would be \`my�identifier`.
 
 a|
 label:functionality[]
@@ -50,14 +62,6 @@ The following Unicode Characters are deprecated in identifiers:
 '\u202D', '\u202E', '\u2060', '\u2061', '\u2062', '\u2063', '\u2064', '\u2066',
 '\u2067', '\u2068', '\u2069', '\u206A', '\u206B', '\u206C', '\u206D', '\u206E',
 '\u206F', '\u2E2F', '\uFEFF', '\uFFF9', '\uFFFA', '\uFFFB'
-=======
-RETURN 1 as my\u0085identifier
-----
-a|
-The Unicode character \`\u0085` is deprecated for unescaped identifiers and will be considered as a whitespace character in the future. 
-To continue using it, escape the identifier by adding backticks around the identifier.
-This applies to all unescaped identifiers in Cypher, such as label expressions, properties, variable names or parameters. 
-In the given example, the quoted identifier would be \`my�identifier`.
 
 |===
 

--- a/modules/ROOT/pages/syntax/naming.adoc
+++ b/modules/ROOT/pages/syntax/naming.adoc
@@ -51,7 +51,7 @@ Some techniques to mitigate this are:
 
 [NOTE]
 ====
-Some more special characters have been deprecated and will require escaping in a Neo4j 6.0, see xref::deprecations-additions-removals-compatibility.adoc#cypher-deprecations-additions-removals-5.15[here] for the comprehensive list of deprecated characters.
+Several special characters have been deprecated and will require escaping in Neo4j 6.0, see xref::deprecations-additions-removals-compatibility.adoc#cypher-deprecations-additions-removals-5.15[here] for the comprehensive list of deprecated characters.
 ====
 
 == Scoping and namespace rules

--- a/modules/ROOT/pages/syntax/naming.adoc
+++ b/modules/ROOT/pages/syntax/naming.adoc
@@ -49,6 +49,11 @@ Some techniques to mitigate this are:
 
 ====
 
+[NOTE]
+====
+Some more special characters have been deprecated and will require escaping in a Neo4j 6.0, see xref::deprecations-additions-removals-compatibility.adoc#cypher-deprecations-additions-removals-5.15[here] for the comprehensive list of deprecated characters.
+====
+
 == Scoping and namespace rules
 
 * Node labels, relationship types and property names may re-use names.


### PR DESCRIPTION
We are deprecating the use of certain unicodes in identifiers, this contains the list of them. Some of the characters are easy to show without unicode e.g dollar sign, some are not :) 