### PR TITLE
normalise vector index settings achors

### DIFF
--- a/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
@@ -130,7 +130,7 @@ OPTIONS { indexConfig: {
 
 For more information about the values accepted by different index providers, see xref:indexes/semantic-indexes/vector-indexes.adoc#vector-index-providers[].
 
-[[config-vector-dimensions]]
+[[config-vector.dimensions]]
 ==== `vector.dimensions`
 The dimensions of the vectors to be indexed.
 For more information, see xref:indexes/semantic-indexes/vector-indexes.adoc#embeddings[].
@@ -144,7 +144,7 @@ Accepted values::: `INTEGER` between `1` and `4096` inclusively.
 Default value::: None.
 The setting was mandatory prior to Neo4j 5.23.
 
-[[config-vector-similarity-function]]
+[[config-vector.similarity_function]]
 ==== `vector.similarity_function`
 
 The name of the similarity function used to assess the similarity of two vectors.
@@ -154,7 +154,7 @@ Accepted values::: `STRING`: `'cosine'`, `'euclidean'`.
 Default value::: `'cosine'`. The setting was mandatory prior to Neo4j 5.23.
 
 [role=label--new-5.23]
-[[config-vector-quantization]]
+[[config-vector.quantization.enabled]]
 ==== `vector.quantization.enabled`
 
 Quantization is a technique to reduce the size of vector representations.
@@ -170,7 +170,7 @@ Default value::: `true`
 === Advanced configuration settings
 
 [role=label--new-5.23]
-[[config-vector-hsnw.m]]
+[[config-vector.hsnw.m]]
 ==== `vector.hnsw.m`
 
 The `M` parameter controls the maximum number of connections each node has in the HNSW (Hierarchical Navigable Small Worlds) graph.
@@ -181,7 +181,7 @@ Accepted values::: `INTEGER` between `1` and `512` inclusively.
 Default value::: `16`
 
 [role=label--new-5.23]
-[[config-vector-hsnw.ef_construction]]
+[[config-vector.hsnw.ef_construction]]
 ==== `vector.hnsw.ef_construction`
 
 The number of nearest neighbors tracked during the insertion of vectors into the HNSW graph.


### PR DESCRIPTION
There were a mix of - _ . being used in the new sections, and some
omitted parts of the name, and felt a little inconsistent.

This changes the new achors such that it would be
        #config-INDEXSETTING

This is similar to how the Neo4j configuration settings are referenced
in the operations manual.
