### PR TITLE
Remove update boundary paragraph #1186

### DIFF
--- a/modules/ROOT/pages/appendix/gql-conformance/supported-optional.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/supported-optional.adoc
@@ -98,6 +98,18 @@ These codes order the features in the table below.
 | xref:syntax/naming.adoc#identifier-length-limit[Naming rules and recommendations -> Identifier length limit]
 |
 
+| GD01
+| Updatable graphs
+| xref:clauses/clause-composition.adoc#writing-clauses[Cypher clauses -> Writing clauses]
+| * Feature GD01 implies compliance with GQL feature GT01, "Explicit transaction commands", which states that conforming languages shall contain the following transaction control commands: `START TRANSACTION`, `ROLLBACK`, and `COMMIT`.
+These are not present in Cypher.
+However, Neo4j offers transaction management through the link:{neo4j-docs-base-uri}/create-applications[driver] transaction API.
+Cypher Shell also offers specific link:{neo4j-docs-base-uri}/operations-manual/current/tools/cypher-shell/#cypher-shell-commands[commands] to manage transactions.
+* Feature GD01 implies conformance to GQL's `<set-statement>` (subclause 13.3).
+GQL’s `SET` has no order dependencies because all right-hand side operations are completed before any assignments occur.
+However, In Cypher’s `SET`, the order of rows can affect the outcome because changes made during execution may depend on the sequence of assignments.
+The only way to guarantee row order in Neo4j is to use xref:clauses/order-by.adoc[`ORDER BY`]. 
+
 | GF01
 | Enhanced numeric functions
 | xref:functions/mathematical-numeric.adoc#functions-abs[`abs()`], xref:functions/mathematical-numeric.adoc#functions-floor[`floor()`], xref:functions/mathematical-logarithmic.adoc#functions-sqrt[`sqrt()`].

--- a/modules/ROOT/pages/clauses/with.adoc
+++ b/modules/ROOT/pages/clauses/with.adoc
@@ -25,10 +25,6 @@ Another use is to filter on aggregated values.
 `WITH` is used to introduce aggregates which can then be used in predicates in `WHERE`.
 These aggregate expressions create new bindings in the results.
 
-`WITH` is also used to separate reading from updating of the graph.
-Every part of a query must be either read-only or write-only.
-When going from a writing part to a reading part, the switch must be done with a `WITH` clause.
-
 image:graph_with_clause.svg[]
 
 ////

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -173,6 +173,18 @@ Graph name parts with special characters may require additional escaping of thos
 
 Note that escaping graph names within the graph functions string argument is not supported in Cypher 5.
 
+a|
+label:functionality[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+CREATE (:Person)
+MATCH (p:Person)
+RETURN count(p) AS count
+----
+
+| Queries no longer require xref:clauses/with.adoc[`WITH`] to transition between reading and writing operations.
+
 |===
 
 === New features


### PR DESCRIPTION
Removes the paragraph about the update boundary property of `WITH`.