### PR TITLE
Removed possibly broken syntax

### DIFF
--- a/modules/ROOT/pages/queries/composed-queries/sequential-queries.adoc
+++ b/modules/ROOT/pages/queries/composed-queries/sequential-queries.adoc
@@ -447,7 +447,7 @@ WHEN sum >= 1000 THEN {
   RETURN customer.firstName AS customer, "club 1000 plus" AS customerType, sum AS sum
 }
 ELSE {
-  RETURN customer AS customer, sum * (1 - customer.discount) AS finalSum
+  RETURN sum * (1 - customer.discount) AS finalSum
 
   NEXT
 


### PR DESCRIPTION
The returning of a constant in a NEXT query is non-idomatic and might be broken syntax that should be removed.