### PR TITLE
Update descriptions in show index columns

### DIFF
--- a/modules/ROOT/pages/constraints/managing-constraints.adoc
+++ b/modules/ROOT/pages/constraints/managing-constraints.adoc
@@ -452,6 +452,8 @@ The allowed property types for property type constraints are:
 
 [NOTE]
 Because storing lists of xref:values-and-types/vector.adoc[`VECTOR`] values is not supported, property type constraints cannot be created for `LIST<VECTOR<TYPE>(DIMENSION) NOT NULL>`.
+Additionally, `VECTOR` property type constraints must be created with a specific dimension and coordinate value, where the dimension must be greater than `0` and less or equal to `4096`.
+For more information, see xref:values-and-types/vector.adoc[Values and types -> Vectors].
 
 For a complete reference describing all types available in Cypher, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].
 

--- a/modules/ROOT/pages/constraints/managing-constraints.adoc
+++ b/modules/ROOT/pages/constraints/managing-constraints.adoc
@@ -452,7 +452,7 @@ The allowed property types for property type constraints are:
 
 [NOTE]
 Because storing lists of xref:values-and-types/vector.adoc[`VECTOR`] values is not supported, property type constraints cannot be created for `LIST<VECTOR<TYPE>(DIMENSION) NOT NULL>`.
-Additionally, `VECTOR` property type constraints must be created with a specific dimension and coordinate value, where the dimension must be greater than `0` and less or equal to `4096`.
+Additionally, `VECTOR` property type constraints must be created with a specific dimension and coordinate value, where the dimension must be greater than `0` and less than or equal to `4096`.
 For more information, see xref:values-and-types/vector.adoc[Values and types -> Vectors].
 
 For a complete reference describing all types available in Cypher, see the section on xref::values-and-types/property-structural-constructed.adoc#types-synonyms[types and their synonyms].

--- a/modules/ROOT/pages/constraints/syntax.adoc
+++ b/modules/ROOT/pages/constraints/syntax.adoc
@@ -138,7 +138,7 @@ Where `<TYPE>` is one of the following property types:
 
 [NOTE]
 Because storing lists of xref:values-and-types/vector.adoc[`VECTOR`] values is not supported, property type constraints cannot be created for `LIST<VECTOR<TYPE>(DIMENSION) NOT NULL>`.
-Additionally, `VECTOR` property type constraints must be created with a specific dimension and coordinate value, where the dimension must be greater than `0` and less or equal to `4096`.
+Additionally, `VECTOR` property type constraints must be created with a specific dimension and coordinate value, where the dimension must be greater than `0` and less than or equal to `4096`.
 For more information, see xref:values-and-types/vector.adoc[Values and types -> Vectors].
 
 Allowed syntax variations of these types are listed in  xref::values-and-types/property-structural-constructed.adoc#types-synonyms[Types and their synonyms].

--- a/modules/ROOT/pages/indexes/search-performance-indexes/managing-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/managing-indexes.adoc
@@ -954,11 +954,11 @@ The below table contains the full information about all columns returned by the 
 | `FLOAT`
 
 | `type`
-| The IndexType of this index (`FULLTEXT`, `LOOKUP`, `POINT`, `RANGE`, or `TEXT`). label:default-output[]
+| The IndexType of this index (`FULLTEXT`, `LOOKUP`, `POINT`, `RANGE`, `TEXT`, or `VECTOR`). label:default-output[]
 | `STRING`
 
 | `entityType`
-| Type of entities this index represents (nodes or relationship). label:default-output[]
+| Type of entities this index represents (`NODE` or `RELATIONSHIP`). label:default-output[]
 | `STRING`
 
 | `labelsOrTypes`


### PR DESCRIPTION
was missing vector type in the index type column and the entity type values were odd (now they're aligned with the constraints one and more accurate to what values it actually returns)

the vector in the index type column should have been added when vector indexes were introduced, the entity type column update is just general from the beginning of show indexes.

the vector property type constraint update is only relevant for cypher 25 after the vector type was released