### PR TITLE
Fix examples in Patterns / Syntax and semantics / shortestPaths

### DIFF
--- a/modules/ROOT/pages/patterns/reference.adoc
+++ b/modules/ROOT/pages/patterns/reference.adoc
@@ -1399,7 +1399,7 @@ Note that it is possible to pass a fixed length path pattern (with a single rela
 === Rules
 
 [[shortest-functions-rules-var-length-restriction]]
-==== Restricted to variable length
+==== Restricted to variable-length relationships
 
 The pattern in the path selector function must be a variable-length relationship and not a quantified path pattern.
 

--- a/modules/ROOT/pages/patterns/reference.adoc
+++ b/modules/ROOT/pages/patterns/reference.adoc
@@ -1470,14 +1470,14 @@ Return a single shortest path for each distinct pair of nodes matching `(:A)` an
 
 [source, role=noheader]
 ----
-MATCH shortestPath((:A)-[:R]->{0,10}(:B))
+MATCH shortestPath((:A)-[:R*0..10]->(:B))
 ----
 
 Return all paths equal to the shortest path length for each distinct pair of nodes matching `(:A)` and `(:B)`:
 
 [source, role=noheader]
 ----
-MATCH allShortestPaths((:A)-[:R]->{0,10}(:B))
+MATCH allShortestPaths((:A)-[:R*0..10]->(:B))
 ----
 
 [[graph-patterns]]


### PR DESCRIPTION
The examples in Patterns / Syntax and semantics / shortestPaths / Examples mix legacy shortest path and QPPs, which is disallowed. This PR changes them to variable-length relationships.

It also improves the header "Restricted to variable length". QPPs are disallowed but also variable length. What they are not are variable-length relationships.  