### PR TITLE
Update the links to syntax description section

### DIFF
--- a/modules/ROOT/pages/clauses/listing-functions.adoc
+++ b/modules/ROOT/pages/clauses/listing-functions.adoc
@@ -76,7 +76,7 @@ m| BOOLEAN
 
 [NOTE]
 ====
-More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
 ====
 
 List functions, either all or only built-in or user-defined::

--- a/modules/ROOT/pages/clauses/listing-functions.adoc
+++ b/modules/ROOT/pages/clauses/listing-functions.adoc
@@ -76,7 +76,7 @@ m| BOOLEAN
 
 [NOTE]
 ====
-More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax/#administration-syntax-reading[here].
 ====
 
 List functions, either all or only built-in or user-defined::

--- a/modules/ROOT/pages/clauses/listing-procedures.adoc
+++ b/modules/ROOT/pages/clauses/listing-procedures.adoc
@@ -79,7 +79,7 @@ The deprecation information for procedures is returned both in the `isDeprecated
 
 [NOTE]
 ====
-More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
 ====
 
 List all procedures::

--- a/modules/ROOT/pages/clauses/listing-procedures.adoc
+++ b/modules/ROOT/pages/clauses/listing-procedures.adoc
@@ -79,7 +79,7 @@ The deprecation information for procedures is returned both in the `isDeprecated
 
 [NOTE]
 ====
-More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax/#administration-syntax-reading[here].
 ====
 
 List all procedures::

--- a/modules/ROOT/pages/clauses/listing-settings.adoc
+++ b/modules/ROOT/pages/clauses/listing-settings.adoc
@@ -76,7 +76,7 @@ m| BOOLEAN
 
 [NOTE]
 ====
-More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
 ====
 
 List settings::

--- a/modules/ROOT/pages/clauses/listing-settings.adoc
+++ b/modules/ROOT/pages/clauses/listing-settings.adoc
@@ -76,7 +76,7 @@ m| BOOLEAN
 
 [NOTE]
 ====
-More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax/#administration-syntax-reading[here].
 ====
 
 List settings::

--- a/modules/ROOT/pages/clauses/transaction-clauses.adoc
+++ b/modules/ROOT/pages/clauses/transaction-clauses.adoc
@@ -208,7 +208,7 @@ The `SHOW TRANSACTIONS` command can be combined with multiple `SHOW TRANSACTIONS
 
 [NOTE]
 ====
-More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax/#administration-syntax-reading[here].
 ====
 
 List transactions on the current server::
@@ -370,7 +370,7 @@ The `TERMINATE TRANSACTIONS` command can be combined with multiple `SHOW TRANSAC
 
 [NOTE]
 ====
-More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax/#administration-syntax-reading[here].
 ====
 
 Terminate transactions by ID on the current server::

--- a/modules/ROOT/pages/clauses/transaction-clauses.adoc
+++ b/modules/ROOT/pages/clauses/transaction-clauses.adoc
@@ -208,7 +208,7 @@ The `SHOW TRANSACTIONS` command can be combined with multiple `SHOW TRANSACTIONS
 
 [NOTE]
 ====
-More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
 ====
 
 List transactions on the current server::
@@ -370,7 +370,7 @@ The `TERMINATE TRANSACTIONS` command can be combined with multiple `SHOW TRANSAC
 
 [NOTE]
 ====
-More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
 ====
 
 Terminate transactions by ID on the current server::

--- a/modules/ROOT/pages/indexes-for-full-text-search.adoc
+++ b/modules/ROOT/pages/indexes-for-full-text-search.adoc
@@ -103,7 +103,7 @@ Creating a full-text index requires link:{neo4j-docs-base-uri}/operations-manual
 
 [NOTE]
 ====
-More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax/#administration-syntax-reading[here].
 ====
 
 .Syntax for creating full-text indexes

--- a/modules/ROOT/pages/indexes-for-full-text-search.adoc
+++ b/modules/ROOT/pages/indexes-for-full-text-search.adoc
@@ -103,7 +103,7 @@ Creating a full-text index requires link:{neo4j-docs-base-uri}/operations-manual
 
 [NOTE]
 ====
-More details about the syntax descriptions can be found xref:administration/index.adoc#administration-syntax[here].
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
 ====
 
 .Syntax for creating full-text indexes

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -1113,7 +1113,7 @@ SHOW [ALL \| FULLTEXT \| LOOKUP \| POINT \| RANGE \| TEXT] INDEX[ES]
 
 [NOTE]
 ====
-More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax/#administration-syntax-reading[here].
 ====
 
 Creating an index requires link:{neo4j-docs-base-uri}/operations-manual/{page-version}/authentication-authorization/database-administration/#access-control-database-administration-index[the `CREATE INDEX` privilege],

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -1109,6 +1109,10 @@ SHOW [ALL \| FULLTEXT \| LOOKUP \| POINT \| RANGE \| TEXT] INDEX[ES]
 
 |===
 
+[NOTE]
+====
+More details about the syntax descriptions can be found link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/syntax.adoc#administration-syntax-reading[here].
+====
 
 Creating an index requires link:{neo4j-docs-base-uri}/operations-manual/{page-version}/authentication-authorization/database-administration/#access-control-database-administration-index[the `CREATE INDEX` privilege],
 while dropping an index requires link:{neo4j-docs-base-uri}/operations-manual/{page-version}/authentication-authorization/database-administration/#access-control-database-administration-index[the `DROP INDEX` privilege] and listing indexes require link:{neo4j-docs-base-uri}/operations-manual/{page-version}/authentication-authorization/database-administration/#access-control-database-administration-index[the `SHOW INDEX` privilege].

--- a/modules/ROOT/pages/indexes-for-search-performance.adoc
+++ b/modules/ROOT/pages/indexes-for-search-performance.adoc
@@ -28,8 +28,10 @@ There are multiple index types available:
 * Text index.
 * Point index.
 * Full-text index.
+* Vector index.
 
 See xref::indexes-for-full-text-search.adoc[Full-text search index] for more information about full-text indexes.
+See xref::indexes-for-vector-search.adoc[Vector search index] for more information about vector indexes.
 Lookup indexes contain nodes with one or more labels or relationship types, without regard for any properties.
 
 Cypher enables the creation of range indexes on one or more properties for all nodes or relationships with a given label or relationship type:


### PR DESCRIPTION

Since they were broken after it moved to the operations manual.

Also add a comment around the new vector index type where we explain different index types same as how it looks for full-text indexes.