### PR TITLE
Fix broken link in WITH clause chapter

### DIFF
--- a/modules/ROOT/pages/clauses/with.adoc
+++ b/modules/ROOT/pages/clauses/with.adoc
@@ -10,7 +10,7 @@ The `WITH` clause serves multiple purposes in Cypher:
 * xref:clauses/with.adoc#bind-values-to-variables[Bind the results of expressions to new variables]
 * xref:clauses/with.adoc#aggregations[Perform aggregations]
 * xref:clauses/with.adoc#remove-duplicate-values[Remove duplicate values]
-* xref:clauses/with.adoc#ordering-and-pagination[Order and paginate results]
+* xref:clauses/with.adoc#ordering-pagination[Order and paginate results]
 * xref:clauses/with.adoc#filter-results[Filter results]
 * xref:clauses/with.adoc#combine-write-and-read-clauses[Combine write and read clauses]
 


### PR DESCRIPTION
The section had updated it's tag but the list referencing it hadn't updated its reference

Not sure which versions of the docs are affected and need cherry-picks