### PR TITLE
Update comment about all available types under list of allowed types for property type constraints

### DIFF
--- a/modules/ROOT/pages/constraints/examples.adoc
+++ b/modules/ROOT/pages/constraints/examples.adoc
@@ -1303,7 +1303,7 @@ The allowed property types for the constraints are:
 * `LIST<POINT NOT NULL>` label:new[Introduced in 5.10]
 * Any closed dynamic union of the above types, e.g. `INTEGER | FLOAT | STRING`. label:new[Introduced in 5.11]
 
-For all types available in Cypher, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
+For a complete reference describing all types available in Cypher, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
 
 * xref::constraints/examples.adoc#constraints-create-a-node-property-type-constraint[]
 * xref::constraints/examples.adoc#constraints-create-a-node-property-type-constraint-by-param[]
@@ -1713,7 +1713,7 @@ The allowed property types for the constraints is:
 * `LIST<POINT NOT NULL>` label:new[Introduced in 5.10]
 * Any closed dynamic union of the above types, e.g. `INTEGER | FLOAT | STRING`. label:new[Introduced in 5.11]
 
-For all types available in Cypher, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
+For a complete reference describing all types available in Cypher, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
 
 * xref::constraints/examples.adoc#constraints-create-a-relationship-property-type-constraint[]
 * xref::constraints/examples.adoc#constraints-create-a-relationship-property-type-constraint-by-param[]

--- a/modules/ROOT/pages/constraints/examples.adoc
+++ b/modules/ROOT/pages/constraints/examples.adoc
@@ -1303,7 +1303,7 @@ The allowed property types for the constraints are:
 * `LIST<POINT NOT NULL>` label:new[Introduced in 5.10]
 * Any closed dynamic union of the above types, e.g. `INTEGER | FLOAT | STRING`. label:new[Introduced in 5.11]
 
-For all available Cypher types, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
+For all types available in Cypher, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
 
 * xref::constraints/examples.adoc#constraints-create-a-node-property-type-constraint[]
 * xref::constraints/examples.adoc#constraints-create-a-node-property-type-constraint-by-param[]
@@ -1713,7 +1713,7 @@ The allowed property types for the constraints is:
 * `LIST<POINT NOT NULL>` label:new[Introduced in 5.10]
 * Any closed dynamic union of the above types, e.g. `INTEGER | FLOAT | STRING`. label:new[Introduced in 5.11]
 
-For all available Cypher types, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
+For all types available in Cypher, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
 
 * xref::constraints/examples.adoc#constraints-create-a-relationship-property-type-constraint[]
 * xref::constraints/examples.adoc#constraints-create-a-relationship-property-type-constraint-by-param[]


### PR DESCRIPTION
Was a bit confusing to first have supported types and then say available types (as available could be seen as 'available to the constraints as well')