### PR TITLE
 Replaced deprecated pattern (#780)

### DIFF
--- a/modules/ROOT/pages/styleguide.adoc
+++ b/modules/ROOT/pages/styleguide.adoc
@@ -360,17 +360,15 @@ RETURN count(vehicle)
 .Bad
 [source, cypher]
 ----
-CREATE (a:End {prop: 42}),
-       (b:End {prop: 3}),
-       (c:Begin {prop: elementId(a)})
+MATCH (kate:Person {name: 'Kate'})-[r:LIKES]-(c:Car)
+RETURN c.type
 ----
 +
 .Good
 [source, cypher]
 ----
-CREATE (a:End {prop: 42}),
-       (:End {prop: 3}),
-       (:Begin {prop: elementId(a)})
+MATCH (:Person {name: 'Kate'})-[:LIKES]-(c:Car)
+RETURN c.type
 ----
 
 * Chain patterns together to avoid repeating variables.


### PR DESCRIPTION
Cross-references in CREATE statements are deprecated, as their semantics are often unclear.