### PR TITLE
Remove `SET` keyword from db creation

### DIFF
--- a/modules/ROOT/pages/queries/select-version.adoc
+++ b/modules/ROOT/pages/queries/select-version.adoc
@@ -75,7 +75,7 @@ To alter the default Cypher version on an existing database, add `SET DEFAULT LA
 .Cypher 25
 [source,cypher]
 ----
-ALTER DATABASE movies DEFAULT LANGUAGE CYPHER 25
+ALTER DATABASE movies SET DEFAULT LANGUAGE CYPHER 25
 ----
 
 ======
@@ -85,7 +85,7 @@ ALTER DATABASE movies DEFAULT LANGUAGE CYPHER 25
 .Cypher 5
 [source,cypher]
 ----
-ALTER DATABASE actors DEFAULT LANGUAGE CYPHER 5
+ALTER DATABASE actors SET DEFAULT LANGUAGE CYPHER 5
 ----
 
 ======

--- a/modules/ROOT/pages/queries/select-version.adoc
+++ b/modules/ROOT/pages/queries/select-version.adoc
@@ -48,7 +48,7 @@ To select a default Cypher version when creating a database, add `DEFAULT LANGUA
 .Cypher 25
 [source,cypher]
 ----
-CREATE DATABASE actors SET DEFAULT LANGUAGE CYPHER 25
+CREATE DATABASE actors DEFAULT LANGUAGE CYPHER 25
 ----
 
 ======
@@ -75,7 +75,7 @@ To alter the default Cypher version on an existing database, add `SET DEFAULT LA
 .Cypher 25
 [source,cypher]
 ----
-ALTER DATABASE movies SET DEFAULT LANGUAGE CYPHER 25
+ALTER DATABASE movies DEFAULT LANGUAGE CYPHER 25
 ----
 
 ======
@@ -85,7 +85,7 @@ ALTER DATABASE movies SET DEFAULT LANGUAGE CYPHER 25
 .Cypher 5
 [source,cypher]
 ----
-ALTER DATABASE actors SET DEFAULT LANGUAGE CYPHER 5
+ALTER DATABASE actors DEFAULT LANGUAGE CYPHER 5
 ----
 
 ======


### PR DESCRIPTION
Not supported on Cypher 5 (under which tests for this branch run), plus it's confusing that the `SET` keyword is optional in Cypher 25 and not supported in Cypher 5.