### PR TITLE
Add docs for the new simple case extension

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -16,6 +16,37 @@ New features are added to the language continuously, and occasionally, some feat
 This section lists all of the features that have been removed, deprecated, added, or extended in different Cypher versions.
 Replacement syntax for deprecated and removed features are also indicated.
 
+[[cypher-deprecations-additions-removals-5.18]]
+== Neo4j 5.18
+
+=== New features
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:new[]
+
+[source, cypher, role=noheader]
+----
+MATCH (n)
+RETURN CASE n.prop
+        WHEN IS NULL THEN "Null"
+        WHEN < 0 THEN "Negative"
+        WHEN 2, 4, 6, 8 THEN "Even"
+        ELSE "Odd"
+        END
+----
+
+| Extension of the xref::queries/case.adoc#case-simple[simple `CASE` expression], allowing multiple matching values to be comma separated in the same `WHEN` statement.
+The simple `CASE` uses an implied equals (`=`) comparator, and this extension additionally allows other comparison predicates to be explicitly specified before the matching value
+in an xref::queries/case.adoc#case-extended-simple[extended version of the simple `CASE`].
+
+|===
+
 [[cypher-deprecations-additions-removals-5.17]]
 == Neo4j 5.17
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -41,7 +41,7 @@ RETURN CASE n.prop
         END
 ----
 
-| Extension of the xref::queries/case.adoc#case-simple[simple `CASE` expression], allowing multiple matching values to be comma separated in the same `WHEN` statement.
+| Extension of the xref::queries/case.adoc#case-simple[simple `CASE` expression], allowing multiple matching values to be comma-separated in the same `WHEN` statement.
 The simple `CASE` uses an implied equals (`=`) comparator, and this extension additionally allows other comparison predicates to be explicitly specified before the matching value
 in an xref::queries/case.adoc#case-extended-simple[extended version of the simple `CASE`].
 

--- a/modules/ROOT/pages/queries/case.adoc
+++ b/modules/ROOT/pages/queries/case.adoc
@@ -110,7 +110,6 @@ The supported comparators are:
 * xref:values-and-types/type-predicate.adoc[Type Predicate Expression]: `IS [NOT] :: <TYPE>`
 * xref::syntax/operators.adoc#match-string-is-normalized[Normalization Predicate Expression]: `IS [NOT] NORMALIZED`
 * xref::syntax/operators.adoc#query-operator-comparison-string-specific[String Comparison Operators]: `STARTS WITH`, `ENDS WITH`, `CONTAINS`, `=~` (regex matching)
-* xref::syntax/operators.adoc#query-operators-list[List Comparison Operator]: `IN`
 
 === Syntax
 

--- a/modules/ROOT/pages/queries/case.adoc
+++ b/modules/ROOT/pages/queries/case.adoc
@@ -48,7 +48,7 @@ If there is no `ELSE` case and no match is found, `null` will be returned.
 [source, syntax]
 ----
 CASE test
-  WHEN value THEN result
+  WHEN value [, value]* THEN result
   [WHEN ...]
   [ELSE default]
 END
@@ -81,7 +81,7 @@ MATCH (n:Person)
 RETURN
 CASE n.eyes
   WHEN 'blue'  THEN 1
-  WHEN 'brown' THEN 2
+  WHEN 'brown', 'hazel' THEN 2
   ELSE 3
 END AS result, n.eyes
 ----
@@ -94,6 +94,81 @@ END AS result, n.eyes
 | 3      | "green"
 | 2      | "brown"
 | 1      | "blue"
+2+d|Rows: 5
+|===
+
+[[case-extended-simple]]
+== Extended Simple `CASE`
+
+The extended simple `CASE` form allows the comparison operator to be specified explicitly. The simple `CASE` uses an
+implied equals (`=`) comparator.
+
+The supported comparators are:
+
+* xref::syntax/operators.adoc#query-operators-comparison[Regular Comparison Operators]: `+=+`, `+<>+`, `+<+`, `+>+`, `+<=+`, `+>=+`
+* xref:values-and-types/working-with-null.adoc#is-null-is-not-null[`IS NULL` Operator]: `IS [NOT] NULL`
+* xref:values-and-types/type-predicate.adoc[Type Predicate Expression]: `IS [NOT] :: <TYPE>`
+* xref::syntax/operators.adoc#match-string-is-normalized[Normalization Predicate Expression]: `IS [NOT] NORMALIZED`
+* xref::syntax/operators.adoc#query-operator-comparison-string-specific[String Comparison Operators]: `STARTS WITH`, `ENDS WITH`, `CONTAINS`, `=~` (regex matching)
+* xref::syntax/operators.adoc#query-operators-list[List Comparison Operator]: `IN`
+
+=== Syntax
+
+[source, syntax]
+----
+CASE test
+  WHEN [comparisonOperator] value [, [comparisonOperator] value ]* THEN result
+  [WHEN ...]
+  [ELSE default]
+END
+----
+
+*Arguments:*
+[options="header", cols="1,2"]
+|===
+| Name | Description
+
+| `test`
+| An expression.
+
+| `comparisonOperator`
+| One of the supported comparison operators.
+
+| `value`
+| An expression whose result will be compared to `test` using the given comparison operator.
+
+| `result`
+| The expression returned as output if `value` matches `test`
+
+| `default`
+| The expression to return if no value matches the test expression.
+|===
+
+[[case-extended-simple-examples]]
+=== Example
+
+[source, cypher]
+----
+MATCH (n:Person)
+RETURN
+CASE n.name, n.age
+  WHEN IS NULL THEN "Unknown"
+  WHEN < 2 THEN "Baby"
+  WHEN < 13 THEN "Child"
+  WHEN < 20 THEN "Teenager"
+  WHEN < 30 THEN "Young Adult"
+  ELSE "Adult"
+END AS result
+----
+
+[role="queryresult",options="header,footer",cols="2*<m"]
+|===
+| n.name    | result
+| "Alice"   | "Adult"
+| "Bob"     | "Young Adult"
+| "Charlie" | "Adult"
+| "Daniel"  | "Unknown"
+| "Eskil"   | "Adult"
 2+d|Rows: 5
 |===
 

--- a/modules/ROOT/pages/queries/case.adoc
+++ b/modules/ROOT/pages/queries/case.adoc
@@ -135,10 +135,10 @@ END
 | One of the supported comparison operators.
 
 | `value`
-| An expression whose result will be compared to `test` using the given comparison operator.
+| An expression whose result is compared to `test` using the given comparison operator.
 
 | `result`
-| The expression returned as output if `value` matches `test`
+| The expression returned as output if `value` matches `test`.
 
 | `default`
 | The expression to return if no value matches the test expression.
@@ -150,13 +150,14 @@ END
 [source, cypher]
 ----
 MATCH (n:Person)
-RETURN
-CASE n.name, n.age
-  WHEN IS NULL THEN "Unknown"
-  WHEN < 2 THEN "Baby"
-  WHEN < 13 THEN "Child"
+RETURN n.name,
+CASE n.age
+  WHEN IS NULL, IS NOT :: INTEGER | FLOAT THEN "Unknown"
+  WHEN = 0, = 1, = 2 THEN "Baby"
+  WHEN <= 13 THEN "Child"
   WHEN < 20 THEN "Teenager"
   WHEN < 30 THEN "Young Adult"
+  WHEN > 1000 THEN "Immortal"
   ELSE "Adult"
 END AS result
 ----


### PR DESCRIPTION
Adds an extension to the Simple Case. This is to allow comma separated when operands as well as comparison operators where the LHS is inferred as the case operand.

E.g.

```
CASE n.prop
  WHERE < 10, 13 THEN 1
  WHERE IS NOT NULL THEN 2
  ELSE 3
END
```