### PR TITLE
Fix typo in date truncation documentation

### DIFF
--- a/modules/ROOT/pages/functions/temporal/index.adoc
+++ b/modules/ROOT/pages/functions/temporal/index.adoc
@@ -183,7 +183,7 @@ The following truncation units are supported:
 * `quarter`: Select the temporal instant corresponding to the _quarter of the year_ of the given instant.
 * `month`: Select the temporal instant corresponding to the _month_ of the given instant.
 * `week`: Select the temporal instant corresponding to the _week_ of the given instant.
-* `day`: Select the temporal instant corresponding to the _month_ of the given instant.
+* `day`: Select the temporal instant corresponding to the _day_ of the given instant.
 * `hour`: Select the temporal instant corresponding to the _hour_ of the given instant.
 * `minute`: Select the temporal instant corresponding to the _minute_ of the given instant.
 * `second`: Select the temporal instant corresponding to the _second_ of the given instant.


### PR DESCRIPTION
Day truncation description says month instead of day