### PR TITLE
Add a notice for directedUnionRelationshipTypeScans

### DIFF
--- a/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
+++ b/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
@@ -1688,12 +1688,14 @@ Total database accesses: 37
 
 The `DirectedUnionRelationshipTypesScan` operator fetches all relationships and their start and end nodes with at least one of the provided types from the relationship type index.
 
+[NOTE]
+As the block storage format becomes the default, this operator will cease to be used in generating plans. Please refer to  link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-internals/store-formats[Operations Manual -> Store formats] for futher details on the various store formats available.
 
 .DirectedUnionRelationshipTypesScan
 ======
 
 .Query
-[source,cypher]
+[source,cypher,role=test-result-skip]
 ----
 PROFILE
 MATCH ()-[friendOrFoe: FRIENDS_WITH|FOE]->()
@@ -1733,12 +1735,14 @@ Total database accesses: 14, total allocated memory: 184
 The `PartitionedDirectedUnionRelationshipTypeScan` is a variant of the xref:planning-and-tuning/operators/operators-detail.adoc#query-plan-directed-union-relationship-types-scan[`DirectedUnionRelationshipTypesScan`] operator used by the xref:planning-and-tuning/runtimes/concepts.adoc#runtimes-parallel-runtime[parallel runtime].
 It allows the index to be partitioned into different segments where each segment can be scanned independently in parallel.
 
+[NOTE]
+As the block storage format becomes the default, this operator will cease to be used in generating plans. Please refer to  link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-internals/store-formats[Operations Manual -> Store formats] for futher details on the various store formats available.
 
 .PartitionedDirectedUnionRelationshipTypesScan
 ======
 
 .Query
-[source,cypher]
+[source,cypher,role=test-result-skip]
 ----
 CYPHER runtime=parallel
 PROFILE
@@ -1777,12 +1781,14 @@ Total database accesses: 25
 
 The `UndirectedUnionRelationshipTypesScan` operator fetches all relationships and their start and end nodes with at least one of the provided types from the relationship type index.
 
+[NOTE]
+As the block storage format becomes the default, this operator will cease to be used in generating plans. Please refer to  link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-internals/store-formats[Operations Manual -> Store formats] for futher details on the various store formats available.
 
 .UndirectedUnionRelationshipTypeScan
 ======
 
 .Query
-[source,cypher]
+[source,cypher,role=test-result-skip]]
 ----
 PROFILE
 MATCH ()-[friendOrFoe: FRIENDS_WITH|FOE]-()
@@ -1822,11 +1828,14 @@ Total database accesses: 14, total allocated memory: 184
 The `PartitionedUndirectedUnionRelationshipTypeScan` is a variant of the xref:planning-and-tuning/operators/operators-detail.adoc#query-plan-undirected-union-relationship-types-scan[`UndirectedUnionRelationshipTypesScan`] operator used by the xref:planning-and-tuning/runtimes/concepts.adoc#runtimes-parallel-runtime[parallel runtime].
 It allows the index to be partitioned into different segments where each segment can be scanned independently in parallel.
 
+[NOTE]
+As the block storage format becomes the default, this operator will cease to be used in generating plans. Please refer to  link:{neo4j-docs-base-uri}/operations-manual/{page-version}/database-internals/store-formats[Operations Manual -> Store formats] for futher details on the various store formats available.
+
 .PartitionedUndirectedUnionRelationshipTypesScan
 ======
 
 .Query
-[source,cypher]
+[source,cypher,role=test-result-skip]
 ----
 CYPHER runtime=parallel
 PROFILE


### PR DESCRIPTION
The UnionRelationshipTypeScans are not supported in the block-store storage formats. Therefore, since they have been rolled out as the default in enterprise, we add a note suggesting these plans will not be used in the planner anymore.