### PR TITLE
`SHOW INDEXES` can now be filtered on `VECTOR` same as other index type filtering

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -65,6 +65,26 @@ The following Unicode Characters are deprecated in identifiers:
 
 |===
 
+=== Updated features
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+a|
+label:functionality[]
+label:updated[]
+
+[source, cypher, role="noheader"]
+----
+SHOW VECTOR INDEXES
+----
+
+| Extended xref:indexes-for-search-performance.adoc#indexes-list-indexes[`SHOW INDEXES`] with easy filtering for vector indexes.
+This is equivalent to `SHOW INDEXES WHERE type = 'VECTOR'`.
+
+|===
+
 === New features
 
 [cols="2", options="header"]

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -599,7 +599,7 @@ Listing indexes can be done with `SHOW INDEXES`.
 
 [source, syntax, role="noheader"]
 ----
-SHOW [ALL \| FULLTEXT \| LOOKUP \| POINT \| RANGE \| TEXT] INDEX[ES]
+SHOW [ALL \| FULLTEXT \| LOOKUP \| POINT \| RANGE \| TEXT \| VECTOR] INDEX[ES]
   [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
   [WHERE expression]
   [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
@@ -629,7 +629,7 @@ This command will produce a table with the following columns:
 | `FLOAT`
 
 | `type`
-| The IndexType of this index (`FULLTEXT`, `LOOKUP`, `POINT`, `RANGE`, or `TEXT`). label:default-output[]
+| The IndexType of this index (`FULLTEXT`, `LOOKUP`, `POINT`, `RANGE`, `TEXT`, or `VECTOR`). label:default-output[]
 | `STRING`
 
 | `entityType`
@@ -1097,7 +1097,7 @@ With `IF EXISTS`, no error is thrown and nothing happens should the index not ex
 |
 [source, syntax, role="noheader"]
 ----
-SHOW [ALL \| FULLTEXT \| LOOKUP \| POINT \| RANGE \| TEXT] INDEX[ES]
+SHOW [ALL \| FULLTEXT \| LOOKUP \| POINT \| RANGE \| TEXT \| VECTOR] INDEX[ES]
   [YIELD { * \| field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]
   [WHERE expression]
   [RETURN field[, ...] [ORDER BY field[, ...]] [SKIP n] [LIMIT n]]

--- a/modules/ROOT/pages/indexes-for-vector-search.adoc
+++ b/modules/ROOT/pages/indexes-for-vector-search.adoc
@@ -57,11 +57,11 @@ Returns the requested number of approximate nearest neighbor nodes and their sim
 
 | Drop vector index.
 | `+DROP INDEX index_name+`
-| Drop the specified index.
+| Drop the specified index, see the xref:indexes-for-search-performance.adoc#indexes-drop-indexes[`DROP INDEX`] command for details.
 
 | Listing all vector indexes.
-| `SHOW INDEXES WHERE type = "VECTOR"`
-| Lists all vector indexes, see the xref:indexes-for-search-performance.adoc#indexes-list-indexes[`SHOW INDEXES`] command for details. There is no vector index filter built into `SHOW INDEXES`.
+| `SHOW VECTOR INDEXES`
+| Lists all vector indexes, see the xref:indexes-for-search-performance.adoc#indexes-list-indexes[`SHOW INDEXES`] command for details.
 
 | Set vector property.
 | {link-procedures-reference}#procedure_db_create_setNodeVectorProperty[`db.create.setNodeVectorProperty`]
@@ -144,8 +144,7 @@ You can see that the vector index has been created using `SHOW INDEXES`:
 .Query
 [source,cypher]
 ----
-SHOW INDEXES YIELD name, type, labelsOrTypes, properties, options
-WHERE type = 'VECTOR'
+SHOW VECTOR INDEXES YIELD name, type, labelsOrTypes, properties, options
 ----
 
 .Result
@@ -404,7 +403,7 @@ For example, you cannot have one xref:indexes-vector-similarity-euclidean[Euclid
 
 * Changes made within the same transaction are not visible to the index.
 
-* There is no Cypher syntax for creating a vector index, nor for the standard index type filtering with xref:indexes-for-search-performance.adoc#indexes-list-indexes[`SHOW INDEXES`] command.
+* There is no Cypher syntax for creating a vector index.
 
 [[index-vector-issues]]
 == Known issues
@@ -415,6 +414,19 @@ The following table lists the known issues and the version in which they were fi
 [%header,cols="5a,d"]
 |===
 | Known issues | Fixed in
+
+| The standard index type filtering for xref:indexes-for-search-performance.adoc#indexes-list-indexes[`SHOW INDEXES`] command is missing.
+
+[TIP]
+====
+Filtering on vector indexes can be done with the `WHERE` clause as well:
+[source,cypher]
+----
+SHOW INDEXES
+WHERE type = 'VECTOR'
+----
+====
+| Neo4j 5.15
 
 | Querying for a _single_ approximate nearest neighbor from an index would fail a validation check. Passing a `null` value would also provide an unhelpful exception.
 | Neo4j 5.13
@@ -481,9 +493,7 @@ If a store copy is required, make a note of the information in the `createStatem
 For example:
 [source,cypher]
 ----
-SHOW INDEXES YIELD type, createStatement
-WHERE type = 'VECTOR'
-RETURN createStatement
+SHOW VECTOR INDEXES YIELD createStatement
 ----
 ====
 | Neo4j 5.12

--- a/modules/ROOT/pages/indexes-for-vector-search.adoc
+++ b/modules/ROOT/pages/indexes-for-vector-search.adoc
@@ -493,7 +493,9 @@ If a store copy is required, make a note of the information in the `createStatem
 For example:
 [source,cypher]
 ----
-SHOW VECTOR INDEXES YIELD createStatement
+SHOW INDEXES YIELD type, createStatement
+WHERE type = 'VECTOR'
+RETURN createStatement
 ----
 ====
 | Neo4j 5.12


### PR DESCRIPTION
Allowing for `SHOW VECTOR INDEXES`.