### PR TITLE
Fix some tests

### DIFF
--- a/modules/ROOT/pages/indexes/search-performance-indexes/using-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/using-indexes.adoc
@@ -1,7 +1,5 @@
-:description: Information about how to use the search-performance indexes in Neo4j.
+:description: Information about how search-performance indexes impact query performance in Neo4j.
 :test-setup-dump: https://github.com/neo4j-graph-examples/openstreetmap/raw/main/data/openstreetmap-50.dump
-:test-skip: true
-
 
 = The impact of indexes on query performance
 
@@ -53,7 +51,7 @@ RETURN count(n)
 |===
 | count(n)
 | 26
-d|Rows:1
+d|Rows: 1
 |===
 
 .Execution plan
@@ -181,7 +179,7 @@ RETURN n.name AS name, n.type AS type
 | "William Shakespeare" | "statue"
 | "William Tecumseh Sherman" | "equestrian statue"
 
-2+d|Rows:2
+2+d|Rows: 2
 |===
 
 .Execution plan
@@ -263,7 +261,7 @@ For information about calculating the size of indexes, see link:https://neo4j.co
 Point indexes solve predicates operating on spatial xref:values-and-types/spatial.adoc#spatial-values-point-type[`POINT`] values.
 Point indexes are optimized for queries filtering for the xref:functions/spatial.adoc#functions-distance[distance] between property values, or for property values within a xref:functions/spatial.adoc#functions-withinBBox[bounding box].
 
-The following example creates a point index which is then accessed through the `point.distance()` function to return the `name` and `type` of all `PointOfInterest` nodes within 100 meters of the  `William Shakespeare` statue:
+The following example creates a point index which is then used in an query returning the `name` and `type` of all `PointOfInterest` nodes within a set bounding box:
 
 .Create a point index
 [source,cypher]
@@ -271,49 +269,51 @@ The following example creates a point index which is then accessed through the `
 CREATE POINT INDEX point_index_location FOR (n:PointOfInterest) ON (n.location)
 ----
 
-.Query using the `point.distance()` function
+.Query using the `point.withinBBox()` function
 [source,cypher]
 ----
-PROFILE
-MATCH (p1:PointOfInterest {name:'William Shakespeare'}),(p2:PointOfInterest)
-WHERE p1<>p2 AND point.distance(p1.location, p2.location) < 100
-RETURN p2.name AS name, p2.type AS type
+PROFILE 
+MATCH (n:PointOfInterest)
+WHERE point.withinBBox(
+  n.location,
+  point({srid: 4326, x: -73.9723702, y: 40.7697989}),
+  point({srid: 4326, x: -73.9725659, y: 40.770193}))
+RETURN n.name AS name, n.type AS type
 ----
 
 .Result
 [options="header,footer",cols="2*m"]
 |===
 | name | type
-| "Walter Scott" | "statue"
+| "Heckscher Ballfield 3" | "baseball"
+| "Heckscher Ballfield 4" | "baseball"
+| "Heckscher Ballfield 1" | "baseball"
 | "Robert Burns" | "statue"
 | "Christopher Columbus" | "statue"
-| "Fitz-Greene Halleck" | "statue"
+| "Walter Scott" | "statue"
+| "William Shakespeare" | "statue"
+| "Balto" | "statue"
 
-2+d|Rows:4
+2+d|Rows: 8
 |===
 
 .Execution plan
 [role="queryplan"]
 ----
-+--------------------+----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------+
-| Operator           | Id | Details                                                               | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline      |
-+--------------------+----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------+
-| +ProduceResults    |  0 | name, type                                                            |              0 |    0 |       0 |                |                    0/0 |     0.000 |               |
-| |                  +----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+               |
-| +Projection        |  1 | cache[p2.name] AS name, cache[p2.type] AS type                        |              0 |    0 |       0 |                |                    0/0 |     0.000 |               |
-| |                  +----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+               |
-| +CacheProperties   |  2 | cache[p2.type], cache[p2.name]                                        |              0 |    0 |       0 |                |                    0/0 |     0.000 |               |
-| |                  +----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+               |
-| +Filter            |  3 | NOT p1 = p2 AND point.distance(p1.location, p2.location) < $autoint_1 |              0 |    0 |       0 |                |                    0/0 |     0.000 |               |
-| |                  +----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+               |
-| +CartesianProduct  |  4 |                                                                       |              0 |    0 |       0 |           1392 |                    0/0 |     0.021 | In Pipeline 2 |
-| |\                 +----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------+
-| | +NodeByLabelScan |  5 | p2:PointOfInterest                                                    |              0 |    0 |       0 |            256 |                    0/0 |     0.000 | In Pipeline 1 |
-| |                  +----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------+
-| +NodeIndexSeek     |  6 | RANGE INDEX p1:PointOfInterest(name) WHERE name = $autostring_0       |              0 |    0 |       1 |            376 |                    1/0 |     0.372 | In Pipeline 0 |
-+--------------------+----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------+
++-----------------------+----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| Operator              | Id | Details                                                                                              | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
++-----------------------+----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| +ProduceResults       |  0 | `n.name`, `n.type`                                                                                   |              4 |    8 |       0 |              0 |                        |           |                     |
+| |                     +----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
+| +Projection           |  1 | cache[n.name] AS `n.name`, cache[n.type] AS `n.type`                                                 |              4 |    8 |       0 |                |                        |           |                     |
+| |                     +----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
+| +CacheProperties      |  2 | cache[n.type], cache[n.name]                                                                         |              4 |    8 |      24 |                |                        |           |                     |
+| |                     +----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
+| +NodeIndexSeekByRange |  3 | POINT INDEX n:PointOfInterest(location) WHERE point.withinBBox(location, point($autoint_0, $autodoub |              4 |    8 |      10 |            248 |                  302/0 |     2.619 | Fused in Pipeline 0 |
+|                       |    | le_1, $autodouble_2), point($autoint_3, $autodouble_4, $autodouble_5))                               |                |      |         |                |                        |           |                     |
++-----------------------+----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
 
-Total database accesses: 1, total allocated memory: 2104
+Total database accesses: 34, total allocated memory: 312
 ----
 
 For more information about the predicates supported by text indexes, see xref:indexes/search-performance-indexes/managing-indexes.adoc#point-indexes-supported-predicates[Managing search-performance indexes -> Point indexes: supported predicates].
@@ -385,7 +385,7 @@ RETURN length(path) AS pathLength, sum(rel.distance) AS geographicalDistance
 
 |  25  | 2410.4495689536334
 
-2+d|Rows:1
+2+d|Rows: 1
 |===
 
 .Execution plan
@@ -456,7 +456,7 @@ RETURN n.name AS name
 |===
 | name
 | "William Shakespeare"
-1+d|Rows:1
+1+d|Rows: 1
 |===
 
 .Execution plan
@@ -751,7 +751,7 @@ RETURN count(n) AS nodes
 |===
 | nodes
 | 5
-1+d|Rows:1
+1+d|Rows: 1
 |===
 
 The query result now includes both the three nodes with an unset `name` value found in the previous query and the two nodes with a `name` value containing `William` (`William Shakespeare` and `William Tecumseh Sherman`).
@@ -807,7 +807,7 @@ RETURN count(n) AS nodes
 |===
 | nodes
 | 185
-1+d|Rows:1
+1+d|Rows: 1
 |===
 
 .Execution plan

--- a/modules/ROOT/pages/indexes/search-performance-indexes/using-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/using-indexes.adoc
@@ -84,7 +84,7 @@ In the above example, had a node label lookup index not existed, the `NodeByLabe
 
 While useful, token lookup indexes will rarely be sufficient for applications querying databases of a non-trivial size because they cannot solve any property-related predicates.
 
-For more information about the predicates supported by token lookup indexes, see xref:indexes/search-performance-indexes/managing-indexes.adoc#lookup-index-supported-predicates[Managing search-performance indexes -> Token lookup indexes: supported predicates]. 
+For more information about the predicates supported by token lookup indexes, see xref:indexes/search-performance-indexes/managing-indexes.adoc#lookup-index-supported-predicates[Managing search-performance indexes -> Token lookup indexes: supported predicates].
 
 [[range-indexes]]
 == Range indexes
@@ -110,7 +110,7 @@ For more information about creating indexes, see xref:indexes/search-performance
 PROFILE
 MATCH (n:PointOfInterest)
 WHERE n.type = 'baseball'
-RETURN count(n) 
+RETURN count(n)
 ----
 
 .Execution plan
@@ -141,12 +141,12 @@ These points all illustrate the fundamental point that search-performance indexe
 For more information about the predicates supported by range indexes, see xref:indexes/search-performance-indexes/managing-indexes.adoc#range-indexes-supported-predicates[Managing search-performance indexes -> Range indexes: supported predicates].
 
 [[text-indexes]]
-== Text indexes 
+== Text indexes
 
 Text indexes are used for queries filtering on `STRING` properties.
 
 If there exists both a range and a text index on a given `STRING` property, the text index will only be used by the Cypher planner for queries filtering with the `CONTAINS` or `ENDS WITH` operators.
-In all other cases, the range index will be used. 
+In all other cases, the range index will be used.
 
 To show this behavior, it is necessary to create a text index and a range index on the same property:
 
@@ -247,7 +247,7 @@ For more information about the predicates supported by text indexes, see xref:in
 [[text-index-string-size]]
 === Text indexes and `STRING` sizes
 
-The size of the indexed `STRING` properties is also relevant to the planner’s selection between range and text indexes. 
+The size of the indexed `STRING` properties is also relevant to the planner’s selection between range and text indexes.
 
 Range indexes have a maximum key size limit of around 8 kb.
 This means that range indexes cannot be used to index `STRING` values larger than 8 kb.
@@ -257,7 +257,7 @@ As a result, they can be used to index `STRING` values up to that size.
 For information about calculating the size of indexes, see link:https://neo4j.com/developer/kb/a-method-to-calculate-index-size/[Neo4j Knowledge Base -> A method to calculate the size of an index in Neo4j].
 
 [[point-indexes]]
-== Point indexes 
+== Point indexes
 
 Point indexes solve predicates operating on spatial xref:values-and-types/spatial.adoc#spatial-values-point-type[`POINT`] values.
 Point indexes are optimized for queries filtering for the xref:functions/spatial.adoc#functions-distance[distance] between property values, or for property values within a xref:functions/spatial.adoc#functions-withinBBox[bounding box].
@@ -294,29 +294,25 @@ RETURN p2.name AS name, p2.type AS type
 .Execution plan
 [role="queryplan"]
 ----
-+--------------------+----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| Operator           | Id | Details                                                                             | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
-+--------------------+----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| +ProduceResults    |  0 | name, type                                                                          |              8 |    4 |       0 |              0 |                    0/0 |     0.029 |                     |
-| |                  +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+                     |
-| +Projection        |  1 | cache[p2.name] AS name, cache[p2.type] AS type                                      |              8 |    4 |       0 |                |                    0/0 |     0.011 |                     |
-| |                  +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+                     |
-| +CacheProperties   |  2 | cache[p2.type], cache[p2.name]                                                      |              8 |    4 |      12 |                |                    7/0 |     0.078 |                     |
-| |                  +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+                     |
-| +Filter            |  3 | point.distance(cache[p1.location], cache[p2.location]) < $autoint_1 AND NOT p1 = p2 |              8 |    4 |       0 |                |                    0/0 |     0.241 |                     |
-| |                  +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+                     |
-| +CartesianProduct  |  4 |                                                                                     |            285 |  188 |       0 |          13008 |                        |     0.139 | In Pipeline 2       |
-| |\                 +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| | +CacheProperties |  5 | cache[p2.location]                                                                  |            188 |  188 |     376 |                |                        |           |                     |
-| | |                +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
-| | +NodeByLabelScan |  6 | p2:PointOfInterest                                                                  |            188 |  188 |     189 |            400 |                  354/0 |     0.396 | Fused in Pipeline 1 |
-| |                  +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| +CacheProperties   |  7 | cache[p1.location]                                                                  |              2 |    1 |       2 |                |                        |           |                     |
-| |                  +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +NodeIndexSeek     |  8 | RANGE INDEX p1:PointOfInterest(name) WHERE name = $autostring_0                     |              2 |    1 |       2 |            376 |                    4/0 |     0.223 | Fused in Pipeline 0 |
-+--------------------+----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
++--------------------+----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------+
+| Operator           | Id | Details                                                               | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline      |
++--------------------+----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------+
+| +ProduceResults    |  0 | name, type                                                            |              0 |    0 |       0 |                |                    0/0 |     0.000 |               |
+| |                  +----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+               |
+| +Projection        |  1 | cache[p2.name] AS name, cache[p2.type] AS type                        |              0 |    0 |       0 |                |                    0/0 |     0.000 |               |
+| |                  +----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+               |
+| +CacheProperties   |  2 | cache[p2.type], cache[p2.name]                                        |              0 |    0 |       0 |                |                    0/0 |     0.000 |               |
+| |                  +----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+               |
+| +Filter            |  3 | NOT p1 = p2 AND point.distance(p1.location, p2.location) < $autoint_1 |              0 |    0 |       0 |                |                    0/0 |     0.000 |               |
+| |                  +----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+               |
+| +CartesianProduct  |  4 |                                                                       |              0 |    0 |       0 |           1392 |                    0/0 |     0.021 | In Pipeline 2 |
+| |\                 +----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------+
+| | +NodeByLabelScan |  5 | p2:PointOfInterest                                                    |              0 |    0 |       0 |            256 |                    0/0 |     0.000 | In Pipeline 1 |
+| |                  +----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------+
+| +NodeIndexSeek     |  6 | RANGE INDEX p1:PointOfInterest(name) WHERE name = $autostring_0       |              0 |    0 |       1 |            376 |                    1/0 |     0.372 | In Pipeline 0 |
++--------------------+----+-----------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------+
 
-Total database accesses: 581, total allocated memory: 13776
+Total database accesses: 1, total allocated memory: 2104
 ----
 
 For more information about the predicates supported by text indexes, see xref:indexes/search-performance-indexes/managing-indexes.adoc#point-indexes-supported-predicates[Managing search-performance indexes -> Point indexes: supported predicates].
@@ -332,7 +328,7 @@ This is done by specifying either of the following settings in the `indexConfig`
 * `spatial.wgs-84.min` and `spatial.wgs-84.max`: used for xref:values-and-types/spatial.adoc#spatial-values-crs-geographic[WGS-84 2D] coordinate systems.
 * `spatial.wgs-84-3d.min` and `spatial.wgs-84-3d.max`: used for xref:values-and-types/spatial.adoc#spatial-values-crs-geographic[WGS-84 3D] coordinate systems.
 
-The `min` and `max` of each setting define the minimum and maximum bounds for the spatial data in each coordinate system. 
+The `min` and `max` of each setting define the minimum and maximum bounds for the spatial data in each coordinate system.
 
 For example, the following index would only store `OSMNodes` in the northern half of Central Park:
 
@@ -433,7 +429,7 @@ Like single-property range indexes, composite indexes support all predicates:
 * Prefix search: `n.prop STARTS WITH value`
 
 However, the order in which properties are defined when creating a composite index impacts how the planner will use the index to solve predicates.
-For example, a composite index on `(n.prop1, n.prop2, n.prop3)` will generate a different query plan than a composite index created on `(n.prop3, n.prop2, n.prop1)`. 
+For example, a composite index on `(n.prop1, n.prop2, n.prop3)` will generate a different query plan than a composite index created on `(n.prop3, n.prop2, n.prop1)`.
 
 The following example shows how composite indexes on the same properties defined in a different order will generate different execution plans:
 
@@ -480,7 +476,7 @@ Total database accesses: 1, total allocated memory: 312
 ----
 
 The plan shows the recently created composite index is used.
-It also shows that the predicates are filtered as specified in the query (i.e. an equality check on the `lat` property, a prefix search on the `name` property, and an existence check on the `type` property). 
+It also shows that the predicates are filtered as specified in the query (i.e. an equality check on the `lat` property, a prefix search on the `name` property, and an existence check on the `type` property).
 
 However, if the order of the properties is altered when creating the index, a different query plan will be generated.
 To demonstrate this behavior, it is first necessary to drop the recently created `composite_2` index and create a new composite index on the same properties defined in a different order:
@@ -530,7 +526,7 @@ Total database accesses: 3, total allocated memory: 312
 This plan now shows that, while a prefix search has been used to solve the `name` property predicate, the `lat` property predicate is no longer solved with an equality check, but rather with an existence check and an explicit xref:planning-and-tuning/operators/operators-detail.adoc#query-plan-filter[filter] operation afterward.
 Note that if the `composite_2` index had not been dropped before the query was rerun, the planner would have used it instead of the `composite_3` index.
 
-This is because, when using composite indexes, any predicate after a prefix search will automatically be planned as an existence check predicate. 
+This is because, when using composite indexes, any predicate after a prefix search will automatically be planned as an existence check predicate.
 
 [[composite-index-rules]]
 === Composite index rules
@@ -698,7 +694,7 @@ This plan shows that a separate index is used to improve the performance of each
 Neo4j indexes do not store xref:values-and-types/working-with-null.adoc[`null`] values.
 This means that the planner must be able to rule out the possibility of `null` values in order for queries to use an index.
 
-The following query demonstrates the incompatibility between `null` values and indexes by counting all `PointOfInterest` nodes with an unset `name` property: 
+The following query demonstrates the incompatibility between `null` values and indexes by counting all `PointOfInterest` nodes with an unset `name` property:
 
 .Query to count nodes with a `null` `name` value
 [source,cypher]
@@ -735,7 +731,7 @@ RETURN count(n) AS nodes
 Total database accesses: 562, total allocated memory: 472
 ----
 
-The plan shows that neither of the two available indexes (range and text) on the `name` property is used to solve the predicate. 
+The plan shows that neither of the two available indexes (range and text) on the `name` property is used to solve the predicate.
 
 However, if a query predicate is added which is able to exclude the presence of any `null` values, then an index can be used.
 The following query shows this by adding a substring predicate to the above query:
@@ -967,7 +963,7 @@ Note that xref:constraints/examples.adoc#constraints-examples-node-property-exis
 While it is impossible to give exact directions on when a search-performance index might be beneficial for a particular use-case, the following points provide some useful heuristics for when creating an index might improve query performance:
 
 * *Frequent property-based queries*: if some properties are used frequently for filtering or matching, consider creating an index on them.
-* *Performance optimization*: If certain queries are too slow, re-examine the properties that are filtered on, and consider creating indexes for those properties that may cause bottlenecking. 
+* *Performance optimization*: If certain queries are too slow, re-examine the properties that are filtered on, and consider creating indexes for those properties that may cause bottlenecking.
 * *High cardinality properties*: high cardinality properties have many distinct values (e.g., unique identifiers, timestamps, or user names). Queries that seek to retrieve such properties will likely benefit from indexing.
 * *Complex queries*: if queries traverse complex paths in a graph (for example, by involving multiple hops and several layers of filtering), adding indexes to the properties used in those queries can improve query performance.
 * *Experiment and test*: It is good practice to experiment with different indexes and query patterns, and to measure the performance of critical queries with and without different indexes to evaluate their effectiveness.

--- a/modules/ROOT/pages/indexes/search-performance-indexes/using-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/using-indexes.adoc
@@ -43,11 +43,11 @@ For more information, see xref:planning-and-tuning/index.adoc#profile-and-explai
 PROFILE
 MATCH (n:PointOfInterest)
 WHERE n.type = 'baseball'
-RETURN count(n) 
+RETURN count(n)
 ----
 
 .Result
-[role="queryresult",options="header,footer",cols="m"]
+[options="header,footer",cols="m"]
 |===
 | count(n)
 | 26
@@ -606,7 +606,7 @@ CREATE INDEX range_index_relationships FOR ()-[r:ROUTE]-() ON (r.distance)
 Re-running the query, it now generates a different plan:
 
 .Rerun query after the creation of a relevant index
-[source,syntax]
+[source,cypher]
 ----
 PROFILE
 MATCH ()-[r:ROUTE]-()

--- a/modules/ROOT/pages/indexes/search-performance-indexes/using-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/using-indexes.adoc
@@ -1,5 +1,6 @@
 :description: Information about how to use the search-performance indexes in Neo4j.
 :test-setup-dump: https://github.com/neo4j-graph-examples/openstreetmap/raw/main/data/openstreetmap-50.dump
+:test-skip: true
 
 
 = The impact of indexes on query performance

--- a/modules/ROOT/pages/indexes/search-performance-indexes/using-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/using-indexes.adoc
@@ -1,9 +1,10 @@
 :description: Information about how to use the search-performance indexes in Neo4j.
-:test-skip: true
 :test-setup-dump: https://github.com/neo4j-graph-examples/openstreetmap/raw/main/data/openstreetmap-50.dump
+
+
 = The impact of indexes on query performance
 
-Search-performance indexes enable quicker and more efficient pattern matching by solving a particular combination of node label/relationship type and property predicate. 
+Search-performance indexes enable quicker and more efficient pattern matching by solving a particular combination of node label/relationship type and property predicate.
 They are used automatically by the Cypher planner in `MATCH` clauses, usually at the start of a query, to scan the graph for the most appropriate place to start the pattern-matching process.
 
 By examining xref:planning-and-tuning/execution-plans.adoc[query execution plans], this page will explain the scenarios in which the various search-performance indexes are used to improve the performance of Cypher queries.

--- a/modules/ROOT/pages/indexes/search-performance-indexes/using-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/using-indexes.adoc
@@ -173,7 +173,7 @@ RETURN n.name AS name, n.type AS type
 ----
 
 .Result
-[role="queryresult",options="header,footer",cols="2*m"]
+[options="header,footer",cols="2*m"]
 |===
 | name | type
 | "William Shakespeare" | "statue"
@@ -279,7 +279,7 @@ RETURN p2.name AS name, p2.type AS type
 ----
 
 .Result
-[role="queryresult",options="header,footer",cols="2*m"]
+[options="header,footer",cols="2*m"]
 |===
 | name | type
 | "Walter Scott" | "statue"
@@ -293,27 +293,29 @@ RETURN p2.name AS name, p2.type AS type
 .Execution plan
 [role="queryplan"]
 ----
-+-------------------------+----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| Operator                | Id | Details                                                                                              | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
-+-------------------------+----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| +ProduceResults         |  0 | name, type                                                                                           |              8 |    4 |       0 |              0 |                        |           |                     |
-| |                       +----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +Projection             |  1 | cache[p2.name] AS name, cache[p2.type] AS type                                                       |              8 |    4 |       0 |                |                        |           |                     |
-| |                       +----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +CacheProperties        |  2 | cache[p2.type], cache[p2.name]                                                                       |              8 |    4 |      12 |                |                        |           |                     |
-| |                       +----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +Filter                 |  3 | NOT p1 = p2 AND p1.name = $autostring_0 AND point.distance(cache[p1.location], cache[p2.location]) < |              8 |    4 |    2891 |                |                        |           |                     |
-| |                       |    | $autoint_1                                                                                           |                |      |         |                |                        |           |                     |
-| |                       +----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +Apply                  |  4 |                                                                                                      |           1060 | 1448 |       0 |                |                        |           |                     |
-| |\                      +----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
-| | +NodeIndexSeekByRange |  5 | POINT INDEX p1:PointOfInterest(location) WHERE point.distance(location, cache[p2.location]) < $autoi |           1060 | 1448 |    1638 |          16616 |                 1529/1 |   125.886 | Fused in Pipeline 1 |
-| |                       |    | nt_1, cache[p1.location]                                                                             |                |      |         |                |                        |           |                     |
-| |                       +----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| +NodeByLabelScan        |  6 | p2:PointOfInterest                                                                                   |            188 |  188 |     189 |            376 |                    2/0 |     0.533 | In Pipeline 0       |
-+-------------------------+----+------------------------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
++--------------------+----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| Operator           | Id | Details                                                                             | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
++--------------------+----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| +ProduceResults    |  0 | name, type                                                                          |              8 |    4 |       0 |              0 |                    0/0 |     0.029 |                     |
+| |                  +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+                     |
+| +Projection        |  1 | cache[p2.name] AS name, cache[p2.type] AS type                                      |              8 |    4 |       0 |                |                    0/0 |     0.011 |                     |
+| |                  +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+                     |
+| +CacheProperties   |  2 | cache[p2.type], cache[p2.name]                                                      |              8 |    4 |      12 |                |                    7/0 |     0.078 |                     |
+| |                  +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+                     |
+| +Filter            |  3 | point.distance(cache[p1.location], cache[p2.location]) < $autoint_1 AND NOT p1 = p2 |              8 |    4 |       0 |                |                    0/0 |     0.241 |                     |
+| |                  +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+                     |
+| +CartesianProduct  |  4 |                                                                                     |            285 |  188 |       0 |          13008 |                        |     0.139 | In Pipeline 2       |
+| |\                 +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| | +CacheProperties |  5 | cache[p2.location]                                                                  |            188 |  188 |     376 |                |                        |           |                     |
+| | |                +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
+| | +NodeByLabelScan |  6 | p2:PointOfInterest                                                                  |            188 |  188 |     189 |            400 |                  354/0 |     0.396 | Fused in Pipeline 1 |
+| |                  +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| +CacheProperties   |  7 | cache[p1.location]                                                                  |              2 |    1 |       2 |                |                        |           |                     |
+| |                  +----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
+| +NodeIndexSeek     |  8 | RANGE INDEX p1:PointOfInterest(name) WHERE name = $autostring_0                     |              2 |    1 |       2 |            376 |                    4/0 |     0.223 | Fused in Pipeline 0 |
++--------------------+----+-------------------------------------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
 
-Total database accesses: 4730, total allocated memory: 16952
+Total database accesses: 581, total allocated memory: 13776
 ----
 
 For more information about the predicates supported by text indexes, see xref:indexes/search-performance-indexes/managing-indexes.adoc#point-indexes-supported-predicates[Managing search-performance indexes -> Point indexes: supported predicates].
@@ -379,7 +381,7 @@ RETURN length(path) AS pathLength, sum(rel.distance) AS geographicalDistance
 
 
 .Result
-[role="queryresult",options="header,footer",cols="2*m"]
+[options="header,footer",cols="2*m"]
 |===
 |pathLength | geographicalDistance
 
@@ -452,7 +454,7 @@ RETURN n.name AS name
 ----
 
 .Result
-[role="queryresult",options="header,footer",cols="1*m"]
+[options="header,footer",cols="1*m"]
 |===
 | name
 | "William Shakespeare"
@@ -559,7 +561,7 @@ This can have important implications for query performance, because the planner 
 To demonstrate this behavior, the following query will filter out any `ROUTE` relationships with a `distance` property less than `30`, and return the `distance` property of the matched relationships in ascending numerical order using the xref:clauses/order-by.adoc[ORDER BY] clause.
 
 .Query to return order of results without a relevant index
-[source,syntax]
+[source,cypher]
 ----
 PROFILE
 MATCH ()-[r:ROUTE]-()
@@ -707,7 +709,7 @@ RETURN count(n) AS nodes
 ----
 
 .Result
-[role="queryresult",options="header,footer",cols="1*m"]
+[options="header,footer",cols="1*m"]
 |===
 | nodes
 | 3
@@ -747,7 +749,7 @@ RETURN count(n) AS nodes
 ----
 
 .Result
-[role="queryresult",options="header,footer",cols="1*m"]
+[options="header,footer",cols="1*m"]
 |===
 | nodes
 | 5
@@ -803,7 +805,7 @@ RETURN count(n) AS nodes
 ----
 
 .Result
-[role="queryresult",options="header,footer",cols="1*m"]
+[options="header,footer",cols="1*m"]
 |===
 | nodes
 | 185
@@ -900,19 +902,19 @@ RETURN count(n) AS nodes
 .Execution plan
 [role="queryplan"]
 ----
-+------------------+----+---------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| Operator         | Id | Details                   | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
-+------------------+----+---------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| +ProduceResults  |  0 | name                      |            187 |  185 |       0 |              0 |                        |           |                     |
-| |                +----+---------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +Projection      |  1 | cache[n.name] AS name     |            187 |  185 |       0 |                |                        |           |                     |
-| |                +----+---------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +Filter          |  2 | cache[n.name] IS NOT NULL |            187 |  185 |     373 |                |                        |           |                     |
-| |                +----+---------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +NodeByLabelScan |  3 | n:PointOfInterest         |            188 |  188 |     189 |            248 |                  119/0 |     1.004 | Fused in Pipeline 0 |
-+------------------+----+---------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
++-------------------+----+--------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| Operator          | Id | Details            | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
++-------------------+----+--------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| +ProduceResults   |  0 | nodes              |              1 |    1 |       0 |              0 |                    0/0 |     0.012 | In Pipeline 1       |
+| |                 +----+--------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| +EagerAggregation |  1 | count(n) AS nodes  |              1 |    1 |       0 |             32 |                        |           |                     |
+| |                 +----+--------------------+----------------+------+---------+----------------+                        |           |                     |
+| +Filter           |  2 | n.name IS NOT NULL |            187 |  185 |     373 |                |                        |           |                     |
+| |                 +----+--------------------+----------------+------+---------+----------------+                        |           |                     |
+| +NodeByLabelScan  |  3 | n:PointOfInterest  |            188 |  188 |     189 |            376 |                  259/0 |     0.363 | Fused in Pipeline 0 |
++-------------------+----+--------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
 
-Total database accesses: 562, total allocated memory: 312
+Total database accesses: 562, total allocated memory: 472
 ----
 
 This plan shows that the available text index on the `name` property was not used to solve the predicate.
@@ -939,20 +941,20 @@ RETURN count(n) AS nodes
 .Execution plan
 [role="queryplan"]
 ----
-+-----------------+----+-----------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| Operator        | Id | Details                                                   | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
-+-----------------+----+-----------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
-| +ProduceResults |  0 | name                                                      |            187 |  185 |       0 |              0 |                        |           |                     |
-| |               +----+-----------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +Projection     |  1 | n.name AS name                                            |            187 |  185 |     370 |                |                        |           |                     |
-| |               +----+-----------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
-| +NodeIndexScan  |  2 | TEXT INDEX n:PointOfInterest(name) WHERE name IS NOT NULL |            187 |  185 |     186 |            248 |                  115/0 |     1.671 | Fused in Pipeline 0 |
-+-----------------+----+-----------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
++-------------------+----+-----------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| Operator          | Id | Details                                                   | Estimated Rows | Rows | DB Hits | Memory (Bytes) | Page Cache Hits/Misses | Time (ms) | Pipeline            |
++-------------------+----+-----------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| +ProduceResults   |  0 | nodes                                                     |              1 |    1 |       0 |              0 |                    0/0 |     0.013 | In Pipeline 1       |
+| |                 +----+-----------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
+| +EagerAggregation |  1 | count(n) AS nodes                                         |              1 |    1 |       0 |             32 |                        |           |                     |
+| |                 +----+-----------------------------------------------------------+----------------+------+---------+----------------+                        |           |                     |
+| +NodeIndexScan    |  2 | TEXT INDEX n:PointOfInterest(name) WHERE name IS NOT NULL |            187 |  185 |     186 |            376 |                    0/0 |     0.328 | Fused in Pipeline 0 |
++-------------------+----+-----------------------------------------------------------+----------------+------+---------+----------------+------------------------+-----------+---------------------+
 
-Total database accesses: 556, total allocated memory: 312
+Total database accesses: 186, total allocated memory: 472
 ----
 
-Because of the type constraint on the `name` property, the planner is now able to deduce that all `name` properties are of type `STRING`, and therefore use the available text index. 
+Because of the type constraint on the `name` property, the planner is now able to deduce that all `name` properties are of type `STRING`, and therefore use the available text index.
 
 Point indexes can be extended in the same way if a type constraint is created to ensure that all properties are `POINT` values.
 

--- a/modules/ROOT/pages/patterns/concepts.adoc
+++ b/modules/ROOT/pages/patterns/concepts.adoc
@@ -1,4 +1,4 @@
-:description: this chapter describes the concepts behind graph pattern matching, including node patterns, relationship patterns, path patterns, path pattern matching, equijoins, shortestPath, quantified path patterns, variable length relationships, and graph patterns. 
+:description: this chapter describes the concepts behind graph pattern matching, including node patterns, relationship patterns, path patterns, path pattern matching, equijoins, shortestPath, quantified path patterns, variable length relationships, and graph patterns.
 
 = Concepts
 
@@ -11,7 +11,7 @@ The model data in the examples below are based on the UK national rail network, 
 [[node-patterns]]
 == Node patterns
 
-Every graph pattern contains at least one node pattern. 
+Every graph pattern contains at least one node pattern.
 The simplest graph pattern is a single, empty node pattern:
 
 [source, role=noheader]
@@ -55,7 +55,7 @@ The following matches nodes that have their `mode` property equal to `Rail`:
 
 [source, role=noheader]
 ----
-MATCH (n { mode: 'Rail' }) 
+MATCH (n { mode: 'Rail' })
 ----
 
 More general predicates can be expressed with a `WHERE` clause.
@@ -66,7 +66,7 @@ The following matches nodes whose name property starts with `Preston`:
 MATCH (n:Station WHERE n.name STARTS WITH 'Preston')
 ----
 
-See the xref:patterns/reference.adoc#node-patterns[node patterns] reference section for more details. 
+See the xref:patterns/reference.adoc#node-patterns[node patterns] reference section for more details.
 
 [[relationship-patterns]]
 == Relationship patterns
@@ -78,8 +78,8 @@ The simplest possible relationship pattern is a pair of dashes:
 --
 ----
 
-This pattern matches a relationship with any direction and does not filter on any relationship type or property. 
-Unlike a node pattern, a relationship pattern cannot be used in a `MATCH` clause without node patterns at both ends. 
+This pattern matches a relationship with any direction and does not filter on any relationship type or property.
+Unlike a node pattern, a relationship pattern cannot be used in a `MATCH` clause without node patterns at both ends.
 See xref:patterns/concepts.adoc#path-patterns[path patterns] for more details.
 
 In order to obtain a reference to the relationships matched by the pattern, a relationship variable needs to be declared in the pattern by adding the variable name in square brackets in between the dashes:
@@ -117,7 +117,7 @@ A `WHERE` clause can be used for more general predicates:
 -[r WHERE time() + duration(r.duration) < time('22:00') ]->
 ----
 
-See the xref:patterns/reference.adoc#relationship-patterns[relationship patterns] reference section for more details. 
+See the xref:patterns/reference.adoc#relationship-patterns[relationship patterns] reference section for more details.
 
 [[path-patterns]]
 == Path patterns
@@ -160,11 +160,11 @@ These are invalid path patterns:
 ----
 
 [[path-pattern-matching]]
-== Path pattern matching 
+== Path pattern matching
 
 This section contains an example of matching a path pattern to paths in a property graph.
 
-It uses the following graph: 
+It uses the following graph:
 
 image::path_pattern_example_graph.svg[width="600",role="middle"]
 
@@ -190,10 +190,10 @@ CREATE (pmr:Station {name: 'Peckham Rye'}),
 
 
 The graph contains a number of train `Stations` and `Stops`.
-A `Stop` represents  the arrival and departure of a train that `CALLS_AT` a `Station`. 
+A `Stop` represents  the arrival and departure of a train that `CALLS_AT` a `Station`.
 Each `Stop` forms part of a sequence of `Stops` connected by relationships with the type `NEXT`, representing the order of calling points made by a train service.
 
-The graph shows three chains of `Stops` that represent different train services. 
+The graph shows three chains of `Stops` that represent different train services.
 Each of these services calls at the `Station` with the name `Denmark Hill`.
 
 To return all `Stops` that call at the `Station` `Denmark Hill`, the following _motif_ is used (the term motif is used to describe the pattern looked for in the graph):
@@ -227,7 +227,7 @@ RETURN s.departs AS departureTime
 |===
 
 [[equijoins]]
-== Equijoins 
+== Equijoins
 
 An equijoin is an operation on paths that requires more than one of the nodes or relationships of the paths to be the same.
 The equality between the nodes or relationships is specified by declaring the same variable in multiple node patterns or relationship patterns.
@@ -274,7 +274,7 @@ The solution is the following path with a cycle:
 
 image::patterns_equijoins_solution2.svg[width="400",role="middle"]
 
-If unique properties exist on the node where the cycle "join" occurs in the path, then it is possible to repeat the node pattern with a predicate matching on the unique property. 
+If unique properties exist on the node where the cycle "join" occurs in the path, then it is possible to repeat the node pattern with a predicate matching on the unique property.
 The following motif demonstrates how that can be achieved, repeating a `Station` node pattern with the name `London Euston`:
 
 image::patterns_equijoins_motif.svg[width="700",role="middle"]
@@ -302,7 +302,7 @@ Putting this path pattern with an equijoin in a query, the times of the outbound
 MATCH (n:Station {name: 'London Euston'})<-[:CALLS_AT]-(s1:Stop)
   -[:NEXT]->(s2:Stop)-[:CALLS_AT]->(:Station {name: 'Coventry'})
   <-[:CALLS_AT]-(s3:Stop)-[:NEXT]->(s4:Stop)-[:CALLS_AT]->(n)
-RETURN s1.departs+'-'+s2.departs AS outbound, 
+RETURN s1.departs+'-'+s2.departs AS outbound,
   s3.departs+'-'+s4.departs AS `return`
 ----
 
@@ -319,12 +319,12 @@ RETURN s1.departs+'-'+s2.departs AS outbound,
 
 
 [[quantified-path-patterns]]
-== Quantified path patterns 
+== Quantified path patterns
 
 _This feature was introduced in Neo4j 5.9._
 
-All the path patterns discussed so far have had a fixed length. 
-This section considers how to match paths of _varying_ length by using _quantified path patterns_, allowing you to search for paths whose lengths are unknown or within a specific range. 
+All the path patterns discussed so far have had a fixed length.
+This section considers how to match paths of _varying_ length by using _quantified path patterns_, allowing you to search for paths whose lengths are unknown or within a specific range.
 
 Quantified path patterns can be useful when, for example, searching for all nodes that can be reached from an anchor node, finding all paths connecting two nodes, or when traversing a hierarchy that may have differing depths.
 
@@ -346,9 +346,9 @@ To recreate the graph, run the following query against an empty Neo4j database:
 .Query
 [source, cypher, role=test-setup]
 ----
-CREATE (pmr:Station {name: 'Peckham Rye'}), 
+CREATE (pmr:Station {name: 'Peckham Rye'}),
   (dmk:Station {name: 'Denmark Hill'}),
-  (clp:Station {name: 'Clapham High Street'}), 
+  (clp:Station {name: 'Clapham High Street'}),
   (wwr:Station {name: 'Wandsworth Road'}),
   (clj:Station {name: 'Clapham Junction'}),
   (s1:Stop {arrives: time('17:19'), departs: time('17:20')}),
@@ -370,7 +370,7 @@ CREATE (pmr:Station {name: 'Peckham Rye'}),
 Each `Stop` on a service `CALLS_AT` one `Station`. Each `Stop` has the properties `arrives` and `departs` that give the times the train is at the `Station`.
 Following the `NEXT` relationship of a `Stop` will give the next `Stop` of the service.
 
-For this example, a path pattern is constructed to match each of the services that allow passengers to travel from `Denmark Hill` to `Clapham Junction`. 
+For this example, a path pattern is constructed to match each of the services that allow passengers to travel from `Denmark Hill` to `Clapham Junction`.
 The following shows the two paths that the path pattern should match:
 
 image::patterns_qpp_solutions.svg[width="700",role="middle"]
@@ -443,7 +443,7 @@ For the current example, the first step is identifying the repeating pattern, wh
 (:Stop)-[:NEXT]->(:Stop)
 ----
 
-The shortest path has one instance of this pattern, the longest three. 
+The shortest path has one instance of this pattern, the longest three.
 So the quantifier applied to the wrapper parentheses is the range one to three, expressed as `{1,3}`:
 
 [source, role=noheader]
@@ -525,10 +525,10 @@ Quantified relationships allow some simple quantified path patterns to be re-wri
 Continuing with the example of `Stations` and `Stops` from the previous section, consider the following query:
 
 .Query
-[source,cypher,role=test-skip-result]
+[source,cypher]
 ----
 MATCH (d:Station { name: 'Denmark Hill' })<-[:CALLS_AT]-(n:Stop)
-      ((:Stop)-[:NEXT]->(:Stop)){1,10} 
+      ((:Stop)-[:NEXT]->(:Stop)){1,10}
       (m:Stop)-[:CALLS_AT]->(a:Station { name: 'Clapham Junction' })
 WHERE m.arrives < time('17:18')
 RETURN n.departs AS departureTime
@@ -537,21 +537,21 @@ RETURN n.departs AS departureTime
 If the relationship `NEXT` only connects `Stop` nodes, the `:Stop` label expressions can be removed:
 
 .Query
-[source, cypher, role=test-skip-result]
+[source, cypher]
 ----
 MATCH (d:Station { name: 'Denmark Hill' })<-[:CALLS_AT]-(n:Stop)
-      (()-[:NEXT]->()){1,10} 
+      (()-[:NEXT]->()){1,10}
       (m:Stop)-[:CALLS_AT]->(a:Station { name: 'Clapham Junction' })
 WHERE m.arrives < time('17:18')
 RETURN n.departs AS departureTime
 ----
 
 When the quantified path pattern has one relationship pattern, it can be abbreviated to a _quantified relationship_.
-A quantified relationship is a relationship pattern with a postfix quantifier. 
+A quantified relationship is a relationship pattern with a postfix quantifier.
 Below is the previous query rewritten with a quantified relationship:
 
 .Query
-[source, cypher, role=test-skip-result]
+[source, cypher]
 ----
 MATCH (d:Station { name: 'Denmark Hill' })<-[:CALLS_AT]-
         (n:Stop)-[:NEXT]->{1,10}(m:Stop)-[:CALLS_AT]->
@@ -577,8 +577,8 @@ then it can be re-written as follows:
 
 [NOTE]
 ====
-Prior to the introduction of quantified path patterns and quantified relationships in Neo4j 5.9, the only method in Cypher to match paths of a variable length was through variable-length relationships. 
-This syntax is still available. 
+Prior to the introduction of quantified path patterns and quantified relationships in Neo4j 5.9, the only method in Cypher to match paths of a variable length was through variable-length relationships.
+This syntax is still available.
 It is very similar to the syntax for quantified relationships, with the following differences:
 
 * Position and syntax of quantifier.
@@ -596,7 +596,7 @@ This section uses the example of `Stations` and `Stops` used in the previous sec
 
 image::patterns_group_variables_graph.svg[width="700", role="middle"]
 
-As the name suggests, this property represents the distance between two `Stops`. 
+As the name suggests, this property represents the distance between two `Stops`.
 To return the total distance for each service connecting a pair of `Stations`, a variable referencing each of the relationships traversed is needed.
 Similarly, to extract the `departs` and `arrives` properties of each `Stop`, variables referencing each of the nodes traversed is required.
 In this example of matching services between `Denmark Hill` and `Clapham Junction`, the variables `l` and `m` are declared to match the `Stops` and `r` is declared to match the relationships.
@@ -655,7 +655,7 @@ Singleton variables bind at most to one node or relationship.
 
 |===
 
-Returning to the original goal, which was to return the sequence of depart times for the `Stops` and the total distance of each service, the final query exploits the compatibility of group variables with list comprehensions and list functions such as xref::functions/list#functions-reduce[reduce()]: 
+Returning to the original goal, which was to return the sequence of depart times for the `Stops` and the total distance of each service, the final query exploits the compatibility of group variables with list comprehensions and list functions such as xref::functions/list#functions-reduce[reduce()]:
 
 .Query
 [source, cypher]
@@ -718,17 +718,17 @@ SET asc.location = point({longitude: -2.10876, latitude: 51.9989}),
   wop.location = point({longitude: -2.16003, latitude: 52.15605}),
   wof.location = point({longitude: -2.2216, latitude: 52.19514}),
   wos.location = point({longitude: -2.20941, latitude: 52.19473})
-CREATE (asc)-[:LINK {distance: 7.25}]->(cnm), 
-  (asc)-[:LINK {distance: 11.29}]->(wop), 
-  (asc)-[:LINK {distance: 14.75}]->(wos), 
-  (bmv)-[:LINK {distance: 31.14}]->(cnm), 
-  (bmv)-[:LINK {distance: 6.16}]->(dtw), 
-  (bmv)-[:LINK {distance: 12.6}]->(wop), 
-  (dtw)-[:LINK {distance: 5.64}]->(hby), 
-  (dtw)-[:LINK {distance: 6.03}]->(wof), 
-  (dtw)-[:LINK {distance: 5.76}]->(wos), 
-  (psh)-[:LINK {distance: 4.16}]->(wop), 
-  (wop)-[:LINK {distance: 3.71}]->(wos), 
+CREATE (asc)-[:LINK {distance: 7.25}]->(cnm),
+  (asc)-[:LINK {distance: 11.29}]->(wop),
+  (asc)-[:LINK {distance: 14.75}]->(wos),
+  (bmv)-[:LINK {distance: 31.14}]->(cnm),
+  (bmv)-[:LINK {distance: 6.16}]->(dtw),
+  (bmv)-[:LINK {distance: 12.6}]->(wop),
+  (dtw)-[:LINK {distance: 5.64}]->(hby),
+  (dtw)-[:LINK {distance: 6.03}]->(wof),
+  (dtw)-[:LINK {distance: 5.76}]->(wos),
+  (psh)-[:LINK {distance: 4.16}]->(wop),
+  (wop)-[:LINK {distance: 3.71}]->(wos),
   (wof)-[:LINK {distance: 0.65}]->(wos)
 ----
 
@@ -759,7 +759,7 @@ RETURN [n in nodes(p) | n.name] AS stops
 1+d|Rows: 1
 |===
 
-The path pattern passed to the `shortestPath` function defines the pattern that the shortest path must conform to. 
+The path pattern passed to the `shortestPath` function defines the pattern that the shortest path must conform to.
 It needs to be a variable-length relationship with a single relationship pattern.
 For more information, see the reference section on xref::patterns/reference#variable-length_relationships[variable-length relationships].
 
@@ -868,7 +868,7 @@ RETURN [n in nodes(p) | n.name] AS stops
 [[predicates-in-qpps]]
 == Predicates in quantified path patterns
 
-One of the pitfalls of quantified path patterns is that, depending on the graph, they can end up matching very large numbers of paths, resulting in a slow query performance. 
+One of the pitfalls of quantified path patterns is that, depending on the graph, they can end up matching very large numbers of paths, resulting in a slow query performance.
 This is especially true when searching for paths with a large maximum length or when the pattern is too general. However, by using inline predicates that specify precisely which nodes and relationships should be included in the results, unwanted results will be pruned as the graph is traversed.
 
 Here are some examples of the types of constraints you can impose on quantified path pattern traversals:
@@ -877,12 +877,12 @@ Here are some examples of the types of constraints you can impose on quantified 
 For example, all nodes must be an `Employee`, but not a `Contractor`.
 * Relationships must have certain types.
 For example, all relationships in the path must be of type `EMPLOYED_BY`.
-* Nodes or relationships must have properties satisfying some condition. 
+* Nodes or relationships must have properties satisfying some condition.
 For example, all relationships must have property `distance` `>` `10`.
 
 The same example used in the xref:patterns/concepts.adoc#shortest-path[shortest path] section above is used here to illustrate the use of inline predicates.
 In that section, the shortest path in terms of number of hops was found.
-Here the example is developed to find the shortest path by physical distance and compared to the result from the shortestPath function. 
+Here the example is developed to find the shortest path by physical distance and compared to the result from the shortestPath function.
 
 The total distance from `Hartlebury` to `Cheltenham Spa` following the path yielded by `shortestPath` is given by the following query:
 
@@ -892,7 +892,7 @@ The total distance from `Hartlebury` to `Cheltenham Spa` following the path yiel
 MATCH (hby:Station {name: 'Hartlebury'}),
       (cnm:Station {name: 'Cheltenham Spa'})
 MATCH p = shortestPath((hby)-[:LINK*]-(cnm))
-RETURN reduce(acc = 0, r in relationships(p) | acc + r.distance) 
+RETURN reduce(acc = 0, r in relationships(p) | acc + r.distance)
   AS distance
 ----
 
@@ -915,7 +915,7 @@ Whether this is the shortest path by distance can be checked by looking at each 
 MATCH (hby:Station {name: 'Hartlebury'}),
       (cnm:Station {name: 'Cheltenham Spa'})
 MATCH p = (hby)-[:LINK]-+(cnm)
-RETURN reduce(acc = 0, r in relationships(p) | acc + r.distance) 
+RETURN reduce(acc = 0, r in relationships(p) | acc + r.distance)
   AS distance
 ORDER BY distance LIMIT 1
 ----
@@ -948,9 +948,9 @@ To compose the predicate, the xref:functions/spatial.adoc#functions-distance[poi
 MATCH (hby:Station {name: 'Hartlebury'}),
       (cnm:Station {name: 'Cheltenham Spa'})
 MATCH p = (hby)
-          ((a)-[:LINK]-(b) WHERE point.distance(a.location, cnm.location) > 
+          ((a)-[:LINK]-(b) WHERE point.distance(a.location, cnm.location) >
             point.distance(b.location, cnm.location))+ (cnm)
-RETURN reduce(acc = 0, r in relationships(p) | acc + r.distance) 
+RETURN reduce(acc = 0, r in relationships(p) | acc + r.distance)
   AS distance
 ORDER BY distance
 ----
@@ -978,7 +978,7 @@ Using inline predicates or making quantified path patterns more specific where p
 
 In addition to the single path patterns discussed so far, multiple path patterns can be combined in a comma-separated list to form a graph pattern.
 In a graph pattern, each path pattern is matched separately, and where node variables are repeated in the separate path patterns, the solutions are reduced via equijoins.
-If there are no equijoins between the path patterns, the result is a Cartesian product between the separate solutions. 
+If there are no equijoins between the path patterns, the result is a Cartesian product between the separate solutions.
 
 The benefit of joining multiple path patterns in this way is that it allows the specification of more complex patterns than the linear paths allowed by a single path pattern.
 To illustrate this, another example drawn from the railway model will be used.

--- a/modules/ROOT/pages/styleguide.adoc
+++ b/modules/ROOT/pages/styleguide.adoc
@@ -176,7 +176,7 @@ RETURN b1 AND b2
 ** parameters
 +
 .Bad
-[source, cypher, role=test-skip]
+[source, cypher]
 ----
 CREATE (N {Prop: 0})
 WITH RAND() AS Rand, $pArAm AS MAP
@@ -184,7 +184,7 @@ RETURN Rand, MAP.property_key, Count(N)
 ----
 +
 .Good
-[source, cypher, role=test-skip]
+[source, cypher]
 ----
 CREATE (n {prop: 0})
 WITH rand() AS rand, $param AS map

--- a/modules/ROOT/pages/values-and-types/type-predicate.adoc
+++ b/modules/ROOT/pages/values-and-types/type-predicate.adoc
@@ -133,9 +133,10 @@ A graph containing the following nodes is used for the example below:
 ////
 [source, cypher, role=test-setup]
 ----
-CREATE (:Person {name: 'Alice', age:18}),
-(:Person {name:'Bob', age:'20'}),
-(:Person {name:'Charlie', age:21}),
+CREATE
+  (:Person {name: 'Alice', age:18}),
+  (:Person {name:'Bob', age:'20'}),
+  (:Person {name:'Charlie', age:21})
 ----
 ////
 
@@ -153,7 +154,7 @@ RETURN n.name AS name, n.age AS age
 [role="queryresult",options="header,footer",cols="2*<m"]
 |===
 | name | age
-| Charlie | 21
+| 'Charlie' | 21
 2+d|Rows: 1
 |===
 


### PR DESCRIPTION
- A setup block was (silently) failing due to an extra trailing comma. With that fixed, the test for the other example failed because `Charlie` was not reported as a string in the asciidoc.
- `test-result-skip` is not needed when a result is missing, only when a result is present but _different_ from what the tester would get.
- No need to `test-skip` when query parameters are missing: the tester skips automatically.
- After a query block, there may only be _one_ result block, either of type `queryresult` or `queryplan`. If there's both of them, the parser will pick the first one, but its internal state will probably also get messed up.
- The last two query plans were surely wrong (they didn't have the right return value), while I'm not sure about the first. It may be something that changed in newer releases or IDK, they look pretty similar.