### PR TITLE
Remove prerelease

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -1,7 +1,6 @@
 name: cypher-manual
 title: Cypher Manual
 version: '25'
-prerelease: true
 start_page: ROOT:introduction/index.adoc
 nav:
 - modules/ROOT/content-nav.adoc


### PR DESCRIPTION
We can remove the prerelease attribute now from Cypher 25