### PR TITLE
Mark 25 as prerelease - force sitemap to Cypher 5

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,7 @@
 name: cypher-manual
 title: Cypher Manual
 version: '25'
+prerelease: true
 start_page: ROOT:introduction/index.adoc
 nav:
 - modules/ROOT/content-nav.adoc


### PR DESCRIPTION
Marking 25 as prerelease will do the following:

- Ensure the sitemaps extension treats Cypher 5 as the latest version, so that it will generate a sitemap from Cypher 5 content
- Ensure canonical URLs in the HTML `<head>` are accurate. We can then allow new pages in Cypher 25 to be indexed, or we can index the whole of the Cypher manual.