### PR TITLE
Document change in behaviour for db.schema.nodeTypeProperties() and db.schema.relTypeProperties()

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -35,7 +35,8 @@ CALL db.schema.nodeTypeProperties() YIELD propertyTypes RETURN propertyTypes;
 CALL db.schema.relTypeProperties() YIELD propertyTypes RETURN propertyTypes;
 ----
 a|
-The column `propertyTypes` now returns a list of strings representing the possible Cypher Types the given property has.
+The column `propertyTypes` returned by the procedures link:{neo4j-docs-base-uri}/operations-manual/{page-version}/procedures/#procedure_db_schema_nodetypeproperties[`db.schema.nodeTypeProperties()`] and link:{neo4j-docs-base-uri}/operations-manual/{page-version}/procedures/#procedure_db_schema_reltypeproperties[`db.schema.relTypeProperties()`] previously returned a list of strings representing the potential Java types for a given property.
+It now returns a list of strings representing the possible Cypher Types the given property has.
 For all available Cypher types, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
 |===
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -20,10 +20,12 @@ Replacement syntax for deprecated and removed features are also indicated.
 == Neo4j 2025.01
 
 === Removed features
+
 [cols="2", options="header"]
 |===
 | Feature
 | Details
+
 a|
 label:functionality[]
 label:removed[]
@@ -36,6 +38,7 @@ The Unicode character \`\u0085` has been removed for unescaped identifiers and i
 To continue using it, escape the identifier by adding backticks around it.
 This applies to all unescaped identifiers in Cypher, such as label expressions, properties, variable names, or parameters.
 In the given example, the quoted identifier would be \`my�identifier`.
+
 a|
 label:functionality[]
 label:removed[]
@@ -46,6 +49,7 @@ RETURN 1 as my$Identifier
 a|
 The character with the Unicode representation \`\u0024` has been removed for unescaped identifiers. To continue using it, escape the identifier by adding backticks around the identifier.
 This applies to all unescaped identifiers in Cypher, such as label expressions, properties, variable names, or parameters. In the given example, the quoted identifier would be \`my$identifier`.
+
 The following Unicode Characters are removed in identifiers:
 '\u0000', '\u0001', '\u0002', '\u0003', '\u0004', '\u0005', '\u0006', '\u0007',
 '\u0008', '\u000E', '\u000F', '\u0010', '\u0011', '\u0012', '\u0013', '\u0014',

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -16,6 +16,29 @@ New features are added to the language continuously, and occasionally, some feat
 This section lists all of the features that have been removed, deprecated, added, or extended in different Cypher versions.
 Replacement syntax for deprecated and removed features are also indicated.
 
+[[cypher-deprecations-additions-removals-2025.01]]
+== Neo4j 2025.01
+
+=== Updated features
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+CALL db.schema.nodeTypeProperties() YIELD propertyTypes RETURN propertyTypes;
+CALL db.schema.relTypeProperties() YIELD propertyTypes RETURN propertyTypes;
+----
+a|
+The column `propertyTypes` now returns a list of strings representing the possible Cypher Types the given property has.
+For all available Cypher types, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
+|===
+
 [[cypher-deprecations-additions-removals-5.24]]
 == Neo4j 5.24
 


### PR DESCRIPTION
The column propertyTypes is a LIST<STRING>, currently it outputs runtime types, but in Cypher25 it outputs Cypher Types.