### PR TITLE
Document old deprecation for database naming

### DIFF
--- a/modules/ROOT/pages/syntax/naming.adoc
+++ b/modules/ROOT/pages/syntax/naming.adoc
@@ -27,8 +27,8 @@ For example, `MATCH (  a  ) RETURN a` is equivalent to `MATCH (a) RETURN a`.
 === Using special characters in names
 Non-alphabetic characters, including numbers, symbols and whitespace characters, *can* be used in names, but *must* be escaped using backticks.
 For example: `++`^n`++`, `++`1first`++`, `++`$$n`++`, and `++`my variable has spaces`++`.
-Database names are an exception and may include dots without the need for escaping.
-For example: naming a database `foo.bar.baz` is perfectly valid.
+Database names are an exception and may include dots without the need for escaping, although this behavior is deprecated as it may introduce ambiguity when addressing composite databases.
+For example: naming a database `foo.bar.baz` is valid, but deprecated. `++`foo.bar.baz`++` is valid.
 
 Within an escaped name, the following escaping sequences are allowed:
 


### PR DESCRIPTION
Database names containing `.` have been deprecated since 5.0, and this has been documented in the operations manual. Document it here also for consistency.