### PR TITLE
Update drop and show index command to reflect changes relevant to the Cypher 25 index updates.

### DIFF
--- a/modules/ROOT/pages/indexes/search-performance-indexes/drop-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/drop-indexes.adoc
@@ -3,6 +3,10 @@
 
 An index can be dropped (removed) using the name with the `DROP INDEX index_name` command.
 This command can drop indexes of any type, except those backing constraints.
+
+It is possible to drop indexes created in a different Cypher version than the one in use.
+For example, although `VECTOR` indexes on multiple labels or with additional properties were added in Cypher 25, such indexes can still be dropped using Cypher 5.
+
 The name of the index can be found using the xref:indexes/search-performance-indexes/list-indexes.adoc[`SHOW INDEXES` command], given in the output column `name`.
 
 ////

--- a/modules/ROOT/pages/indexes/search-performance-indexes/list-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/list-indexes.adoc
@@ -210,7 +210,8 @@ The below table contains the full information about all columns returned by the 
 | `LIST<STRING>`
 
 | `properties`
-| The properties of this index. label:default-output[]
+| The properties of this index.
+For vector indexes with additional properties (only available in Cypher 25) the vector property is the first element of the list, followed by the additional properties for filtering. label:default-output[]
 | `LIST<STRING>`
 
 | `indexProvider`
@@ -249,7 +250,7 @@ If neither is specified when creating the index, this column will return the def
 | `STRING`
 
 | `createStatement`
-| Statement used to create the index.
+| Statement used to create the index, or `null` if the index cannot be created through `CREATE INDEX` (for example in case of version incompatibilities).
 | `STRING`
 
 |===


### PR DESCRIPTION
As we can show and drop constraints in Cypher 5 that were created in Cypher 25.

Cypher 25 PR: https://github.com/neo4j/docs-cypher/pull/1454