### PR TITLE
Change new[5.17] labels to text in index and constraints pages.

### DIFF
--- a/modules/ROOT/pages/constraints/examples.adoc
+++ b/modules/ROOT/pages/constraints/examples.adoc
@@ -99,7 +99,7 @@ It will be updated to say `Node property uniqueness constraints added: 1` in Neo
 Creating an already existing constraint will fail.
 To avoid such an error, `IF NOT EXISTS` can be added to the `CREATE` command.
 This will ensure that no error is thrown and that no constraint is created if any other constraint with the given name, or another node property uniqueness constraint on the same schema, already exists.
-label:new[Introduced in 5.17] An informational notification is instead returned showing the existing constraint which blocks the creation.
+As of Neo4j 5.17, an informational notification is instead returned showing the existing constraint which blocks the creation.
 
 .+CREATE CONSTRAINT+
 ======
@@ -452,7 +452,7 @@ It will be updated to say `Relationship property uniqueness constraints added: 1
 Creating an already existing constraint will fail.
 To avoid such an error, `IF NOT EXISTS` can be added to the `CREATE` command.
 This will ensure that no error is thrown and that no constraint is created if any other constraint with the given name, or another relationship property uniqueness constraint on the same schema, already exists.
-label:new[Introduced in 5.17] An informational notification is instead returned showing the existing constraint which blocks the creation.
+As of Neo4j 5.17, an informational notification is instead returned showing the existing constraint which blocks the creation.
 
 .+CREATE CONSTRAINT+
 ======
@@ -799,7 +799,7 @@ For the node property existence constraints, they will say `Node property existe
 Creating an already existing constraint will fail.
 To avoid such an error, `IF NOT EXISTS` can be added to the `CREATE` command.
 This will ensure that no error is thrown and that no constraint is created if any other constraint with the given name, or another node property existence constraint on the same schema, already exists.
-label:new[Introduced in 5.17] An informational notification is instead returned showing the existing constraint which blocks the creation.
+As of Neo4j 5.17, an informational notification is instead returned showing the existing constraint which blocks the creation.
 
 .+CREATE CONSTRAINT+
 ======
@@ -1082,7 +1082,7 @@ For the relationship property existence constraints, they will say `Relationship
 Creating an already existing constraint will fail.
 To avoid such an error, `IF NOT EXISTS` can be added to the `CREATE` command.
 This will ensure that no error is thrown and that no constraint is created if any other constraint with the given name, or another relationship property existence constraint on the same schema, already exists.
-label:new[Introduced in 5.17] An informational notification is instead returned showing the existing constraint which blocks the creation.
+As of Neo4j 5.17, an informational notification is instead returned showing the existing constraint which blocks the creation.
 
 .+CREATE CONSTRAINT+
 ======
@@ -1410,7 +1410,7 @@ Added 1 constraint.
 Creating an already existing constraint will fail.
 To avoid such an error, `IF NOT EXISTS` can be added to the `CREATE` command.
 This will ensure that no error is thrown and that no constraint is created if any other constraint with the given name, or another node property type constraint on the same schema and property type, already exists.
-label:new[Introduced in 5.17] An informational notification is instead returned showing the existing constraint which blocks the creation.
+As of Neo4j 5.17, an informational notification is instead returned showing the existing constraint which blocks the creation.
 
 .+CREATE CONSTRAINT+
 ======
@@ -1819,7 +1819,7 @@ Added 1 constraint.
 Creating an already existing constraint will fail.
 To avoid such an error, `IF NOT EXISTS` can be added to the `CREATE` command.
 This will ensure that no error is thrown and that no constraint is created if any other constraint with the given name, or another relationship property type constraint on the same schema and property type, already exists.
-label:new[Introduced in 5.17] An informational notification is instead returned showing the existing constraint which blocks the creation.
+As of Neo4j 5.17, an informational notification is instead returned showing the existing constraint which blocks the creation.
 
 .+CREATE CONSTRAINT+
 ======
@@ -2176,7 +2176,7 @@ Added 1 constraint.
 Creating an already existing constraint will fail.
 To avoid such an error, `IF NOT EXISTS` can be added to the `CREATE` command.
 This will ensure that no error is thrown and that no constraint is created if any other constraint with the given name, or another node key constraint on the same schema, already exists.
-label:new[Introduced in 5.17] An informational notification is instead returned showing the existing constraint which blocks the creation.
+As of Neo4j 5.17, an informational notification is instead returned showing the existing constraint which blocks the creation.
 
 .+CREATE CONSTRAINT+
 ======
@@ -2530,7 +2530,7 @@ Added 1 constraint.
 Creating an already existing constraint will fail.
 To avoid such an error, `IF NOT EXISTS` can be added to the `CREATE` command.
 This will ensure that no error is thrown and that no constraint is created if any other constraint with the given name, or another relationship key constraint on the same schema, already exists.
-label:new[Introduced in 5.17] An informational notification is instead returned showing the existing constraint which blocks the creation.
+As of Neo4j 5.17, an informational notification is instead returned showing the existing constraint which blocks the creation.
 
 .+CREATE CONSTRAINT+
 ======

--- a/modules/ROOT/pages/constraints/syntax.adoc
+++ b/modules/ROOT/pages/constraints/syntax.adoc
@@ -16,7 +16,7 @@ This means its default behavior is to throw an error if an attempt is made to cr
 With the `IF NOT EXISTS` flag, no error is thrown and nothing happens should a constraint with the same name or same schema and constraint type already exist.
 It may still throw an error if conflicting data, indexes, or constraints exist.
 Examples of this are nodes with missing properties, indexes with the same name, or constraints with same schema but a different conflicting constraint type.
-As of Neo4j 5.17, an informational notification is instead returned showing the existing constraint which blocks the creation.
+As of Neo4j 5.17, an informational notification is returned in case nothing happens showing the existing constraint which blocks the creation.
 
 For constraints that are backed by an index, the index provider for the backing index can be specified using the `OPTIONS` clause.
 Only one valid value exists for the index provider, `range-1.0`, which is the default value.

--- a/modules/ROOT/pages/constraints/syntax.adoc
+++ b/modules/ROOT/pages/constraints/syntax.adoc
@@ -16,7 +16,7 @@ This means its default behavior is to throw an error if an attempt is made to cr
 With the `IF NOT EXISTS` flag, no error is thrown and nothing happens should a constraint with the same name or same schema and constraint type already exist.
 It may still throw an error if conflicting data, indexes, or constraints exist.
 Examples of this are nodes with missing properties, indexes with the same name, or constraints with same schema but a different conflicting constraint type.
-label:new[Introduced in 5.17] In case nothing happens an informational notification is returned showing the existing constraint which blocks the creation.
+As of Neo4j 5.17, an informational notification is instead returned showing the existing constraint which blocks the creation.
 
 For constraints that are backed by an index, the index provider for the backing index can be specified using the `OPTIONS` clause.
 Only one valid value exists for the index provider, `range-1.0`, which is the default value.

--- a/modules/ROOT/pages/indexes/search-performance-indexes/managing-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/managing-indexes.adoc
@@ -29,7 +29,7 @@ The `CREATE INDEX` command is optionally idempotent.
 This mean that its default behavior is to throw an error if an attempt is made to create the same index twice.
 If `IF NOT EXISTS` is appended to the command, no error is thrown and nothing happens should an index with the same name or same schema and index type already exist.
 It may still throw an error if conflicting constraints exist, such as constraints with the same name or schema and backing index type.
-label:new[Introduced in 5.17] An informational notification is instead returned showing the existing index which blocks the creation.
+As of Neo4j 5.17, an informational notification is instead returned showing the existing index which blocks the creation.
 
 Index providers and configuration settings can be specified using the `OPTIONS` clause.footnote:[Index providers are essentially different implementations of the same index type.
 Different providers are only available for xref:indexes/search-performance-indexes/managing-indexes.adoc#create-a-text-index-specifying-the-index-provider[text indexes].]
@@ -199,7 +199,7 @@ FOR (n:Person) ON (n.surname)
 ----
 
 The index will not be created if there already exists an index with the same schema and type, same name or both.
-label:new[Introduced in 5.17] An informational notification is instead returned.
+As of Neo4j 5.17, an informational notification is instead returned.
 
 .Notification
 [source]
@@ -355,7 +355,7 @@ CREATE TEXT INDEX node_index_name IF NOT EXISTS FOR (n:Person) ON (n.nickname)
 ----
 
 Note that the index will not be created if there already exists an index with the same schema and type, same name or both.
-label:new[Introduced in 5.17] An informational notification is instead returned.
+As of Neo4j 5.17, an informational notification is instead returned.
 
 .Notification
 [source]
@@ -500,7 +500,7 @@ FOR (n:Person) ON (n.sublocation)
 ----
 
 Note that the index will not be created if there already exists an index with the same schema and type, same name or both.
-label:new[Introduced in 5.17] An informational notification is instead returned.
+As of Neo4j 5.17, an informational notification is instead returned.
 
 .Notification
 [source]
@@ -656,7 +656,7 @@ CREATE LOOKUP INDEX node_label_lookup IF NOT EXISTS FOR (n) ON EACH labels(n)
 ----
 
 The index will not be created if there already exists an index with the same schema and type, same name or both.
-label:new[Introduced in 5.17] An informational notification is instead returned.
+As of Neo4j 5.17, an informational notification is instead returned.
 
 .Notification
 [source]
@@ -1042,7 +1042,7 @@ DROP INDEX index_name [IF EXISTS]
 The `DROP INDEX` command is optionally idempotent.
 This means that its default behavior is to throw an error if an attempt is made to drop the same index twice.
 With `IF EXISTS`, no error is thrown and nothing happens should the index not exist.
-label:new[Introduced in 5.17] An informational notification is instead returned detailing that the index does not exist.
+As of Neo4j 5.17, an informational notification is instead returned detailing that the index does not exist.
 
 [TIP]
 Dropping an index requires link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-administration/authentication-authorization/database-administration/#access-control-database-administration-index[the `DROP INDEX` privilege].
@@ -1131,7 +1131,7 @@ DROP INDEX missing_index_name IF EXISTS
 ----
 
 If an index with that name exists it is removed, if not the command does nothing.
-label:new[Introduced in 5.17] Additionally, an informational notification is returned.
+As of Neo4j 5.17, additionally, an informational notification is returned.
 
 .Notification
 [source]

--- a/modules/ROOT/pages/indexes/semantic-indexes/full-text-indexes.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/full-text-indexes.adoc
@@ -38,8 +38,8 @@ If no name is given when created, a random name will be assigned to the full-tex
 The `CREATE FULLTEXT INDEX` command is optionally idempotent.
 This mean that its default behavior is to throw an error if an attempt is made to create the same index twice.
 If `IF NOT EXISTS` is appended to the command, no error is thrown and nothing happens should an index with the same name or a full-text index on the same schema already exist.
-label:new[Introduced in 5.17] An informational notification is instead returned showing the existing index which blocks the creation.
-label:new[Introduced in 5.16] The index name can also be given as a parameter, `CREATE FULLTEXT INDEX $name FOR ...`.
+As of Neo4j 5.17, an informational notification is instead returned showing the existing index which blocks the creation.
+As of Neo4j 5.16, the index name can also be given as a parameter, `CREATE FULLTEXT INDEX $name FOR ...`.
 
 [TIP]
 Creating a full-text index requires the link:{neo4j-docs-base-uri}/operations-manual/{page-version}/authentication-authorization/database-administration/#access-control-database-administration-index[`CREATE INDEX` privilege].
@@ -352,7 +352,7 @@ In the following example, the previously created `communications` full-text inde
 DROP INDEX communications
 ----
 
-label:new[Introduced in 5.16] The index name can also be given as a parameter when dropping an index:  `DROP INDEX $name`.
+As of Neo4j 5.16, the index name can also be given as a parameter when dropping an index:  `DROP INDEX $name`.
 
 [[full--text-index-procedures]]
 == List of full-text index procedures

--- a/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
@@ -114,7 +114,7 @@ The options map is mandatory because setting the vector dimensions and similarit
 It is considered best practice to give the index a name when it is created.
 This name is needed for both dropping and querying the index.
 If the index is not explicitly named, it will get an auto-generated name.
-label:new[Introduced in 5.16] The index name can also be given as a parameter, `CREATE VECTOR INDEX $name FOR ...`.
+As of Neo4j 5.16, the index name can also be given as a parameter, `CREATE VECTOR INDEX $name FOR ...`.
 
 [IMPORTANT]
 ====
@@ -128,7 +128,7 @@ The `indexConfig` is a `MAP` from `STRING` values to `STRING` and `INTEGER` valu
 The command is optionally idempotent. This means that its default behavior is to throw an error if an attempt is made to create the same index twice.
 With `IF NOT EXISTS`, no error is thrown and nothing happens should an index with the same name, schema or both already exist.
 It may still throw an error should a constraint with the same name exist.
-label:new[Introduced in 5.17] An informational notification is instead returned showing the existing index which blocks the creation.
+As of Neo4j 5.17, an informational notification is instead returned showing the existing index which blocks the creation.
 
 [NOTE]
 ====

--- a/modules/ROOT/pages/indexes/syntax.adoc
+++ b/modules/ROOT/pages/indexes/syntax.adoc
@@ -22,7 +22,7 @@ ON property_or_token_lookup_pattern
 The `CREATE … INDEX …` command is optionally idempotent.
 This means that its default behavior is to throw an error if an attempt is made to create an index with the same name twice.
 With `IF NOT EXISTS`, no error is thrown and nothing happens should an index with the same name or same schema and index type already exist (it may still throw an error if conflicting constraints exist, such as constraints with the same name or with the same schema and backing index).
-label:new[Introduced in 5.17] An informational notification is instead returned showing the existing index which blocks the creation.
+As of Neo4j 5.17, an informational notification is instead returned showing the existing index which blocks the creation.
 
 The index name must be unique among both indexes and constraints.
 A random name will be assigned if no name is explicitly given when an index is created.
@@ -289,7 +289,7 @@ The name of the index can be found using the `SHOW INDEXES` command, given in th
 The `DROP INDEX` command is optionally idempotent.
 This means that its default behavior is to throw an error if an attempt is made to drop the same index twice.
 With `IF EXISTS`, no error is thrown and nothing happens should the index not exist.
-label:new[Introduced in 5.17] An informational notification is instead returned detailing that the index does not exist.
+As of Neo4j 5.17, an informational notification is instead returned detailing that the index does not exist.
 
 [TIP]
 Dropping indexes requires link:{neo4j-docs-base-uri}/operations-manual/{page-version}/authentication-authorization/database-administration/#access-control-database-administration-index[the `DROP INDEX` privilege].


### PR DESCRIPTION
In-text labels look a bit odd.

<img width="954" alt="Screenshot 2024-03-05 at 11 31 06" src="https://github.com/neo4j/docs-cypher/assets/112686610/ce863d25-33d0-4df5-9484-3e370fcda609">
