### PR TITLE
Adding stable ids to all changes in 5.0 to be linkable

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -1623,6 +1623,7 @@ This is also the default provider if none is given.
 | Details
 
 a|
+[[cypher-5_0-r_1]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1653,6 +1654,7 @@ SHOW REL[ATIONSHIP] [PROPERTY] EXIST[ENCE] CONSTRAINTS
 ----
 
 a|
+[[cypher-5_0-r_2]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1675,6 +1677,7 @@ SHOW CONSTRAINTS
 ----
 
 a|
+[[cypher-5_0-r_3]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1697,6 +1700,7 @@ SHOW CONSTRAINTS YIELD *
 ----
 
 a|
+[[cypher-5_0-r_4]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1711,6 +1715,7 @@ DROP INDEX name
 ----
 
 a|
+[[cypher-5_0-r_5]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1737,6 +1742,7 @@ DROP CONSTRAINT name
 ----
 
 a|
+[[cypher-5_0-r_6]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1751,6 +1757,7 @@ CREATE INDEX FOR (n:Label) ON (n.prop)
 ----
 
 a|
+[[cypher-5_0-r_7]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1765,6 +1772,7 @@ CREATE CONSTRAINT FOR ... REQUIRE ...
 ----
 
 a|
+[[cypher-5_0-r_8]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1805,6 +1813,7 @@ CREATE [RANGE] INDEX ...
 These new indexes may be combined for multiple use cases.
 
 a|
+[[cypher-5_0-r_9]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1821,6 +1830,7 @@ SHOW {POINT \| RANGE \| TEXT} INDEXES
 
 ----
 a|
+[[cypher-5_0-r_10]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1838,6 +1848,7 @@ USING {POINT \| RANGE \| TEXT} INDEX
 
 
 a|
+[[cypher-5_0-r_11]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1858,6 +1869,7 @@ Constraints used for `STRING` properties require an additional text index to cov
 Constraints used for point properties require an additional point index to cover the spatial queries properly.
 
 a|
+[[cypher-5_0-r_12]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1870,6 +1882,7 @@ The `uniqueness` output has been removed along with the concept of index uniquen
 The new column `owningConstraint` was introduced to indicate whether an index belongs to a constraint or not.
 
 a|
+[[cypher-5_0-r_13]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1880,6 +1893,7 @@ a|
 The `ownedIndexId` output has been removed and replaced by the new `ownedIndex` column.
 
 a|
+[[cypher-5_0-r_14]]
 label:functionality[]
 label:removed[] +
 For privilege commands:
@@ -1896,6 +1910,7 @@ ON HOME DATABASE
 
 
 a|
+[[cypher-5_0-r_15]]
 label:functionality[]
 label:removed[] +
 For privilege commands:
@@ -1912,6 +1927,7 @@ ON HOME GRAPH
 
 
 a|
+[[cypher-5_0-r_16]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1922,6 +1938,7 @@ a|
 The `allocatedBytes` output has been removed, because it was never tracked and thus was always 0.
 
 a|
+[[cypher-5_0-r_17]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1936,6 +1953,7 @@ prop IS NOT NULL
 ----
 
 a|
+[[cypher-5_0-r_18]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1950,6 +1968,7 @@ prop IS NULL
 ----
 
 a|
+[[cypher-5_0-r_19]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1961,6 +1980,7 @@ Replaced by `+0o...+`.
 
 
 a|
+[[cypher-5_0-r_20]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1971,6 +1991,7 @@ a|
 Only `+0x...+` (lowercase x) is supported.
 
 a|
+[[cypher-5_0-r_21]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1982,6 +2003,7 @@ a|
 Remaining support for repeated relationship variables is removed.
 
 a|
+[[cypher-5_0-r_22]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -1998,6 +2020,7 @@ WHERE NOT isEmpty([1, 2, 3])
 ----
 
 a|
+[[cypher-5_0-r_23]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -2012,6 +2035,7 @@ point.distance(n.prop, point({x:0, y:0})
 ----
 
 a|
+[[cypher-5_0-r_24]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -2027,6 +2051,7 @@ point.withinBBox(point({x:1, y:1}), point({x:0, y:0}), point({x:2, y:2}))
 ----
 
 a|
+[[cypher-5_0-r_25]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -2043,6 +2068,7 @@ CALL {
 ----
 
 a|
+[[cypher-5_0-r_26]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -2053,6 +2079,7 @@ a|
 It is no longer allowed to have `CREATE` clauses in which a variable introduced in the pattern is also referenced from the same pattern.
 
 a|
+[[cypher-5_0-r_27]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -2067,6 +2094,7 @@ CALL { RETURN 1 AS one }
 ----
 
 a|
+[[cypher-5_0-r_28]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -2082,6 +2110,7 @@ MATCH (a) RETURN [p=(a)--() \| p]
 ----
 
 a|
+[[cypher-5_0-r_29]]
 label:functionality[]
 label:removed[]
 [source, cypher, role="noheader"]
@@ -2113,6 +2142,7 @@ In expressions that contain aggregations, the leaves must be either:
 | Details
 
 a|
+[[cypher-5_0-d_1]]
 label:functionality[]
 label:deprecated[]
 [source, cypher, role="noheader"]
@@ -2128,6 +2158,7 @@ MATCH (n)-[r:REL]->(m) SET n=properties(r)
 ----
 
 a|
+[[cypher-5_0-d_2]]
 label:functionality[]
 label:deprecated[]
 [source, cypher, role="noheader"]
@@ -2144,6 +2175,7 @@ MATCH (a), (b), shortestPath((a)-[r*1..1]->(b)) RETURN b
 ----
 
 a|
+[[cypher-5_0-d_3]]
 label:functionality[]
 label:deprecated[]
 [source, cypher, role="noheader"]
@@ -2159,6 +2191,7 @@ CREATE DATABASE `databaseName.withDot` ...
 ----
 
 a|
+[[cypher-5_0-d_4]]
 label:functionality[]
 label:deprecated[]
 [source, cypher, role="noheader"]
@@ -2182,6 +2215,7 @@ Replaced by:
 | Details
 
 a|
+[[cypher-5_0-u_1]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2192,6 +2226,7 @@ a|
 The default index type is changed from B-tree to range index.
 
 a|
+[[cypher-5_0-u_2]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2203,6 +2238,7 @@ The new column `owningConstraint` was added and will be returned by default from
 It will list the name of the constraint that the index is associated with or `null`, in case it is not associated with any constraint.
 
 a|
+[[cypher-5_0-u_3]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2214,6 +2250,7 @@ The new column `ownedIndex` was added and will be returned by default from now o
 It will list the name of the index associated with the constraint or `null`, in case no index is associated with it.
 
 a|
+[[cypher-5_0-u_4]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2237,6 +2274,7 @@ New columns for the current query are added:
 These columns are only returned in the full set (with `YIELD`) and not by default.
 
 a|
+[[cypher-5_0-u_5]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2254,6 +2292,7 @@ Terminate transaction now allows `YIELD`.
 The `WHERE` clause is not allowed on its own, as it is for `SHOW`, but needs the `YIELD` clause.
 
 a|
+[[cypher-5_0-u_6]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2268,6 +2307,7 @@ a|
 `transaction-id` now allows general expressions resolving to a `STRING` or `LIST<STRING>` instead of just parameters.
 
 a|
+[[cypher-5_0-u_7]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2300,6 +2340,7 @@ When the command is not in standalone mode, the `YIELD` and `RETURN` clauses are
 It could also be an expression resolving to a `STRING` or a `LIST<STRING>` (for example the output column from `SHOW`).
 
 a|
+[[cypher-5_0-u_8]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2313,6 +2354,7 @@ The `EXECUTE BOOSTED` privilege will no longer include an implicit `EXECUTE` pri
 That means that to execute a procedure or a function with boosted privileges both `EXECUTE` and `EXECUTE BOOSTED` are needed.
 
 a|
+[[cypher-5_0-u_9]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2324,6 +2366,7 @@ Privileges can be specified as `IMMUTABLE`, which means that they cannot be alte
 They can only be administered with auth disabled.
 
 a|
+[[cypher-5_0-u_10]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2334,6 +2377,7 @@ a|
 `IMMUTABLE` can now be specified with the `REVOKE` command to specify that only immutable privileges should be revoked.
 
 a|
+[[cypher-5_0-u_11]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2359,6 +2403,7 @@ The following columns have been added to the full result set (with `YIELD`) and 
 * `requestedSecondariesCount`
 
 a|
+[[cypher-5_0-u_12]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2389,6 +2434,7 @@ END
 ----
 
 a|
+[[cypher-5_0-u_13]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2423,6 +2469,7 @@ returning an integer approximation for precision 0 and throwing an exception for
 To get an integer value use the `toInteger` function.
 
 a|
+[[cypher-5_0-u_14]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2434,6 +2481,7 @@ DROP ALIAS compositeDatabase.aliasName
 a| The alias commands can now handle aliases in composite databases.
 
 a|
+[[cypher-5_0-u_15]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2444,6 +2492,7 @@ SHOW ALIAS[ES] compositeDatabase.aliasName FOR DATABASE[S]
 a| `SHOW ALIAS` now allows for easy filtering on alias name.
 
 a|
+[[cypher-5_0-u_16]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2455,6 +2504,7 @@ DROP ALIAS compositeDatabase.aliasName
 a| The alias commands can now handle aliases in composite databases.
 
 a|
+[[cypher-5_0-u_17]]
 label:functionality[]
 label:updated[]
 [source, cypher, role="noheader"]
@@ -2474,6 +2524,7 @@ a| `SHOW ALIAS` now allows for easy filtering on alias name.
 | Details
 
 a|
+[[cypher-5_0-a_1]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2484,6 +2535,7 @@ DROP COMPOSITE DATABASE databaseName [IF EXISTS] [DUMP DATA \| DESTROY DATA] [WA
 a| New Cypher command for creating and dropping composite databases.
 
 a|
+[[cypher-5_0-a_2]]
 label:functionality[]
 label:new[] +
 New privilege:
@@ -2497,6 +2549,7 @@ a|
 New privileges that allow a user to `CREATE` and/or `DROP` composite databases.
 
 a|
+[[cypher-5_0-a_3]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2507,6 +2560,7 @@ a|
 Cypher now supports number literals with underscores between digits.
 
 a|
+[[cypher-5_0-a_4]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2519,6 +2573,7 @@ New function which returns whether the given number is `NaN`.
 This function was introduced since comparisons including `NaN = NaN` returns false.
 
 a|
+[[cypher-5_0-a_5]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2531,6 +2586,7 @@ Cypher now supports float literals for the values `Infinity` and `NaN`.
 Both values are implemented according to the Floating-Point Standard IEEE 754.
 
 a|
+[[cypher-5_0-a_6]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2541,6 +2597,7 @@ a|
 New expression which returns the number of results of a subquery.
 
 a|
+[[cypher-5_0-a_7]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2551,6 +2608,7 @@ a|
 New sub-clause for `CREATE DATABASE`, to specify the number of servers hosting a database, when creating a database in cluster environments.
 
 a|
+[[cypher-5_0-a_8]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2561,6 +2619,7 @@ a|
 New sub-clause for `ALTER DATABASE`, which allows modifying the number of servers hosting a database in cluster environments.
 
 a|
+[[cypher-5_0-a_9]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2571,6 +2630,7 @@ a|
 New Cypher command for enabling servers.
 
 a|
+[[cypher-5_0-a_10]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2581,6 +2641,7 @@ a|
 New Cypher command for setting options for a server.
 
 a|
+[[cypher-5_0-a_11]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2591,6 +2652,7 @@ a|
 New Cypher command for changing the name of a server.
 
 a|
+[[cypher-5_0-a_12]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2601,6 +2663,7 @@ a|
 New Cypher command for re-balancing what servers host which databases.
 
 a|
+[[cypher-5_0-a_13]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2611,6 +2674,7 @@ a|
 New Cypher command for moving all databases from servers.
 
 a|
+[[cypher-5_0-a_14]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2621,6 +2685,7 @@ a|
 New Cypher command for dropping servers.
 
 a|
+[[cypher-5_0-a_15]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2631,6 +2696,7 @@ a|
 New Cypher command for listing servers.
 
 a|
+[[cypher-5_0-a_16]]
 label:functionality[]
 label:new[] +
 New privileges:
@@ -2646,6 +2712,7 @@ a|
 New privileges that allow a user to create, modify, reallocate, deallocate, drop and list servers.
 
 a|
+[[cypher-5_0-a_17]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2656,6 +2723,7 @@ a|
 New concise syntax for expressing predicates for which labels a node may have, referred to as label expression.
 
 a|
+[[cypher-5_0-a_18]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]
@@ -2666,6 +2734,7 @@ a|
 New concise syntax for expressing predicates for which relationship types a relationship may have, referred to as relationship type expression.
 
 a|
+[[cypher-5_0-a_19]]
 label:functionality[]
 label:new[]
 [source, cypher, role="noheader"]


### PR DESCRIPTION
This will be used by Aura migration readiness report