### PR TITLE
Add ALL keyword to RETURN clause as part of GQL compliance

### DIFF
--- a/modules/ROOT/pages/appendix/gql-conformance/supported-mandatory.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/supported-mandatory.adoc
@@ -73,8 +73,7 @@ The only way to guarantee row order in Neo4j is to use xref:clauses/order-by.ado
 | 14.11
 | <return statement>
 | xref:clauses/return.adoc[`RETURN`]
-| GQL defines the option to specify `RETURN ALL` (functionally equivalent to using `RETURN` on its own).
-This is currently not available in Cypher.
+|
 
 | 15.4
 | <conditional statement>

--- a/modules/ROOT/pages/clauses/return.adoc
+++ b/modules/ROOT/pages/clauses/return.adoc
@@ -236,6 +236,7 @@ The `Movie` node `'Man of Tai Chi'` is returned by the query, but only once (wit
 d|Rows: 1
 |===
 
+[role=label--new-2025.05]
 [[return-all-results]]
 == RETURN ALL
 

--- a/modules/ROOT/pages/clauses/return.adoc
+++ b/modules/ROOT/pages/clauses/return.adoc
@@ -236,3 +236,26 @@ The `Movie` node `'Man of Tai Chi'` is returned by the query, but only once (wit
 d|Rows: 1
 |===
 
+[[return-all-results]]
+== RETURN ALL
+
+Returning all results can also be accomplished by explicitly including `ALL` in the `RETURN`.
+The `RETURN ALL` keyword was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[], and using it is functionally the same as using simple `RETURN`.
+
+.Query
+[source, cypher]
+----
+MATCH (p:Person {name: 'Keanu Reeves'})-->(m)
+RETURN ALL m
+----
+
+The same node is returned twice, as there are two relationships connecting to it from `'Keanu Reeves'`.
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+| m
+| {"title":"Man of Tai Chi","released":2013}+
+| {"title":"Man of Tai Chi","released":2013}+
+d|Rows: 1
+|===

--- a/modules/ROOT/pages/clauses/with.adoc
+++ b/modules/ROOT/pages/clauses/with.adoc
@@ -234,3 +234,56 @@ As the limit is larger than the total number of remaining rows, all rows are ret
 | 6
 |Rows: 4
 |===
+
+[[with-unique-results]]
+== Unique results
+
+`DISTINCT` retrieves only unique rows for the columns that have been selected for projection.
+
+.Query
+[source, cypher]
+----
+MATCH (n)-[:KNOWS]->(p)
+WITH DISTINCT p.name AS name
+RETURN name
+----
+
+`'George'` is returned by the query, but only once (without the `DISTINCT` operator it would have been returned twice because there are two `KNOWS` relationships going to it):
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+| name
+| "Bossman"
+| "George"
+| "Anders"
+d|Rows: 3
+|===
+
+
+[[with-all-results]]
+== WITH ALL
+
+Projecting all results can also be accomplished by explicitly including `ALL` in the `WITH`.
+
+.Query
+[source, cypher]
+----
+MATCH (n)-[:KNOWS]->(p)
+WITH ALL p.name AS name
+RETURN name
+----
+
+The same name is returned twice, as there are two `KNOWS` relationships connecting to it.
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+| name
+| "Bossman"
+| "George"
+| "George"
+| "Anders"
+d|Rows: 4
+|===
+

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -307,6 +307,29 @@ RETURN cosh(0.5), coth(0.5), sinh(0.5), tanh(0.5)
 ----
 | Introduction of four new hyperbolic trigonometric Cypher functions.
 For more information, see xref:functions/mathematical-trigonometric.adoc[Mathematical functions - trigonometric].
+
+a|
+label:functionality[]
+label:new[]
+[source, cypher, role=noheader]
+----
+MATCH (n)
+RETURN ALL n.prop AS prop
+----
+| The keyword `ALL` can now be added after a xref:clauses/return.adoc#return-all-results[RETURN] as the explicit form of a `RETURN` without duplicate removal.
+
+a|
+label:functionality[]
+label:new[]
+[source, cypher, role=noheader]
+----
+MATCH (n)
+WITH ALL n.prop AS prop
+RETURN prop
+----
+| The keyword `ALL` can now be added after a xref:clauses/with.adoc#with-all-results[WITH] as the explicit form of a `WITH` without duplicate removal.
+
+
 |===
 
 [[cypher-deprecations-additions-removals-2025.03]]


### PR DESCRIPTION
Added ALL keyword for GQL compliance for RETURN, and for consistency to WITH