### PR TITLE
Fixes + sign formatting in deprecations page

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -98,7 +98,7 @@ label:deprecated[]
 ----
 ... + n:A&B\|C
 ----
-a| Using an unparenthesized label expression predicate as the right-hand side operand of `+` is deprecated.
+a| Using an unparenthesized label expression predicate as the right-hand side operand of `\+` is deprecated.
 Parenthesize the label expression predicate on the right-hand side of `+`: `... + (n:A)`.
 
 a|


### PR DESCRIPTION
In the following place, the `+` sign needs to be escaped in order to go out of the previous context to render correctly

![image](https://github.com/user-attachments/assets/9629c7b3-12a1-4b9e-94fa-c9e3e604f511)
