### PR TITLE
Update `SHOW SETTINGS` output after bug fix

### DIFF
--- a/modules/ROOT/pages/clauses/listing-settings.adoc
+++ b/modules/ROOT/pages/clauses/listing-settings.adoc
@@ -204,7 +204,7 @@ LIMIT 10
 | "The catch up protocol times out if the given duration elapses with no network activity. Every message received by the client from the server extends the time out duration."
 
 | "dbms.cluster.discovery.endpoints"
-| "No Value"
+| null
 | "A comma-separated list of endpoints which a server should contact in order to discover other cluster members."
 
 | "dbms.cluster.discovery.log_level"

--- a/modules/ROOT/pages/clauses/listing-settings.adoc
+++ b/modules/ROOT/pages/clauses/listing-settings.adoc
@@ -221,7 +221,7 @@ LIMIT 10
 
 | "dbms.cluster.minimum_initial_system_primaries_count"
 | "3"
-| "This setting has been moved to Cluster Base Settings"
+| "Minimum number of machines initially required to formed a clustered DBMS. The cluster is considered formed when at least this many members have discovered each other, bound together and bootstrapped a highly available system database. As a result, at least this many of the cluster's initial machines must have 'server.cluster.system_database_mode' set to 'PRIMARY'.NOTE: If 'dbms.cluster.discovery.resolver_type' is set to 'LIST' and 'dbms.cluster.discovery.endpoints' is empty then the user is assumed to be deploying a standalone DBMS, and the value of this setting is ignored."
 
 | "dbms.cluster.network.handshake_timeout"
 | "20s"


### PR DESCRIPTION
changing the `"No Value"` to `null` when value, default value or startup value is not set