### PR TITLE
Clarify that withdrawal of graph reference deprecation was backported to 5.26

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -407,8 +407,8 @@ label:deprecated[]
 USE my.db ...
 
 ----
-a| The use of unquoted `.` characters in xref:clauses/use.adoc[`USE`] clauses when specifying databases and aliases was deprecated in 5.26, except when `.` indicated that the database or alias belonged to a composite database.
-However, this deprecation has been withdrawn in 2025.06, and replaced by two new deprecations in Cypher 5:
+a| The use of unquoted `.` characters in xref:clauses/use.adoc[`USE`] clauses when specifying databases and aliases was deprecated in 5.26.0, except when `.` indicated that the database or alias belonged to a composite database.
+However, this deprecation has been withdrawn in 5.26.9 and 2025.06. In 2025.06, it was replaced by two new deprecations in Cypher 5:
 
 * xref::deprecations-additions-removals-compatibility.adoc#_graph_reference_removed_name_parts_quoting[Deprecated support for quoted name parts in graph references]
 


### PR DESCRIPTION
I guess we do not need to port this to Cypher 25 docs, as Cypher 25 is not present in 5.26.

This is an amendment to https://github.com/neo4j/docs-cypher/pull/1317