### PR TITLE
result columns for show indexes shouldn't live under examples

### DIFF
--- a/modules/ROOT/pages/indexes/search-performance-indexes/managing-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/managing-indexes.adoc
@@ -937,9 +937,8 @@ To get all columns, use:
 SHOW RANGE INDEXES YIELD * WHERE owningConstraint IS NULL
 ----
 
-[discrete]
 [[listing-indexes-result-columns]]
-==== Result columns for listing indexes
+=== Result columns for listing indexes
 
 The below table contains the full information about all columns returned by the `SHOW INDEXES YIELD *` command:
 


### PR DESCRIPTION
and might be nice to not be discrete but actually listed as a subsection