### PR TITLE
Correct Cypher Example in load-csv.adoc

### DIFF
--- a/modules/ROOT/pages/clauses/load-csv.adoc
+++ b/modules/ROOT/pages/clauses/load-csv.adoc
@@ -488,8 +488,9 @@ person_tmdbId,bio,born,bornIn,died,person_imdbId,name,person_poster,person_url
 .Query
 [source, cypher]
 ----
+LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/importing-cypher/persons.csv' AS row
 CALL {
-  LOAD CSV WITH HEADERS FROM 'https://data.neo4j.com/importing-cypher/persons.csv' AS row
+  WITH row
   MERGE (p:Person {tmdbId: row.person_tmdbId})
   SET p.name = row.name, p.born = row.born
 } IN TRANSACTIONS OF 200 ROWS


### PR DESCRIPTION
When loading large CSV files with sub-transactions I think we want the `LOAD CSV` statement outside the sub-query `CALL{}`