### PR TITLE
Top Level Braces docs

### DIFF
--- a/modules/ROOT/pages/appendix/gql-conformance/index.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/index.adoc
@@ -1,8 +1,8 @@
 :description: Overview of Cypher's conformance to GQL.
 = GQL conformance
 
-*Last updated*: 24 October 2024 +
-*Neo4j version*: 5.25
+*Last updated*: 13 November 2024 +
+*Neo4j version*: 2025.01
 
 GQL is the new link:https://www.iso.org/home.html[ISO] International Standard query language for graph databases.
 

--- a/modules/ROOT/pages/appendix/gql-conformance/supported-mandatory.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/supported-mandatory.adoc
@@ -28,6 +28,11 @@ The below table is instead listed in order of their appearance in the link:https
 
 Cypher supports the boolean type predicate for `TRUE`, `FALSE`, and `NULL` but does not support the GQL keyword `UNKNOWN`.
 
+| 9.1
+| <nested procedure specification>
+| xref:clauses/union.adoc#combining-union-and-union-all[Combining `UNION` and `UNION ALL`].
+|
+
 | 13.2
 | <insert statement>
 | xref:clauses/create.adoc#insert-as-synonym-of-create[`INSERT`]

--- a/modules/ROOT/pages/clauses/union.adoc
+++ b/modules/ROOT/pages/clauses/union.adoc
@@ -124,14 +124,14 @@ The combined result is returned, without duplicates.
 |Rows: 3
 |===
 
-[[union-combining-distinct-and-all]]
-== Combining UNION DISTINCT and UNION ALL
+[role=label--new-2025.01]
+[[combining-union-and-union-all]]
+== Combining UNION and UNION ALL
 
-It is not allowed to mix `UNION DISTINCT` and `UNION ALL` in the same chain of clauses.
-This can be solved by enclosing one or more `UNION` of the same type in curly braces
-allowing the enclosed query to be used as an argument to the outer `UNION`.
+To combine `UNION` (or `UNION DISTINCT`) and `UNION ALL` in the same query, enclose one or more `UNION` operations of the same type in curly braces.
+This allows the enclosed query to act as an argument that can be combined with an outer `UNION` operation of any type.
 
-.Query
+.Combine `UNION` and `UNION ALL` using curly braces
 [source, cypher]
 ----
 {
@@ -158,7 +158,6 @@ The combined result is returned.
 | "Ed Wood"
 |Rows: 4
 |===
-
 
 
 [[post-union-processing]]

--- a/modules/ROOT/pages/clauses/union.adoc
+++ b/modules/ROOT/pages/clauses/union.adoc
@@ -124,6 +124,42 @@ The combined result is returned, without duplicates.
 |Rows: 3
 |===
 
+[[union-combining-distinct-and-all]]
+== Combining UNION DISTINCT and UNION ALL
+
+It is not allowed to mix `UNION DISTINCT` and `UNION ALL` in the same chain of clauses.
+This can be solved by enclosing one or more `UNION` of the same type in curly braces
+allowing the enclosed query to be used as an argument to the outer `UNION`.
+
+.Query
+[source, cypher]
+----
+{
+   MATCH (n:Actor)
+   RETURN n.name AS name
+   UNION
+   MATCH (n:Director)
+   RETURN n.name AS name
+}
+UNION ALL
+MATCH (n:Movie)
+RETURN n.title AS name
+----
+
+The combined result is returned.
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+| name
+| "Johnny Depp"
+| "Sarah Jessica Parker"
+| "Ed Wood"
+| "Ed Wood"
+|Rows: 4
+|===
+
+
 
 [[post-union-processing]]
 == Post-union processing

--- a/modules/ROOT/pages/clauses/union.adoc
+++ b/modules/ROOT/pages/clauses/union.adoc
@@ -124,7 +124,7 @@ The combined result is returned, without duplicates.
 |Rows: 3
 |===
 
-[role=label--new-2025.01]
+[role=label--new-2025.02]
 [[combining-union-and-union-all]]
 == Combining UNION and UNION ALL
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -134,6 +134,37 @@ Several  xref:clauses/transaction-clauses.adoc#query-listing-transactions[`SHOW 
 * The current query-related columns — `currentQuery`, `currentQueryId`, `parameters`, `planner`, `runtime`, `indexes`, `currentQueryStartTime`, `currentQueryElapsedTime`, `currentQueryCpuTime`, `currentQueryIdleTime`, and `currentQueryStatus` — now return `null` when no query is executing.
 |===
 
+
+=== New features
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+{
+   MATCH (n:Actor)
+   RETURN n.name AS name
+   UNION
+   MATCH (n:Director)
+   RETURN n.name AS name
+}
+UNION ALL
+MATCH (n:Movie)
+RETURN n.title AS name
+----
+
+a| `UNION` (or `UNION DISTINCT`) and `UNION ALL` can now be combined in the same query through the use of curly braces.
+This was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+For more information, see xref:clauses/union.adoc#combining-union-and-union-all[Combining `UNION` and `UNION ALL`].
+|===
+
+
 [[cypher-deprecations-additions-removals-5.26]]
 == Neo4j 5.26
 


### PR DESCRIPTION
Adds docs for top level braces from [CIP-146](https://docs.google.com/document/d/1J2lCrQB5ZDLZI3Vu7gtOQKEPW4NWum-yMbAyQ1FlCT0/edit?tab=t.0#heading=h.lzdax825k5wi) implemented in [PR](https://github.com/neo-technology/neo4j/pull/27470).

Note: do not merge until release in Neo4j 2025.01 is confirmed.