### PR TITLE
Improvements of docs related to vectors and vector indexes.

### DIFF
--- a/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
@@ -68,7 +68,7 @@ A vector index allows you to retrieve a neighborhood of nodes or relationships b
 == Create vector indexes
 
 A vector index is a single-label, single-property index for nodes or a single-relationship-type, single-property index for relationships.
-It can be used to index nodes or relationships by `LIST<INTEGER | FLOAT>` or, as of Neo4j 2025.10, `VECTOR` properties valid to the dimensions and vector similarity function of the index.
+It can be used to index nodes or relationships by `LIST<INTEGER | FLOAT>` or, as of Neo4j 2025.10, additionally `VECTOR` properties valid to the dimensions and vector similarity function of the index.
 As of Neo4j 2026.01, the index can also be multi-label, multi-relationship-type or include additional properties for filtering purposes.
 
 A vector index is created by using the `CREATE VECTOR INDEX [index_name]` command.
@@ -172,7 +172,7 @@ For more information about the values accepted by different index providers, see
 ==== `vector.dimensions`
 The dimensions of the vectors to be indexed.
 For more information, see xref:indexes/semantic-indexes/vector-indexes.adoc#embeddings[].
-This setting can be omitted, and any `LIST<INTEGER | FLOAT>` or, as of Neo4j 2025.10, `VECTOR` value can be indexed and queried, separated by their dimensions, _though only vectors of the same dimension can be compared._
+This setting can be omitted, and any `LIST<INTEGER | FLOAT>` or, as of Neo4j 2025.10, additionally `VECTOR` value can be indexed and queried, separated by their dimensions, _though only vectors of the same dimension can be compared._
 Setting this value adds additional checks that ensure only vectors with the configured dimensions are indexed, and querying the index with a vector of a different dimensions returns an error.
 
 [NOTE]
@@ -242,7 +242,7 @@ db.index.vector.queryNodes(indexName :: STRING, numberOfNearestNeighbours :: INT
 
 * The `indexName` refers to the unique name of the vector index to query.
 * The `numberOfNearestNeighbours` refers to the number of nearest neighbors to return.
-* The `query` vector refers to the `LIST<INTEGER | FLOAT>` in which to search for the neighborhood.
+* The `query` refers to the `LIST<INTEGER | FLOAT>` or, as of Neo4j 2025.10, additionally `VECTOR` which neighborhood should be searched.
 
 The procedure returns the neighborhood of nodes with their respective similarity scores, ordered by those scores.
 The scores are bounded between `0` and `1`, where the closer to `1` the score is, the more similar the indexed vector is to the query vector.

--- a/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
@@ -242,7 +242,7 @@ db.index.vector.queryNodes(indexName :: STRING, numberOfNearestNeighbours :: INT
 
 * The `indexName` refers to the unique name of the vector index to query.
 * The `numberOfNearestNeighbours` refers to the number of nearest neighbors to return.
-* The `query` refers to the `LIST<INTEGER | FLOAT>` or, as of Neo4j 2025.10, additionally `VECTOR` which neighborhood should be searched.
+* The `query` refers to the `LIST<INTEGER | FLOAT>` or, as of Neo4j 2025.10, additionally the `VECTOR` of which the neighborhood should be searched.
 
 The procedure returns the neighborhood of nodes with their respective similarity scores, ordered by those scores.
 The scores are bounded between `0` and `1`, where the closer to `1` the score is, the more similar the indexed vector is to the query vector.

--- a/modules/ROOT/pages/indexes/syntax.adoc
+++ b/modules/ROOT/pages/indexes/syntax.adoc
@@ -283,20 +283,20 @@ For more information, see xref:indexes/semantic-indexes/full-text-indexes.adoc#q
 [[query-vector-index]]
 === Vector indexes
 
-.Query vector-text index on nodes: db.index.vector.queryNodes()
+.Query vector index on nodes: db.index.vector.queryNodes()
 [source,syntax]
 ----
-CALL db.index.vector.queryNodes(indexName :: STRING, numberOfNearestNeighbours :: INTEGER, query :: LIST<INTEGER | FLOAT>)
+CALL db.index.vector.queryNodes(indexName :: STRING, numberOfNearestNeighbours :: INTEGER, query :: VECTOR | LIST<INTEGER | FLOAT>)
 ----
 
-.Query vector-text index on relationships: db.index.vector.queryRelationships()
+.Query vector index on relationships: db.index.vector.queryRelationships()
 [source,syntax]
 ----
-CALL db.index.vector.queryRelationships(indexName :: STRING, numberOfNearestNeighbours :: INTEGER, query :: LIST<INTEGER | FLOAT>)
+CALL db.index.vector.queryRelationships(indexName :: STRING, numberOfNearestNeighbours :: INTEGER, query :: VECTOR | LIST<INTEGER | FLOAT>)
 ----
 
 The `numberOfNearestNeighbours` refers to the number of nearest neighbors to return as the neighborhood.
-The `query` vector refers to the `LIST<FLOAT>` in which to search for the neighborhood.
+The `query` refers to the `LIST<INTEGER | FLOAT>` or, as of Neo4j 2025.10, additionally `VECTOR` which neighborhood should be searched.
 
 For more information, see xref:indexes/semantic-indexes/vector-indexes.adoc#query-vector-index[Vector indexes - Query vector indexes].
 

--- a/modules/ROOT/pages/indexes/syntax.adoc
+++ b/modules/ROOT/pages/indexes/syntax.adoc
@@ -296,7 +296,7 @@ CALL db.index.vector.queryRelationships(indexName :: STRING, numberOfNearestNeig
 ----
 
 The `numberOfNearestNeighbours` refers to the number of nearest neighbors to return as the neighborhood.
-The `query` refers to the `LIST<INTEGER | FLOAT>` or, as of Neo4j 2025.10, additionally `VECTOR` which neighborhood should be searched.
+The `query` refers to the `LIST<INTEGER | FLOAT>` or, as of Neo4j 2025.10, additionally the `VECTOR` of which the neighborhood should be searched.
 
 For more information, see xref:indexes/semantic-indexes/vector-indexes.adoc#query-vector-index[Vector indexes - Query vector indexes].
 

--- a/modules/ROOT/pages/values-and-types/casting-data.adoc
+++ b/modules/ROOT/pages/values-and-types/casting-data.adoc
@@ -24,7 +24,7 @@ For any other input value, `null` will be returned.
 | toFloat() | Converts an `INTEGER`, `FLOAT`, or a `STRING` value to a `FLOAT` value.
 Otherwise `null` is returned.
 
-| toFloatList() | Converts a `LIST<ANY>` or, as of Neo4j 2025.10, a `VECTOR` and returns a `LIST<FLOAT>` values.
+| toFloatList() | Converts a `LIST<ANY>` or, as of Neo4j 2025.10, additionally `VECTOR` and returns a `LIST<FLOAT>` values.
 If any values are not convertible to `FLOAT` they will be `null` in the `LIST<FLOAT>` returned.
 
 | toFloatOrNull() | Converts an `INTEGER`, `FLOAT`, or a `STRING` value to a `FLOAT`.
@@ -32,7 +32,7 @@ For any other input value, `null` will be returned.
 
 | toInteger() | Converts a `BOOLEAN`, `INTEGER`, `FLOAT` or a `STRING` value to an `INTEGER` value.
 
-| toIntegerList() | Converts a `LIST<ANY>` or, as of Neo4j 2025.10, a `VECTOR` to a `LIST<INTEGER>` values. If any values are not convertible to `INTEGER` they will be null in the `LIST<INTEGER>` returned.
+| toIntegerList() | Converts a `LIST<ANY>` or, as of Neo4j 2025.10, additionally `VECTOR` to a `LIST<INTEGER>` values. If any values are not convertible to `INTEGER` they will be null in the `LIST<INTEGER>` returned.
 
 | toIntegerOrNull() | Converts a `BOOLEAN`, `INTEGER`, `FLOAT` or a `STRING` value to an `INTEGER` value.
 For any other input value, `null` will be returned.


### PR DESCRIPTION
These were some things which I found when documenting SEARCH, which are not directly related to SEARCH but more vectors and vector indexes in general.

Broke this out to a separate PR to not make the main one too long and in case we want to cherry-pick these changes as they also applies to previous versions of Cypher 25 docs.

Builds on top of https://github.com/neo4j/docs-cypher/pull/1454