### PR TITLE
Fix by-element-id vs by-id confusion

### DIFF
--- a/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
+++ b/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
@@ -1064,10 +1064,55 @@ Total database accesses: 1, total allocated memory: 184
 == Node By Id Seek
 // NodeByIdSeek
 
-The `NodeByIdSeek` operator reads one or more nodes by ID from the node store, specified via the function xref::functions/scalar.adoc#functions-elementid[elementId()].
+The `NodeByIdSeek` operator reads one or more nodes by ID from the node store, specified via the function xref::functions/scalar.adoc#functions-id[id()].
 
 
 .NodeByIdSeek
+======
+
+.Query
+[source, cypher]
+----
+PROFILE
+MATCH (n)
+WHERE id(n) = 0
+RETURN n
+----
+
+.Query Plan
+[role="queryplan", subs="attributes+"]
+----
+Planner COST
+
+Runtime PIPELINED
+
+Runtime version {neo4j-version-minor}
+
+Batch size 128
+
++-----------------+----+----------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| Operator        | Id | Details                    | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
++-----------------+----+----------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| +ProduceResults |  0 | n                          |              1 |    1 |       2 |              0 |                        |           |                     |
+| |               +----+----------------------------+----------------+------+---------+----------------+                        |           |                     |
+| +NodeByIdSeek   |  1 | n WHERE id(n) = $autoint_0 |              1 |    1 |       1 |            248 |                    2/0 |     1.109 | Fused in Pipeline 0 |
++-----------------+----+----------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+
+Total database accesses: 3, total allocated memory: 312
+
+1 row
+----
+
+======
+
+[[query-plan-node-by-element-id-seek]]
+== Node By Element Id Seek
+// NodeByElementIdSeek
+
+The `NodeByElementIdSeek` operator reads one or more nodes by element ID from the node store, specified via the function xref::functions/scalar.adoc#functions-elementid[elementId()].
+
+
+.NodeByElementIdSeek
 ======
 
 .Query

--- a/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
+++ b/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
@@ -311,14 +311,14 @@ Total database accesses: 2, total allocated memory: 184
 ======
 
 
-[[query-plan-directed-relationship-by-id-seek]]
-== Directed Relationship By Id Seek
-// DirectedRelationshipByIdSeek
+[[query-plan-directed-relationship-by-element-id-seek]]
+== Directed Relationship By Element Id Seek
+// DirectedRelationshipByElementIdSeek
 
-The `DirectedRelationshipByIdSeek` operator reads one or more relationships by id from the relationship store, and produces both the relationship and the nodes on either side.
+The `DirectedRelationshipByElementIdSeek` operator reads one or more relationships by element id from the relationship store, and produces both the relationship and the nodes on either side.
 
 
-.DirectedRelationshipByIdSeek
+.DirectedRelationshipByElementIdSeek
 ======
 
 .Query
@@ -341,21 +341,61 @@ Runtime version {neo4j-version-minor}
 
 Batch size 128
 
-+-------------------------------+----+---------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| Operator                      | Id | Details                   | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
-+-------------------------------+----+---------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| +ProduceResults               |  0 | r, n1                     |              1 |    0 |       0 |                |                        |           |                     |
-| |                             +----+---------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +Filter                       |  1 | elementId(r) = $autoint_0 |              1 |    0 |       0 |                |                        |           |                     |
-| |                             +----+---------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +DirectedAllRelationshipsScan |  2 | (n1)-[r]->(anon_0)        |              3 |    0 |       0 |            248 |                    1/0 |     0.134 | Fused in Pipeline 0 |
-+-------------------------------+----+---------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
++--------------------------------------+----+----------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------+
+| Operator                             | Id | Details                                            | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline      |
++--------------------------------------+----+----------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------+
+| +ProduceResults                      |  0 | r, n1                                              |              1 |    0 |       0 |              0 |                    0/0 |     0.314 |               |
+| |                                    +----+----------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+               |
+| +DirectedRelationshipByElementIdSeek |  1 | (n1)-[r]->(anon_0) WHERE elementId(r) = $autoint_0 |              1 |    0 |       0 |            248 |                    0/0 |     2.337 | In Pipeline 0 |
++--------------------------------------+----+----------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------+
 
-Total database accesses: 1, total allocated memory: 184
+Total database accesses: 0, total allocated memory: 312
 ----
 
 ======
 
+[[query-plan-directed-relationship-by-id-seek]]
+== Directed Relationship By Id Seek
+// DirectedRelationshipByIdSeek
+
+The `DirectedRelationshipByIdSeek` operator reads one or more relationships by id from the relationship store, and produces both the relationship and the nodes on either side.
+
+
+.DirectedRelationshipByIdSeek
+======
+
+.Query
+[source, cypher]
+----
+PROFILE
+MATCH (n1)-[r]->()
+WHERE id(r) = 0
+RETURN r, n1
+----
+
+.Query Plan
+[role="queryplan", subs="attributes+"]
+----
+Planner COST
+
+Runtime PIPELINED
+
+Runtime version {neo4j-version-minor}
+
+Batch size 128
+
++-------------------------------+----+---------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| Operator                      | Id | Details                                     | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
++-------------------------------+----+---------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| +ProduceResults               |  0 | r, n1                                       |              1 |    1 |       7 |              0 |                        |           |                     |
+| |                             +----+---------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
+| +DirectedRelationshipByIdSeek |  1 | (n1)-[r]->(anon_0) WHERE id(r) = $autoint_0 |              1 |    1 |       1 |            248 |                    3/0 |     0.483 | Fused in Pipeline 0 |
++-------------------------------+----+---------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+
+Total database accesses: 8, total allocated memory: 312
+----
+
+======
 
 [[query-plan-undirected-relationship-by-element-id-seek]]
 == Undirected Relationship By Element Id Seek

--- a/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
+++ b/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
@@ -357,15 +357,15 @@ Total database accesses: 1, total allocated memory: 184
 ======
 
 
-[[query-plan-undirected-relationship-by-id-seek]]
-== Undirected Relationship By Id Seek
-// UndirectedRelationshipByIdSeek
+[[query-plan-undirected-relationship-by-element-id-seek]]
+== Undirected Relationship By Element Id Seek
+// UndirectedRelationshipByElementIdSeek
 
-The `UndirectedRelationshipByIdSeek` operator reads one or more relationships by id from the relationship store.
+The `UndirectedRelationshipByElementIdSeek` operator reads one or more relationships by element id from the relationship store.
 As the direction is unspecified, two rows are produced for each relationship as a result of alternating the combination of the start and end node.
 
 
-.UndirectedRelationshipByIdSeek
+.UndirectedRelationshipByElementIdSeek
 ======
 
 .Query
@@ -397,6 +397,50 @@ Batch size 128
 +---------------------------------+--------------------------------------------+-----+---------------+------+---------+----------------+------------------------+-----------+---------------------+
 
 Total database accesses: 1, total allocated memory: 184
+----
+
+======
+
+[[query-plan-undirected-relationship-by-id-seek]]
+== Undirected Relationship By Id Seek
+// UndirectedRelationshipByIdSeek
+
+The `UndirectedRelationshipByIdSeek` operator reads one or more relationships by id from the relationship store.
+As the direction is unspecified, two rows are produced for each relationship as a result of alternating the combination of the start and end node.
+
+
+.UndirectedRelationshipByIdSeek
+======
+
+.Query
+[source, cypher]
+----
+PROFILE
+MATCH (n1)-[r]-()
+WHERE id(r) = 1
+RETURN r, n1
+----
+
+.Query Plan
+[role="queryplan", subs="attributes+"]
+----
+Planner COST
+
+Runtime PIPELINED
+
+Runtime version {neo4j-version-minor}
+
+Batch size 128
+
++---------------------------------+----+--------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| Operator                        | Id | Details                                    | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
++---------------------------------+----+--------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| +ProduceResults                 |  0 | r, n1                                      |              2 |    2 |      14 |              0 |                        |           |                     |
+| |                               +----+--------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
+| +UndirectedRelationshipByIdSeek |  1 | (n1)-[r]-(anon_0) WHERE id(r) = $autoint_0 |              2 |    2 |       1 |            248 |                    3/0 |     1.005 | Fused in Pipeline 0 |
++---------------------------------+----+--------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+
+Total database accesses: 15, total allocated memory: 312
 ----
 
 ======


### PR DESCRIPTION
There was some confusion on the "Operators in detail" page about NodeByIdSeek vs NodeByElementIdSeek etc. This PR makes sure both variants are represented on the page.