### PR TITLE
Update styleguide with cypherfmt rules and recommend its usage

### DIFF
--- a/modules/ROOT/pages/styleguide.adoc
+++ b/modules/ROOT/pages/styleguide.adoc
@@ -225,14 +225,14 @@ RETURN [
 .Good
 [source, cypher]
 ----
-MATCH (n)--[r]->(m)
+MATCH (n)-[r]->(m)
 RETURN n, r, m
 ----
 
 .Also good
 [source, cypher]
 ----
-MATCH (n)--[r]->(m)
+MATCH (n)-[r]->(m)
 
 RETURN n, r, m
 ----

--- a/modules/ROOT/pages/styleguide.adoc
+++ b/modules/ROOT/pages/styleguide.adoc
@@ -9,6 +9,12 @@ The purpose of the Cypher styleguide is to make queries as easy to read as possi
 
 For rules and recommendations for naming of labels, relationship types and properties, please see the xref::syntax/naming.adoc[Naming rules and recommendations].
 
+The best way to make sure your queries follow the styling rules is to use `cypherfmt`, the official Cypher formatter.
+It is available as part of the https://marketplace.visualstudio.com/items?itemName=neo4j-extensions.neo4j-for-vscode[Neo4j VS Code Extension],
+and as a command line tool through the https://www.npmjs.com/package/@neo4j-cypher/language-support[Neo4j Cypher Language Support npm package].
+
+
+
 [[cypher-styleguide-general-recommendations]]
 == General recommendations
 
@@ -113,6 +119,123 @@ RETURN a.prop
 MATCH (a:A)
 WHERE EXISTS { (a)-->(b:B) }
 RETURN a.prop
+----
+
+* Limit line length to 80 characters if possible. Line breaks should be applied starting from the outermost group, with each nested group breaking
+until either the line fits or no more line breaks can be inserted. Add two spaces of indentation for each nested broken group.
+
+.Bad
+[source, cypher]
+----
+MATCH (n)
+WHERE n.prop <> 'a' AND n.prop <> 'b' AND n.prop <> 'c' AND n.prop <> 'd' AND n.prop <> 'e'
+RETURN n
+----
+
+.Good
+[source, cypher]
+----
+MATCH (n)
+WHERE
+  n.prop <> 'a' AND
+  n.prop <> 'b' AND
+  n.prop <> 'c' AND
+  n.prop <> 'd' AND
+  n.prop <> 'e'
+RETURN n
+----
+
+* Start ORDER BY and LIMIT clauses on new lines.
+
+.Bad
+[source, cypher]
+----
+MATCH (n)
+RETURN 5 ORDER BY n.prop LIMIT 10
+----
+
+.Good
+[source, cypher]
+----
+MATCH (n)
+RETURN 5
+ORDER BY n.prop
+LIMIT 10
+----
+
+* A group containing a CASE expression should always split, and each WHEN, ELSE, and END should be put on a new line. Additionally, WHEN and ELSE should add two spaces of indentation.
+
+.Bad
+[source, cypher]
+----
+MATCH (n:Person {name: 'Alice'})
+RETURN CASE WHEN n.age >= 18 THEN 'Adult' ELSE 'Minor' END AS ageGroup
+----
+
+.Good
+[source, cypher]
+----
+MATCH (n:Person {name: 'Alice'})
+RETURN
+  CASE
+    WHEN n.age >= 18 THEN 'Adult'
+    ELSE 'Minor'
+  END AS ageGroup-
+----
+
+* Lines that end with a list or map literal and do not fit within the maximum width should leave
+the opening bracket/brace on the previous line and use only two additional spaces of indentation.
+
+.Bad
+[source, cypher]
+----
+RETURN 
+  [
+    "Alice",
+    "Bob",
+    "Charlie",
+    "David",
+    "Eve",
+    "Frank",
+    "Grace",
+    "Heidi",
+    "Ivan",
+    "Judy"
+  ]
+----
+
+.Good
+[source, cypher]
+----
+RETURN [
+  "Alice",
+  "Bob",
+  "Charlie",
+  "David",
+  "Eve",
+  "Frank",
+  "Grace",
+  "Heidi",
+  "Ivan",
+  "Judy"
+]
+----
+
+* A single blank line may be used to separate clauses, queries or comments.
+
+.Good
+[source, cypher]
+----
+MATCH (n)--[r]->(m)
+RETURN n, r, m
+----
+
+.Also good
+[source, cypher]
+----
+MATCH (n)--[r]->(m)
+
+RETURN n, r, m
 ----
 
 [[cypher-styleguide-casing]]

--- a/modules/ROOT/pages/styleguide.adoc
+++ b/modules/ROOT/pages/styleguide.adoc
@@ -181,8 +181,9 @@ RETURN
   END AS ageGroup
 ----
 
-* Lines that end with a list or map literal and do not fit within the maximum width should leave the opening bracket or brace on the preceding line.
-The contents of the literal should be indented two additional spaces from the line where the opening bracket or brace appears.
+* When a line ends with a list or map literal that does not fit within the maximum line width, place the opening bracket or brace on the same line as the clause that introduces it.
+Start each element of the literal on a new line, indented two spaces further than the line containing the opening bracket or brace.
+Close the literal at the original indentation level.
 
 .Bad
 [source, cypher]

--- a/modules/ROOT/pages/styleguide.adoc
+++ b/modules/ROOT/pages/styleguide.adoc
@@ -10,10 +10,7 @@ The purpose of the Cypher styleguide is to make queries as easy to read as possi
 For rules and recommendations for naming of labels, relationship types and properties, please see the xref::syntax/naming.adoc[Naming rules and recommendations].
 
 The best way to make sure your queries follow the styling rules is to use `cypherfmt`, the official Cypher formatter.
-It is available as part of the https://marketplace.visualstudio.com/items?itemName=neo4j-extensions.neo4j-for-vscode[Neo4j VS Code Extension],
-and as a command line tool through the https://www.npmjs.com/package/@neo4j-cypher/language-support[Neo4j Cypher Language Support npm package].
-
-
+It is available as part of the https://marketplace.visualstudio.com/items?itemName=neo4j-extensions.neo4j-for-vscode[Neo4j VS Code Extension], and as a command line tool through the https://www.npmjs.com/package/@neo4j-cypher/language-support[Neo4j Cypher Language Support npm package].
 
 [[cypher-styleguide-general-recommendations]]
 == General recommendations
@@ -23,7 +20,6 @@ and as a command line tool through the https://www.npmjs.com/package/@neo4j-cyph
 * When referring to functions, use lower camel case and parentheses.
 For example: `toString()`.
 * If you are storing Cypher statements in a separate file, use the file extension `.cypher`.
-
 
 [[cypher-styleguide-indentation-and-line-breaks]]
 == Indentation and line breaks
@@ -121,8 +117,9 @@ WHERE EXISTS { (a)-->(b:B) }
 RETURN a.prop
 ----
 
-* Limit line length to 80 characters if possible. Line breaks should be applied starting from the outermost group, with each nested group breaking
-until either the line fits or no more line breaks can be inserted. Add two spaces of indentation for each nested broken group.
+* Limit line length to 80 characters if possible.
+Line breaks should be applied starting from the outermost group, with each nested group breaking until either the line fits or no more line breaks can be inserted.
+Add two spaces of indentation for each nested broken group.
 
 .Bad
 [source, cypher]
@@ -145,7 +142,7 @@ WHERE
 RETURN n
 ----
 
-* Start ORDER BY and LIMIT clauses on new lines.
+* Start `ORDER BY` and `LIMIT` clauses on new lines.
 
 .Bad
 [source, cypher]
@@ -163,7 +160,8 @@ ORDER BY n.prop
 LIMIT 10
 ----
 
-* A group containing a CASE expression should always split, and each WHEN, ELSE, and END should be put on a new line. Additionally, WHEN and ELSE should add two spaces of indentation.
+* A group containing a `CASE` expression should always break, and each `WHEN`, `ELSE`, and `END` should be put on a new line.
+Additionally, `WHEN` and `ELSE` should add two spaces of indentation.
 
 .Bad
 [source, cypher]
@@ -180,11 +178,11 @@ RETURN
   CASE
     WHEN n.age >= 18 THEN 'Adult'
     ELSE 'Minor'
-  END AS ageGroup-
+  END AS ageGroup
 ----
 
-* Lines that end with a list or map literal and do not fit within the maximum width should leave
-the opening bracket/brace on the previous line and use only two additional spaces of indentation.
+* Lines that end with a list or map literal and do not fit within the maximum width should leave the opening bracket or brace on the preceding line.
+The contents of the literal should be indented two additional spaces from the line where the opening bracket or brace appears.
 
 .Bad
 [source, cypher]


### PR DESCRIPTION
## Description
Hey, docs team! For the past few months, as a master's thesis project, @simonthuresson and I have been working on a formatter for Cypher. In short, the formatter formats a Cypher query so that it follows the styleguide recommendations. During development, we found that the styleguide is quite far from comprehensive, and also some of the cypher snippets in the docs disagree with it as well. Filling out the missing pieces and addressing any ambiguity became a fairly large part of our project, and we wrote extensively about how we did so in our thesis, which you can find here:

- [An Evaluation of Approaches to Code Formatting](https://lup.lub.lu.se/luur/download?func=downloadFile&recordOId=9188816&fileOId=9188817)

In short, we did a survey on styling preferences, and talked to Cypher users to try and figure out what the most preferred way of writing Cypher was. We then took those learnings and implemented it in our formatter so that it could automatically enforce the rules.

This PR is a draft of how we think the styleguide should be updated in accordance with the new rules. I did not put a lot of time into the wording and structure of the recommendations, as I would prefer to leave that to the professionals (you), but I provided some examples which hopefully illustrate the ideas well. If you want more detailed context on the rules, refer to the thesis (chapter 4 specifically). I also included a recommendation at the start of the style guide that users should use our formatter, as manual formatting is generally not a great idea.

#### Note
I included a link to the language support npm package that I claim provides a command-line tool. This is not actually live yet, but will be soon: https://github.com/neo4j/cypher-language-support/pull/518

## Try it out
If you want to get a better feel for how the formatter works and how it applies the rules, you can try it out in:
- Query in the Aura console (the ... menu -> format query)
- [The Cypher Language Support CodeMirror playground](https://neo4j.github.io/cypher-language-support/)
- [VS Code](https://marketplace.visualstudio.com/items?itemName=neo4j-extensions.neo4j-for-vscode)

I would also recommend running any Cypher queries you add to the docs through the formatter first, to ensure that the styling is always consistent across all documentation.

## Note
This is my last day at Neo4j, so I probably will not be able to respond to any comments on this PR. If you have questions, direct them at the language support team (#team-cypher-language-support), they have reviewed every line of code in the formatter, and are well aware of how it works. Feel free to completely change the wording I have used, this is just a first draft that I wanted to get in before leaving.
