### PR TITLE
Document unicode changes for Cypher 25

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -32,9 +32,9 @@ label:removed[]
 RETURN 1 as my\u0085identifier
 ----
 a|
-The Unicode character \`\u0085` has been remove for unescaped identifiers and is now considered a whitespace character.
+The Unicode character \`\u0085` has been removed for unescaped identifiers and is now considered a whitespace character.
 To continue using it, escape the identifier by adding backticks around it.
-This applies to all unescaped identifiers in Cypher, such as label expressions, properties, variable names or parameters.
+This applies to all unescaped identifiers in Cypher, such as label expressions, properties, variable names, or parameters.
 In the given example, the quoted identifier would be \`my�identifier`.
 
 a|
@@ -46,7 +46,7 @@ RETURN 1 as my$Identifier
 ----
 a|
 The character with the Unicode representation \`\u0024` has been removed for unescaped identifiers. To continue using it, escape the identifier by adding backticks around the identifier.
-This applies to all unescaped identifiers in Cypher, such as label expressions, properties, variable names or parameters. In the given example, the quoted identifier would be \`my$identifier`.
+This applies to all unescaped identifiers in Cypher, such as label expressions, properties, variable names, or parameters. In the given example, the quoted identifier would be \`my$identifier`.
 
 The following Unicode Characters are removed in identifiers:
 '\u0000', '\u0001', '\u0002', '\u0003', '\u0004', '\u0005', '\u0006', '\u0007',

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -16,6 +16,54 @@ New features are added to the language continuously, and occasionally, some feat
 This section lists all of the features that have been removed, deprecated, added, or extended in different Cypher versions.
 Replacement syntax for deprecated and removed features are also indicated.
 
+[[cypher-deprecations-additions-removals-2025.01]]
+== Neo4j 2025.01
+
+=== Removed features
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+a|
+label:functionality[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+RETURN 1 as my\u0085identifier
+----
+a|
+The Unicode character \`\u0085` has been remove for unescaped identifiers and is now considered a whitespace character.
+To continue using it, escape the identifier by adding backticks around it.
+This applies to all unescaped identifiers in Cypher, such as label expressions, properties, variable names or parameters.
+In the given example, the quoted identifier would be \`my�identifier`.
+
+a|
+label:functionality[]
+label:removed[]
+[source, cypher, role="noheader"]
+----
+RETURN 1 as my$Identifier
+----
+a|
+The character with the Unicode representation \`\u0024` has been removed for unescaped identifiers. To continue using it, escape the identifier by adding backticks around the identifier.
+This applies to all unescaped identifiers in Cypher, such as label expressions, properties, variable names or parameters. In the given example, the quoted identifier would be \`my$identifier`.
+
+The following Unicode Characters are removed in identifiers:
+'\u0000', '\u0001', '\u0002', '\u0003', '\u0004', '\u0005', '\u0006', '\u0007',
+'\u0008', '\u000E', '\u000F', '\u0010', '\u0011', '\u0012', '\u0013', '\u0014',
+'\u0015', '\u0016', '\u0017', '\u0018', '\u0019', '\u001A', '\u001B', '\u007F',
+'\u0080', '\u0081', '\u0082', '\u0083', '\u0084', '\u0086', '\u0087', '\u0088',
+'\u0089', '\u008A', '\u008B', '\u008C', '\u008D', '\u008E', '\u008F', '\u0090',
+'\u0091', '\u0092', '\u0093', '\u0094', '\u0095', '\u0096', '\u0097', '\u0098',
+'\u0099', '\u009A', '\u009B', '\u009C', '\u009D', '\u009E', '\u009F', '\u0024',
+'\u00A2', '\u00A3', '\u00A4', '\u00A5', '\u00AD', '\u0600', '\u0601', '\u0602',
+'\u0603', '\u0604', '\u0605', '\u061C', '\u06DD', '\u070F', '\u08E2', '\u180E',
+'\u200B', '\u200C', '\u200D', '\u200E', '\u200F', '\u202A', '\u202B', '\u202C',
+'\u202D', '\u202E', '\u2060', '\u2061', '\u2062', '\u2063', '\u2064', '\u2066',
+'\u2067', '\u2068', '\u2069', '\u206A', '\u206B', '\u206C', '\u206D', '\u206E',
+'\u206F', '\u2E2F', '\uFEFF', '\uFFF9', '\uFFFA', '\uFFFB'
+|===
+
 [[cypher-deprecations-additions-removals-5.24]]
 == Neo4j 5.24
 

--- a/modules/ROOT/pages/syntax/parsing.adoc
+++ b/modules/ROOT/pages/syntax/parsing.adoc
@@ -56,6 +56,7 @@ The following unicode characters are considered as whitespace:
 | Group separator                   | `\u001D`
 | Record separator                  | `\u001E`
 | Unit separator                    | `\u001F`
+| Next Line                         | `\u0085`
 |===
 
 It is possible to have multiple whitespace characters in a row, and will have the same effect as using a single whitespace.


### PR DESCRIPTION
One unicode was turned into whitespace, the others were just removed as valid in non-delimited identifiers