### PR TITLE
2025.06 changes to mandatory GQL features

### DIFF
--- a/modules/ROOT/pages/appendix/gql-conformance/index.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/index.adoc
@@ -1,8 +1,8 @@
 :description: Overview of Cypher's conformance to GQL.
 = GQL conformance
 
-*Last updated*: 24 October 2024 +
-*Neo4j version*: 5.25
+*Last updated*: 2 June 2025 +
+*Neo4j version*: 2025.06
 
 GQL is the new link:https://www.iso.org/home.html[ISO] International Standard query language for graph databases.
 

--- a/modules/ROOT/pages/appendix/gql-conformance/supported-mandatory.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/supported-mandatory.adoc
@@ -11,6 +11,11 @@ The below table is instead listed in order of their appearance in the link:https
 | Documentation
 | Comment
 
+| 4.9.2
+| GQL-status objects
+| link:https://neo4j.com/docs/status-codes/current/[Status Codes for Errors & Notifications]
+| Neo4j exposes successful execution results, errors, exceptions, and warnings as GQL-status objects.
+
 | 4.11
 | Graph pattern matching
 | xref:patterns/index.adoc[]

--- a/modules/ROOT/pages/appendix/gql-conformance/unsupported-mandatory.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/unsupported-mandatory.adoc
@@ -14,10 +14,6 @@ The below table is instead listed in order of their appearance in the link:https
 | Description
 | Comment and similar Neo4j functionality
 
-| 4.9.2
-| GQL-status objects
-| Exposing successful execution results, errors, exceptions, and warnings as GQL-status objects.
-
 | 7.1-7.3
 | Session management
 | GQL defines the following session commands: `SESSION SET`, `SESSION RESET`, and `SESSION CLOSE`.


### PR DESCRIPTION
As of 2025.06, the location of GQL mandatory feature 4.9.2  "GQL-status objects" should be changed from unsupported to supported.

This is because from this release onwards, the new errors will be shown by default in Query/Browser + Cypher shell.