### PR TITLE
Name Repeat operator without Trail/Walk parameter

### DIFF
--- a/modules/ROOT/pages/planning-and-tuning/execution-plans.adoc
+++ b/modules/ROOT/pages/planning-and-tuning/execution-plans.adoc
@@ -141,7 +141,7 @@ The `id` column specifies a unique ID assigned to each operator.
 There are no guarantees about the order of the ids, although they will usually start with 0 at the root operator, and will increase until the leaf operator is reached at the beginning of the operator tree.
 
 The `Details` column in the middle of the execution plan describes what task is performed by each operator.
-For example, the details column of the xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-repeat[Repeat(Trail)] operator in the middle of the execution plan (`id 5`), specifies that the operator traverses a quantified path pattern without an upward limit.
+For example, the details column of the xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-repeat[Repeat] operator in the middle of the execution plan (`id 5`), specifies that the operator traverses a quantified path pattern without an upward limit.
 
 Finally, the `Estimated Rows` column details the number of rows that are expected to be produced by each operator.
 This estimate is an approximate number based on the available statistical information and the planner uses it to choose a suitable execution plan.footnote:[The statistical information maintained by Neo4j includes the following: the number of nodes having a certain label, the number of relationships by type, selectivity per index, and the number of relationships by type, ending with or starting from a node with a specific label.]

--- a/modules/ROOT/pages/planning-and-tuning/operators/index.adoc
+++ b/modules/ROOT/pages/planning-and-tuning/operators/index.adoc
@@ -423,8 +423,8 @@ Tests for the presence of a pattern predicate in queries containing multiple pat
 |
 
 | xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-nullify-metadata[NullifyMetadata]
-| responsible for cleaning up the state produced by xref:planning-and-tuning/operators/operators-detail.adoc#query-plan-repeat[`Repeat(Trail)`].
-It is only planned directly after `Repeat(Trail)`.
+| responsible for cleaning up the state produced by xref:planning-and-tuning/operators/operators-detail.adoc#query-plan-repeat[`Repeat`].
+It is only planned directly after `Repeat`.
 |
 |
 | 
@@ -632,7 +632,7 @@ It also fetches the start and end nodes of those relationships.
 |
 |
 
-| xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-repeat[Repeat(Trail)]
+| xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-repeat[Repeat]
 | Solves quantified path patterns.
 |
 |

--- a/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
+++ b/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
@@ -4063,15 +4063,15 @@ Total database accesses: 49, total allocated memory: 1200
 
 
 [[query-plan-repeat]]
-=== Repeat (Trail)
-// Repeat(Trail)
+=== Repeat
+// Repeat
 
-Given a start node, the `Repeat(Trail)` operator will traverse xref::patterns/variable-length-patterns.adoc#quantified-path-patterns[quantified path patterns] that cannot be solved (or solved efficiently) with the xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-varlength-expand-all[`VarLengthExpand(All)`] operator.
+Given a start node, the `Repeat` operator will traverse xref::patterns/variable-length-patterns.adoc#quantified-path-patterns[quantified path patterns] that cannot be solved (or solved efficiently) with the xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-varlength-expand-all[`VarLengthExpand(All)`] operator.
 Similar to an xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-apply[`Apply`] operator, it takes a single row from the left-hand side and applies the operators on the right-hand side.
 In contrast to `Apply`, however, it repeatedly applies these operators in accordance with the quantifiers on the quantified path pattern.
 In the following example, the operator will repeat twice and produce rows for both repetitions.
 
-.Repeat(Trail)
+.Repeat
 ======
 
 .Query
@@ -4127,8 +4127,8 @@ Total database accesses: 747, total allocated memory: 45832
 [[query-plan-nullify-metadata]]
 === Nullify Metadata
 
-`NullifyMetadata` is responsible for cleaning up the state produced by xref:planning-and-tuning/operators/operators-detail.adoc#query-plan-repeat[`Repeat(Trail)`].
-It is only planned directly after `Repeat(Trail)`.
+`NullifyMetadata` is responsible for cleaning up the state produced by xref:planning-and-tuning/operators/operators-detail.adoc#query-plan-repeat[`Repeat`].
+It is only planned directly after `Repeat`.
 
 .NullifyMetadata
 ======


### PR DESCRIPTION
All the description of the operator should be applicable independent of the traversal path mode. In EXPLAIN outputs, the parameter will be included, though.

I have left the description in the additions document, as this is how it was introduced. Maybe we should rename it there as well.