### PR TITLE
Update reference.adoc

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -7,5 +7,5 @@ nav:
 asciidoc:
   attributes:
     neo4j-version: '5'
-    neo4j-version-minor: '5.22'
-    neo4j-version-exact: '5.22.0'
+    neo4j-version-minor: '5.21'
+    neo4j-version-exact: '5.21.0'

--- a/modules/ROOT/content-nav.adoc
+++ b/modules/ROOT/content-nav.adoc
@@ -125,6 +125,7 @@
 * Appendix
 ** xref:styleguide.adoc[]
 ** xref:appendix/gql-conformance/index.adoc[]
+*** xref:appendix/gql-conformance/supported-mandatory.adoc[]
 *** xref:appendix/gql-conformance/unsupported-mandatory.adoc[]
 *** xref:appendix/gql-conformance/supported-optional.adoc[]
 *** xref:appendix/gql-conformance/analogous-cypher.adoc[]

--- a/modules/ROOT/pages/appendix/gql-conformance/analogous-cypher.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/analogous-cypher.adoc
@@ -6,7 +6,7 @@ This page lists optional GQL features that have analogous but not identical Cyph
 Optional GQL features are assigned a feature ID code.
 These codes order the features in the table below.
 
-[options="header",cols="a,3a,5a"]
+[options="header",cols="2a,3a,5a"]
 |===
 | GQL Feature ID
 | Description
@@ -15,16 +15,6 @@ These codes order the features in the table below.
 | G100
 | `ELEMENT_ID` function
 | GQL's `ELEMENT_ID()` function is equivalent to Cypher's xref:functions/scalar.adoc#functions-elementid[`elementId()`] function.
-
-| GF01
-| Enhanced numeric functions
-| GQL supports `CEILING()` as a synonym to the `CEIL()` function.
-Cypher only supports xref:functions/mathematical-numeric.adoc#functions-ceil[`ceil()`].
-
-| GF03
-| Logarithmic functions
-| * Cypher uses the xref:functions/mathematical-logarithmic.adoc#functions-log[`log()`] function instead of GQL's `LN()` function.
-* Cypher uses the xref:syntax/operators.adoc#syntax-using-the-exponentiation-operator[exponentiation operator (`^`)] instead of GQL's `POWER()` function.
 
 | GF04
 | Enhanced path functions
@@ -68,25 +58,6 @@ Unlike the `FOR` statement, `UNWIND` does not support yielding indexes and offse
 | GV24
 | 64-bit floating number
 | GQL’s `FLOAT64`  type is equivalent to Cypher’s xref:values-and-types/property-structural-constructed.adoc#_property_type_details[`FLOAT`] type.
-
-| GV39
-| xref:values-and-types/temporal.adoc[Temporal types: date, local datetime, and local time support]
-| Cypher supports GQL’s local temporal types, with the following exceptions:
-
-* GQL defines a parameterless version of the xref:functions/temporal/index.adoc#functions-date[`date()`] function not in Cypher: `CURRENT_DATE`.
-* GQL’s `LOCAL_TIME()` function is equivalent to Cypher’s xref:functions/temporal/index.adoc#functions-localtime[`localtime()`] function.
-GQL also defines a parameterless version of the function not in Cypher: `LOCAL_TIME`.
-* GQL’s `LOCAL_DATETIME()` function is equivalent to Cypher’s xref:functions/temporal/index.adoc#functions-localdatetime[`localdatetime()`] function.
-GQL also defines a parameterless version of the function not in Cypher: `LOCAL_DATETIME`.
-
-| GV40
-| xref:values-and-types/temporal.adoc[Temporal types: zoned datetime and zoned time support]
-| Cypher supports GQL’s zoned temporal types, with the following exceptions:
-
-* GQL’s `ZONED_TIME()` function is equivalent to Cypher’s xref:functions/temporal/index.adoc#functions-time[`time()`] function.
-GQL also defines a parameterless version of the function not in Cypher: `CURRENT_TIME`.
-* GQL’s `ZONED_DATETIME()` function is equivalent to Cypher’s xref:functions/temporal/index.adoc#functions-datetime[`datetime()`] function.
-GQL also defines a parameterless version of the function not in Cypher: `CURRENT_TIMESTAMP`.
 
 | GV45
 | Record types

--- a/modules/ROOT/pages/appendix/gql-conformance/index.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/index.adoc
@@ -1,7 +1,7 @@
 :description: Overview of Cypher's conformance to GQL.
 = GQL conformance
 
-*Last updated*: 11 June 2024 +
+*Last updated*: 5 July 2024 +
 *Neo4j version*: 5.21
 
 GQL is the new link:https://www.iso.org/home.html[ISO] International Standard query language for graph databases.
@@ -19,16 +19,15 @@ WHERE a.name = 'Tom Hanks'
 RETURN m.title
 ----
 
-Neo4j is working towards full GQL conformance (meaning full support of its mandatory features).
-There are, however, currently some mandatory GQL features not implemented in Cypher.
+Cypher supports the majority of mandatory GQL features.
+For a full list, see xref:appendix/gql-conformance/supported-mandatory.adoc[].
+There are, however, currently a few mandatory GQL features not implemented in Cypher.
 These are listed in the page xref:appendix/gql-conformance/unsupported-mandatory.adoc[].
 
 Neo4j is also working towards increasing its support of optional GQL features.
 These are listed in the page xref:appendix/gql-conformance/supported-optional.adoc[].
 
 Additionally, some optional GQL features not yet implemented in Cypher already have analogous Cypher equivalents.
-For example, Cypher and GQL support a function to return the local time.
-In Cypher, this is called xref:functions/temporal/index.adoc#functions-localtime[`localtime()`]; in GQL, it is called `LOCAL_TIME()`.
 These features are listed in the page xref:appendix/gql-conformance/analogous-cypher.adoc[].
 
 [[gql-minimum-conformance]]
@@ -43,5 +42,5 @@ Neo4j 5.14 added support for JavaSE 21 and version 15 of the Unicode Standard.
 For more information, see xref:syntax/parsing.adoc##_using_unicodes_in_cypher[Parsing -> Using Unicode in Cypher].
 * Cypher supports the following mandatory GQL property types: `BOOLEAN` (`BOOL`), `FLOAT` footnote:[The `FLOAT` type in Cypher always represents a 64-bit double-precision floating point number.], `INTEGER` (`SIGNED INTEGER`, or `INT`)footnote:[The `INTEGER` type in Cypher always represents a 64-bit `INTEGER`.], and `STRING` (`VARCHAR`).
 +
-Cypher also supports: `DATE`, `DURATION`, `LIST<INNER_TYPE NOT NULL>` (`ARRAY<INNER_TYPE NOT NULL>`, `INNER_TYPE LIST`, or `INNER_TYPE ARRAY`)footnote:[The `INNER_TYPE` cannot be a `LIST` type.], `LOCAL DATETIME` (`TIMESTAMP WITHOUT TIMEZONE`), `LOCAL TIME` (`TIME WITHOUT TIME ZONE`), `POINT`, `ZONED DATETIME` (`TIME WITH TIMEZONE`), and `ZONED TIME` (`TIMESTAMP WITH TIMEZONE`).
+Cypher also supports the following optional GQL property types: `DATE`, `DURATION`, `LIST<INNER_TYPE NOT NULL>` (`ARRAY<INNER_TYPE NOT NULL>`, `INNER_TYPE LIST`, or `INNER_TYPE ARRAY`)footnote:[The `INNER_TYPE` cannot be a `LIST` type.], `LOCAL DATETIME` (`TIMESTAMP WITHOUT TIMEZONE`), `LOCAL TIME` (`TIME WITHOUT TIME ZONE`), `POINT`, `ZONED DATETIME` (`TIME WITH TIMEZONE`), and `ZONED TIME` (`TIMESTAMP WITH TIMEZONE`).
 For more information, see xref:values-and-types/property-structural-constructed.adoc#_property_types[Values and types -> property types].

--- a/modules/ROOT/pages/appendix/gql-conformance/supported-mandatory.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/supported-mandatory.adoc
@@ -1,0 +1,231 @@
+:description: Information about mandatory GQL features supported by Cypher.
+= Supported mandatory GQL features
+
+Unlike optional GQL features, mandatory GQL features are not assigned a GQL feature ID code.
+The below table is instead listed in order of their appearance in the link:https://www.iso.org/standard/76120.html[ISO/IEC 39075:2024(en) GQL Standard].
+
+[options="header",cols="2a,3a,2a,5a"]
+|===
+| GQL Standard subclause
+| Description
+| Documentation
+| Comment
+
+| 4.11
+| Graph pattern matching
+| xref:patterns/index.adoc[]
+|
+
+| 4.13
+| GQL object types
+| xref:values-and-types/property-structural-constructed.adoc#structural-types[Structural types],  xref:values-and-types/property-structural-constructed.adoc#type-synonyms[Types and their synonyms].
+| Includes: `NODE` (`ANY NODE`, `VERTEX`, `ANY VERTEX`) and `RELATIONSHIP` (`ANY RELATIONSHIP`, `EDGE`, `ANY EDGE`).
+
+| 4.16
+| Predefined value types
+| xref:values-and-types/property-structural-constructed.adoc#property-types[Property types], xref:values-and-types/property-structural-constructed.adoc#type-synonyms[Types and their synonyms].
+| Includes: `BOOLEAN` (`BOOL`), `FLOAT`, `INTEGER` (`SIGNED INTEGER`, `INT`), and `STRING` (`VARCHAR`).
+
+Cypher supports the boolean type predicate for `TRUE`, `FALSE`, and `NULL` but does not support the GQL keyword `UNKNOWN`.
+
+| 13.2
+| <insert statement>
+| xref:clauses/create.adoc#insert-as-synonym-of-create[`INSERT`]
+|
+
+| 13.3
+| <set statement>
+| xref:clauses/set.adoc[`SET`]
+| GQL’s `SET` has no order dependencies because all right-hand side operations are completed before any assignments occur.
+In Cypher’s `SET`, the order of rows can affect the outcome because changes made during execution may depend on the sequence of assignments.
+The only way to guarantee row order in Neo4j is to use xref:clauses/order-by.adoc[`ORDER BY`]. 
+
+| 13.4
+| <remove statement>
+| xref:clauses/remove.adoc[`REMOVE`]
+|
+
+| 13.5
+| <delete statement>
+| xref:clauses/delete.adoc[`DELETE`]
+|
+
+| 14.4
+| <match statement>
+| xref:clauses/match.adoc[`MATCH`], xref:clauses/optional-match.adoc[`OPTIONAL MATCH`]
+| 
+
+| 14.9
+| <order by and page statement>
+| xref:clauses/skip.adoc[`SKIP`]
+| Cypher only supports `SKIP`, which is a GQL-supported synonym to `OFFSET`.
+
+
+| 14.10
+| <primitive result statement>
+| xref:clauses/finish.adoc[`FINISH`]
+|
+
+| 14.11
+| <return statement>
+| xref:clauses/return.adoc[`RETURN`]
+|
+
+| 15.1
+| <call procedure statement> and <procedure call>
+| xref:clauses/call.adoc[`CALL` procedures], xref:subqueries/call-subquery.adoc[`CALL` subqueries].
+| GQL defines an `OPTIONAL CALL` statement, enabling optional procedure and subquery calling.
+This is not available in Cypher.
+
+| 15.2
+| <inline procedure call>
+| xref:subqueries/call-subquery.adoc[`CALL` subqueries].
+| GQL either imports variables implicitly, or explicitly using a variable scope clause.
+In Cypher, `CALL` subqueries require an explicit importing `WITH` clause.
+
+| 15.3
+| <named procedure call>
+| xref:clauses/call.adoc[`CALL` procedure]
+|
+
+| 16.2
+| <limit clause>
+| xref:clauses/limit.adoc[`LIMIT`]
+|
+
+| 16.4
+| <graph pattern>
+| xref:patterns/reference.adoc#graph-patterns[Graph patterns]
+|
+
+| 16.5
+| <insert graph pattern>
+| xref:clauses/create.adoc#[`CREATE`]
+|
+
+| 16.6
+| <order by clause>
+| xref:clauses/order-by.adoc[`ORDER-BY`]
+|
+
+| 16.7
+| <path pattern expression>
+| xref:patterns/reference.adoc#path-patterns[Path patterns]
+|
+
+| 16.8
+| <label expression>
+| xref:patterns/reference.adoc#label-expressions[Label expressions]
+|
+
+| 16.9
+| <path variable reference>
+| xref:patterns/reference.adoc[Patterns -> Syntax and semantics]
+|
+
+| 16.11
+| <graph pattern quantifier>
+| xref:patterns/reference.adoc#quantifiers[Quantifiers]
+|
+
+| 16.17
+| <sort specification list>
+| xref:clauses/order-by.adoc#order-nodes-in-descending-order[Order results in ascending or descending order]
+|
+
+| 16.19
+| <offset clause>
+| xref:clauses/skip.adoc[`SKIP`]
+| Cypher only supports `SKIP` , which is a GQL-supported synonym to `OFFSET`.
+
+| 19.3
+| <comparison predicate>
+| xref:syntax/operators.adoc##query-operators-comparison[Comparison operators]
+|
+
+| 19.4
+| <exists predicate>
+| xref:functions/predicate.adoc#function-exists[`exists()`]
+|
+
+| 19.5
+| <null predicate>
+| xref:values-and-types/type-predicate.adoc#type-predicate-null[Type predicate expressions for `NULL`]
+|
+
+| 19.6
+| <value type predicate>
+| xref:values-and-types/type-predicate.adoc#[]
+|
+
+| 19.7
+| <normalized predicate>
+| xref:syntax/operators.adoc#match-string-is-normalized[`IS NORMALIZED`], xref:syntax/operators.adoc#match-string-is-not-normalized[`IS NOT NORMALIZED`]
+|
+
+| 20.2
+| <value expression primary>
+| xref:queries/expressions.adoc[]
+|
+
+| 20.3
+| <value specification>
+| 
+| GQL defines the `SESSION_USER` value expression, which enables accessing a user’s username within a query.
+In Cypher, current user details can be seen using the link:{neo4j-docs-base-uri}/operations-manual/{page-version}/authentication-authorization/manage-users/#access-control-current-users[`SHOW CURRENT USER` command].
+
+| 20.7
+| <case expression>
+| xref:queries/case.adoc[`CASE`], xref:functions/scalar.adoc#functions-nullIf[`nullIf()`], xref:functions/scalar.adoc#functions-coalesce[`coalesce()`]
+|
+
+| 20.9
+| <aggregate function>
+| xref:functions/aggregating.adoc#functions-avg[`avg()`], xref:functions/aggregating.adoc#functions-count[`count()`], xref:functions/aggregating.adoc#functions-max[`max`], xref:functions/aggregating.adoc#functions-mind[`min()`], xref:functions/aggregating.adoc#functions-sum[`sum()`]
+| Cypher and GQL handle `NULL` values differently for the `sum()` function when queries return 0 rows. 
+For example, `RETURN sum(<expr>)` on an empty table returns `NULL` in GQL, but in Cypher it returns `0`.
+
+| 20.11
+| <property reference>
+| xref:queries/concepts.adoc[Core concepts]
+|
+
+| 20.21
+| <numeric value expression>
+| xref:syntax/operators.adoc#query-operators-mathematical[Mathematical operators]
+|
+
+| 20.22
+| <numeric value function>
+| xref:functions/scalar.adoc#functions-char_length[`char_length()`], xref:functions/scalar.adoc#functions-character_length[`character_length()`]
+|
+
+| 20.23
+| <string value expression>
+| xref:syntax/operators.adoc#syntax-concatenating-two-strings-doublebar[`STRING` concatenation operator (`\|\|`)]
+|
+
+| 20.24
+| <character string function>
+| xref:functions/string.adoc#functions-left[`left()`], xref:functions/string.adoc#functions-lower[`lower()`], xref:functions/string.adoc#functions-normalize[`normalize()`], xref:functions/string.adoc#functions-right[`right()`], xref:functions/string.adoc#functions-trim[`trim()`], xref:functions/string.adoc#functions-upper[`upper()`]
+| In GQL, `TRIM()` removes only space characters.
+In Cypher, `trim()` removes any whitespace character.
+
+| 21.1
+| Names and variables
+| xref:syntax/index.adoc[]
+| Cypher supports GQL’s lexical elements, with the following caveats:
+
+* GQL allows for extended parameter identifiers.
+For example: `RETURN $0hello` is allowed in GQL but not Cypher.
+* GQL allows identifiers that are not variables to be delimited with both backticks and quotes.
+Cypher only allows backticks.
+For example: `MATCH (n) RETURN n."a prop"` is allowed in GQL but not Cypher.
+
+| 22.15
+| Grouping operations
+| xref:functions/aggregating.adoc##counting_with_and_without_duplicates[Counting with and without duplicates]
+|
+
+|===
+

--- a/modules/ROOT/pages/appendix/gql-conformance/supported-optional.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/supported-optional.adoc
@@ -6,105 +6,199 @@ This page lists the optional GQL features Cypher is either fully or partially co
 Optional GQL features are assigned a feature ID code.
 These codes order the features in the table below.
 
-[options="header",cols="a,3a,5a"]
+[options="header",cols="2a,3a,2a,5a"]
 |===
 | GQL Feature ID
 | Description
+| Documentation
 | Comment
 
+| G002
+| Different-edges match mode
+| xref:patterns/reference.adoc#/#graph-patterns-rules-relationship-uniqueness[Relationship uniqueness in Cypher]
+| The semantic for this feature is the default Cypher semantic.
+
+| G004
+| Path variables
+| xref:patterns/reference.adoc#path-patterns[Path patterns]
+|
+
 | G016
-| xref:patterns/shortest-paths.adoc#any[Any path search]
+| Any path search
+| xref:patterns/shortest-paths.adoc#any[`ANY`]
 |
 
 | G017
-| xref:patterns/shortest-paths.adoc#all-shortest[All shortest path search]
+| All shortest path search
+| xref:patterns/shortest-paths.adoc#all-shortest[`ALL SHORTEST`]
 |
 
 | G018
-| xref:patterns/shortest-paths.adoc#any[Any shortest path search]
+| Any shortest path search
+| xref:patterns/shortest-paths.adoc#any[`ANY`]
 |
 
 | G019
-| xref:patterns/shortest-paths.adoc#shortest[Counted shortest path search]
+| Counted shortest path search
+| xref:patterns/shortest-paths.adoc#shortest[`SHORTEST`]
 |
 
 | G020
-| xref:patterns/shortest-paths.adoc#shortest-groups[Counted shortest group search]
+| Counted shortest group search
+| xref:patterns/shortest-paths.adoc#shortest-groups[`SHORTEST GROUPS`]
 |
 
 | G035
-| xref:patterns/variable-length-patterns.adoc#quantified-path-patterns[Quantified paths]
+| Quantified paths
+| xref:patterns/variable-length-patterns.adoc#quantified-path-patterns[Quantified path patterns]
 |
 
 | G036
+| Quantified edges
 | xref:patterns/variable-length-patterns.adoc#quantified-relationships[Quantified relationships]
 |
 
+| G050
+| Parenthesized path pattern: `WHERE` clause
+| xref:patterns/fixed-length-patterns.adoc#path-patterns[Path patterns]
+|
+
+| G051
+| Parenthesized path pattern: non-local predicate
+| xref:patterns/reference.adoc#graph-patterns-rules-variable-references[Graph patterns -> Rules]
+|
+
+| G060
+| Bounded graph pattern quantifier
+| xref:patterns/reference.adoc#quantifiers[Quantifiers]
+|
+
+| G061
+| Unbounded graph pattern quantifier
+| xref:patterns/reference.adoc#quantifiers[Quantifiers]
+|
+
+| G074
+| Label expressions: wildcard label
+| xref:patterns/reference.adoc#label-expressions[Label expressions]
+|
+
 | GA06
-| xref:values-and-types/type-predicate.adoc[Value type predicates]
+| Value type predicates
+| xref:values-and-types/type-predicate.adoc[Type predicate expressions]
+|
+
+| GA07
+| Ordering by discarded binding variables
+| xref:patterns/reference.adoc#graph-patterns-rules-variable-references[Graph patterns -> Rules]
 |
 
 | GF01
 | Enhanced numeric functions
-| Supported functions: xref:functions/mathematical-numeric.adoc#functions-abs[`abs()`], xref:functions/mathematical-numeric.adoc#functions-floor[`floor()`], and xref:functions/mathematical-logarithmic.adoc#functions-sqrt[`sqrt()`].
+| xref:functions/mathematical-numeric.adoc#functions-abs[`abs()`], xref:functions/mathematical-numeric.adoc#functions-floor[`floor()`], xref:functions/mathematical-logarithmic.adoc#functions-sqrt[`sqrt()`].
+| Note the following exceptions:
+GQL supports `CEILING()` as a synonym for the `CEIL()` function.
+Cypher only supports xref:functions/mathematical-numeric.adoc#functions-ceil[`ceil()`].
 
 | GF02
 | Trigonometric functions
-| Supported functions: xref:functions/mathematical-trigonometric.adoc#functions-acos[`acos()`], xref:functions/mathematical-trigonometric.adoc#functions-asin[`asin()`], xref:functions/mathematical-trigonometric.adoc#functions-atan[`atan()`], xref:functions/mathematical-trigonometric.adoc#functions-cos[`cos()`], xref:functions/mathematical-trigonometric.adoc#functions-cot[`cot()`], xref:functions/mathematical-trigonometric.adoc#functions-degrees[`degrees()`], xref:functions/mathematical-trigonometric.adoc#functions-radians[`radians()`], and xref:functions/mathematical-trigonometric.adoc#functions-tan[`tan()`].
+| xref:functions/mathematical-trigonometric.adoc#functions-acos[`acos()`], xref:functions/mathematical-trigonometric.adoc#functions-asin[`asin()`], xref:functions/mathematical-trigonometric.adoc#functions-atan[`atan()`], xref:functions/mathematical-trigonometric.adoc#functions-cos[`cos()`], xref:functions/mathematical-trigonometric.adoc#functions-cot[`cot()`], xref:functions/mathematical-trigonometric.adoc#functions-degrees[`degrees()`], xref:functions/mathematical-trigonometric.adoc#functions-radians[`radians()`], xref:functions/mathematical-trigonometric.adoc#functions-tan[`tan()`]
+|
 
 | GF03
 | Logarithmic functions
-| Supported functions: xref:functions/mathematical-logarithmic.adoc#functions-exp[`exp()`] and xref:functions/mathematical-logarithmic.adoc#functions-log10[`log10()`].
+| xref:functions/mathematical-logarithmic.adoc#functions-exp[`exp()`], xref:functions/mathematical-logarithmic.adoc#functions-log10[`log10()`].
+| Note the following exceptions:
+
+ * Cypher uses the xref:functions/mathematical-logarithmic.adoc#functions-log[`log()`] function instead of GQL's `LN()` function.
+* Cypher uses the xref:syntax/operators.adoc#syntax-using-the-exponentiation-operator[exponentiation operator (`^`)] instead of GQL's `POWER()` function.
 
 | GF05
 | Multi-character trim functions
-| Supported functions: xref:functions/string.adoc#functions-btrim[`btrim()`], xref:functions/string.adoc#functions-ltrim[`ltrim()`], and xref:functions/string.adoc#functions-rtrim[`rtrim()`].
+| xref:functions/string.adoc#functions-btrim[`btrim()`], xref:functions/string.adoc#functions-ltrim[`ltrim()`], xref:functions/string.adoc#functions-rtrim[`rtrim()`]
+|
 
+| GF06
+| Explicit `TRIM` function
+| xref:functions/string.adoc#functions-trim[`trim()`]
+| In GQL, `TRIM()` removes only space characters.
+In Cypher, `trim()` removes any whitespace character.
 
-| G074
-| xref:patterns/reference.adoc#label-expressions[Label expressions: wildcard label]
+| GG01
+| Graph with open graph type
+|
 |
 
 | GQ01
-| xref:clauses/use.adoc[`USE` graph clause]
+| `USE` graph clause
+| xref:clauses/use.adoc[`USE`]
 | Cypher’s `USE` clause supports static graph references (e.g. `USE myComposite.myGraph`)and dynamic graph references (e.g. `USE graph.byName(<expression>)`).
 However, Cypher does not support GQL’s full graph reference syntax.
 For example, GQL’s graph reference values `CURRENT_GRAPH` and `CURRENT_PROPERTY_GRAPH` cannot be used in Cypher.
 
 | GQ03
-| xref:clauses/union.adoc[Composite query: `UNION`]
+| Composite query: `UNION`
+| xref:clauses/union.adoc[`UNION`]
 |
 
 | GQ13
-| xref:clauses/limit.adoc[`ORDER BY` and page statement: `LIMIT`]
+| `ORDER BY` and page statement: `LIMIT`
+| xref:clauses/limit.adoc[`LIMIT`], xref:clauses/order-by.adoc[`ORDER BY`]
 | Cypher requires using the xref:clauses/with.adoc[`WITH`] clause, which GQL does not.
 
+| GV39
+| Temporal types: date, local datetime, and local time support
+| xref:values-and-types/temporal.adoc[Temporal types], xref:functions/temporal/index.adoc#functions-date[`date()`]
+| Note the following exceptions:
+
+* GQL defines a parameterless version of the xref:functions/temporal/index.adoc#functions-date[`date()`] function not in Cypher: `CURRENT_DATE`.
+* GQL’s `LOCAL_TIME()` function is equivalent to Cypher’s xref:functions/temporal/index.adoc#functions-localtime[`localtime()`] function.
+GQL also defines a parameterless version of the function not in Cypher: `LOCAL_TIME`.
+* GQL’s `LOCAL_DATETIME()` function is equivalent to Cypher’s xref:functions/temporal/index.adoc#functions-localdatetime[`localdatetime()`] function.
+GQL also defines a parameterless version of the function not in Cypher: `LOCAL_DATETIME`.
+
+| GV40
+| Temporal types: zoned datetime and zoned time support
+| xref:values-and-types/temporal.adoc[Temporal types]
+| Note the following exceptions:
+
+* GQL’s `ZONED_TIME()` function is equivalent to Cypher’s xref:functions/temporal/index.adoc#functions-time[`time()`] function.
+GQL also defines a parameterless version of the function not in Cypher: `CURRENT_TIME`.
+* GQL’s `ZONED_DATETIME()` function is equivalent to Cypher’s xref:functions/temporal/index.adoc#functions-datetime[`datetime()`] function.
+GQL also defines a parameterless version of the function not in Cypher: `CURRENT_TIMESTAMP`.
+
 | GV50
-| xref:values-and-types/lists.adoc[List value types]
+| List value types
+| xref:values-and-types/lists.adoc[Lists]
 |
 
 | GV55
-| xref:values-and-types/property-structural-constructed.adoc#structural-types[Path value types]
+| Path value types
+| xref:values-and-types/property-structural-constructed.adoc#structural-types[Structural types -> `PATH`]
 |
 
 | GV66
-| xref:values-and-types/type-predicate.adoc#type-predicate-any-and-nothing[Open dynamic unions]
+| Open dynamic unions
+| xref:values-and-types/type-predicate.adoc#type-predicate-any-and-nothing[Type predicate expressions -> `ANY` and `NOTHING`]
 |
 
 | GV67
+| Closed dynamic unions
 | xref:values-and-types/type-predicate.adoc#type-predicate-closed-dynamic-unions[Closed dynamic unions]
 |
 
 | GV70
-| xref:values-and-types/working-with-null.adoc[Immaterial value types: null type support (`NULL`)]
+| Immaterial value types: null type support (`NULL`)
+| xref:values-and-types/working-with-null.adoc[Working with `NULL`]
 |
 
 | GV71
-| xref:values-and-types/type-predicate.adoc#type-predicate-any-and-nothing[Immaterial value types: empty type support (`NOTHING`)]
+| Immaterial value types: empty type support (`NOTHING`)]
+| xref:values-and-types/type-predicate.adoc#type-predicate-any-and-nothing[Type predicate expressions -> `ANY` and `NOTHING`]
 |
 
 |===
 
 [NOTE]
-Cypher and GQL sometimes name functions differently and, as a result, several Cypher functions offer the same (or very similar) functionality to their GQL counterpart, yet they are not conformant with GQL.
+Cypher and GQL sometimes name functions differently and, as a result, several Cypher functions offer the same (or very similar) functionality to their GQL counterpart.
 For more information, see the page xref:appendix/gql-conformance/analogous-cypher.adoc[].

--- a/modules/ROOT/pages/appendix/gql-conformance/unsupported-mandatory.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/unsupported-mandatory.adoc
@@ -7,7 +7,7 @@ The table below provides an overview of these GQL features and, where applicable
 Unlike optional GQL features, mandatory GQL features are not assigned a GQL feature ID code.
 The below table is instead listed in order of their appearance in the link:https://www.iso.org/standard/76120.html[ISO/IEC 39075:2024(en) GQL Standard].
 
-[options="header",cols="a,3a,5a"]
+[options="header",cols="2a,3a,5a"]
 |===
 | GQL Standard subclause
 | Description
@@ -16,11 +16,6 @@ The below table is instead listed in order of their appearance in the link:https
 | 4.9.2
 | GQL-status objects
 | Exposing successful execution results, errors, exceptions, and warnings as GQL-status objects.
-
-| 4.16.2
-| Boolean types
-| Cypher supports the Boolean literals `TRUE` and `FALSE`, but not `UNKNOWN`.
-Cypher also does not support Boolean type predicate tests.
 
 | 7.1-7.3
 | Session management
@@ -38,43 +33,9 @@ Cypher Shell also offers specific link:{neo4j-docs-base-uri}/operations-manual/{
 | Graph expressions
 | GQL defines the following graph reference values commands: `CURRENT_GRAPH` and `CURRENT_PROPERTY_GRAPH`.
 
-| 13.3
-| `SET` statement
-| GQL’s SET statement has no order dependencies because all right-hand side operations are completed before any assignments occur.
-In Cypher’s xref:clauses/set.adoc[`SET`], the order of rows can affect the outcome because changes made during execution may depend on the sequence of assignments.
-The only way to guarantee row order in Neo4j is to use xref:clauses/order-by[`ORDER BY`].
-
-| 15.1 & 15.2
-| `CALL` procedure statement & inline procedure `CALL`
-| * GQL defines an `OPTIONAL CALL` statement, enabling optional procedure and subquery calling.
-* GQL implicitly imports variables.
-In Cypher, `CALL` subqueries require an explicit xref:subqueries/call-subquery.adoc#call-importing-variables[importing `WITH` clause].
-
-| 16.19
-| `OFFSET` clause
-| Cypher only supports xref:clauses/skip.adoc[`SKIP`].
-
 | 17.1
 | Schema reference
 | GQL defines an `AT` clause for selecting the current schema and the following schema selection options: `HOME_SCHEMA` and `CURRENT_SCHEMA`.
-
-| 20.3
-| Value specification
-| GQL defines the `SESSION_USER` value expression, which enables accessing a user’s username within a query.
-In Cypher, current user details can be seen using the link:{neo4j-docs-base-uri}/operations-manual/{page-version}/authentication-authorization/manage-users/#access-control-current-users[`SHOW CURRENT USER` command].
-
-| 20.9
-| Aggregate functions
-| Cypher and GQL handle `NULL` values differently for aggregate functions when queries return 0 rows.
-For example, `RETURN SUM(<expression>)` on an empty table returns `NULL` in GQL, but in Cypher it returns `0`.
-
-| 21.1
-| Names and variables
-| * GQL allows for extended parameter identifiers.
-For example: `RETURN $0hello` is allowed in GQL but not Cypher.
-* GQL allows identifiers that are not variables to be delimited with both backticks and quotes.
-Cypher only allows backticks.
-For example: `MATCH (n) RETURN n."a prop"` is allowed in GQL but not Cypher.
 
 | 21.3
 | <token>, <separator>, and <identifier>

--- a/modules/ROOT/pages/clauses/load-csv.adoc
+++ b/modules/ROOT/pages/clauses/load-csv.adoc
@@ -30,7 +30,7 @@ Loading CSV files requires link:{neo4j-docs-base-uri}/operations-manual/{page-ve
 === Import local files
 
 You can store CSV files on the database server and then access them by using a `+file:///+` URL.
-By default, paths are resolved relative to the Neo4j installation folder.
+By default, paths are resolved relative to the Neo4j import directory.
 
 .Import artists name and year information from a local file
 ====

--- a/modules/ROOT/pages/clauses/transaction-clauses.adoc
+++ b/modules/ROOT/pages/clauses/transaction-clauses.adoc
@@ -1,9 +1,9 @@
-:description: This section explains the `SHOW TRANSACTIONS` and `TERMINATION TRANSACTIONS` commands.
+:description: This section explains the `SHOW TRANSACTIONS` and `TERMINATE TRANSACTIONS` commands.
 
 [[query-transaction-clauses]]
 = Transaction commands
 
-This page explains the `SHOW TRANSACTIONS` and `TERMINATION TRANSACTIONS` commands.
+This page explains the `SHOW TRANSACTIONS` and `TERMINATE TRANSACTIONS` commands.
 
 [[query-listing-transactions]]
 == SHOW TRANSACTIONS

--- a/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
@@ -431,8 +431,8 @@ Returns the requested number of approximate nearest neighbor relationships and t
 
 |===
 
-[limitations-and-issues]
-== Limitiations and known issues
+[[limitations-and-issues]]
+== Limitations and known issues
 
 As of Neo4j 5.13, the vector index is no longer a beta feature.
 It does, however, still contain some limitations and known issues.

--- a/modules/ROOT/pages/patterns/reference.adoc
+++ b/modules/ROOT/pages/patterns/reference.adoc
@@ -779,7 +779,7 @@ Matches one or more relationships with type `R` and of any direction, and any no
 ()-[:R]-+()
 ----
 
-Matches paths consisting of two inbound subpaths, one with relationships of type `A` and one with relationships of type `B`, meeting at a node with label `A`:
+Matches paths consisting of two inbound subpaths, one with relationships of type `R` and one with relationships of type `S`, meeting at a node with label `A`:
 [source, role=noheader]
 ----
 ()-[:R]->+(:A)<-[:S]-+()

--- a/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
+++ b/modules/ROOT/pages/values-and-types/property-structural-constructed.adoc
@@ -8,6 +8,7 @@ Cypher provides first class support for a number of data value types.
 These fall into the following three categories: *property*, *structural*, and *constructed*.
 This section will first provide a brief overview of each type, and then go into more detail about the property data type. 
 
+[[property-types]]
 == Property types
 
 A property type value is one that can be stored as a node or relationship property.

--- a/publish.yml
+++ b/publish.yml
@@ -6,7 +6,7 @@ site:
 content:
   sources:
   - url: ./
-    branches: ['3.5', '4.0', '4.1', '4.2', '4.3', '4.4','dev']
+    branches: ['3.5', '4.0', '4.1', '4.2', '4.3', '4.4', 'HEAD']
     edit_url: https://github.com/neo4j/docs-cypher/tree/{refname}/{path}
     exclude:
     - '!**/_includes/*'


### PR DESCRIPTION
Relationship types should be `R` and `S` in this example instead of `A` and `B`. The node label is `A`.