### PR TITLE
DOCOPS-52 Potential fix for code scanning alert no. 1: Artifact poisoning

### DIFF
--- a/.github/workflows/docs-deploy-surge.yml
+++ b/.github/workflows/docs-deploy-surge.yml
@@ -47,7 +47,7 @@ jobs:
                archive_format: 'zip',
             });
             var fs = require('fs');
-            fs.mkdirSync(process.env.ARTIFACT_DIR, { recursive: true });
+            fs.mkdirSync(process.env.ARTIFACT_DIR + '/docs', { recursive: true });
             fs.writeFileSync(process.env.ARTIFACT_DIR + '/docs/docs.zip', Buffer.from(downloadDocs.data));
 
             var matchArtifactChangelog = artifacts.data.artifacts.filter((artifact) => {
@@ -59,6 +59,7 @@ jobs:
               artifact_id: matchArtifactChangelog.id,
               archive_format: 'zip',
             });
+            fs.mkdirSync(process.env.ARTIFACT_DIR + '/changelog', { recursive: true });
             fs.writeFileSync(process.env.ARTIFACT_DIR + '/changelog/changelog.zip', Buffer.from(downloadChangelog.data));
 
       - id: unzip-docs

--- a/.github/workflows/docs-deploy-surge.yml
+++ b/.github/workflows/docs-deploy-surge.yml
@@ -48,7 +48,7 @@ jobs:
             });
             var fs = require('fs');
             fs.mkdirSync(process.env.ARTIFACT_DIR, { recursive: true });
-            fs.writeFileSync(process.env.ARTIFACT_DIR + '/docs.zip', Buffer.from(downloadDocs.data));
+            fs.writeFileSync(process.env.ARTIFACT_DIR + '/docs/docs.zip', Buffer.from(downloadDocs.data));
 
             var matchArtifactChangelog = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "changelog"
@@ -59,26 +59,26 @@ jobs:
               artifact_id: matchArtifactChangelog.id,
               archive_format: 'zip',
             });
-            fs.writeFileSync(process.env.ARTIFACT_DIR + '/changelog.zip', Buffer.from(downloadChangelog.data));
+            fs.writeFileSync(process.env.ARTIFACT_DIR + '/changelog/changelog.zip', Buffer.from(downloadChangelog.data));
 
       - id: unzip-docs
         env:
-          ARTIFACT_DIR: ${{ runner.temp }}/artifacts
+          ARTIFACT_DIR: ${{ runner.temp }}/artifacts/docs
         run: |
           cd "$ARTIFACT_DIR"
-          unzip docs.zip -d site
+          unzip docs.zip
 
       - id: unzip-changelog
-        if: ${{ hashFiles(format('{0}/changelog.zip', runner.temp + '/artifacts')) != '' }}
+        if: ${{ hashFiles(format('{0}/artifacts/changelog/changelog.zip', runner.temp)) != '' }}
         env:
-          ARTIFACT_DIR: ${{ runner.temp }}/artifacts
+          ARTIFACT_DIR: ${{ runner.temp }}/artifacts/changelog
         run: |
           cd "$ARTIFACT_DIR"
           unzip changelog.zip
       
       - id: get-deploy-id
         env:
-          ARTIFACT_DIR: ${{ runner.temp }}/artifacts
+          ARTIFACT_DIR: ${{ runner.temp }}/artifacts/docs
         run: |
           deployid=$(<"$ARTIFACT_DIR/deployid")
           case "$deployid" in ''|*[!0-9]*) echo "Provided PR number is not an integer"; exit 1 ;; esac
@@ -102,10 +102,10 @@ jobs:
         env:
           DEPLOY_URL: ${{ steps.get-deploy-url.outputs.deploy-url }}
           SURGE_TOKEN: "${{ secrets.DOCS_SURGE_TOKEN }}"
-          SITE_DIR: ${{ runner.temp }}/artifacts/site
+          ARTIFACT_DIR: ${{ runner.temp }}/artifacts/docs
         run: |
           npm install -g surge
-          cd "$SITE_DIR"
+          cd "$ARTIFACT_DIR"
           surge . "$DEPLOY_URL" --token "$SURGE_TOKEN"
 
       # If the PR artifacts include a changelog file, add it to the PR as a comment
@@ -117,7 +117,7 @@ jobs:
           number: ${{ steps.get-deploy-id.outputs.deploy-id }}
           recreate: true
           header: docs-pr-changes
-          path: changelog
+          path: ${{ runner.temp }}/artifacts/changelog/changelog
           GITHUB_TOKEN: ${{ secrets.DOCS_PR_COMMENT_TOKEN }}
 
       # If there's no changelog, add a generic comment to the PR

--- a/.github/workflows/docs-deploy-surge.yml
+++ b/.github/workflows/docs-deploy-surge.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/github-script@v7
         env:
           RUN_ID: ${{ github.event.workflow_run.id }}
-          WORKSPACE: ${{ github.workspace }}
+          ARTIFACT_DIR: ${{ runner.temp }}/artifacts
         with:
           script: |
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
@@ -47,7 +47,8 @@ jobs:
                archive_format: 'zip',
             });
             var fs = require('fs');
-            fs.writeFileSync('${{ env.WORKSPACE }}/docs.zip', Buffer.from(downloadDocs.data));
+            fs.mkdirSync(process.env.ARTIFACT_DIR, { recursive: true });
+            fs.writeFileSync(process.env.ARTIFACT_DIR + '/docs.zip', Buffer.from(downloadDocs.data));
 
             var matchArtifactChangelog = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "changelog"
@@ -58,18 +59,28 @@ jobs:
               artifact_id: matchArtifactChangelog.id,
               archive_format: 'zip',
             });
-            fs.writeFileSync('${{ env.WORKSPACE }}/changelog.zip', Buffer.from(downloadChangelog.data));
+            fs.writeFileSync(process.env.ARTIFACT_DIR + '/changelog.zip', Buffer.from(downloadChangelog.data));
 
       - id: unzip-docs
-        run: unzip docs.zip
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/artifacts
+        run: |
+          cd "$ARTIFACT_DIR"
+          unzip docs.zip -d site
 
       - id: unzip-changelog
-        if: ${{ hashFiles('changelog.zip') != '' }}
-        run: unzip changelog.zip
+        if: ${{ hashFiles(format('{0}/changelog.zip', runner.temp + '/artifacts')) != '' }}
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/artifacts
+        run: |
+          cd "$ARTIFACT_DIR"
+          unzip changelog.zip
       
       - id: get-deploy-id
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/artifacts
         run: |
-          deployid=$(<deployid)
+          deployid=$(<"$ARTIFACT_DIR/deployid")
           case "$deployid" in ''|*[!0-9]*) echo "Provided PR number is not an integer"; exit 1 ;; esac
           echo "deploy-id=$deployid" >> "$GITHUB_OUTPUT"
 
@@ -91,10 +102,11 @@ jobs:
         env:
           DEPLOY_URL: ${{ steps.get-deploy-url.outputs.deploy-url }}
           SURGE_TOKEN: "${{ secrets.DOCS_SURGE_TOKEN }}"
-          SITE_DIR: ${{ steps.get-top-dir.outputs.top-dir }}
+          SITE_DIR: ${{ runner.temp }}/artifacts/site
         run: |
           npm install -g surge
-          surge . $DEPLOY_URL --token "$SURGE_TOKEN"
+          cd "$SITE_DIR"
+          surge . "$DEPLOY_URL" --token "$SURGE_TOKEN"
 
       # If the PR artifacts include a changelog file, add it to the PR as a comment
       # The changelog contains links to new and changed files in the deployed docs

--- a/.github/workflows/docs-deploy-surge.yml
+++ b/.github/workflows/docs-deploy-surge.yml
@@ -69,8 +69,16 @@ jobs:
           cd "$ARTIFACT_DIR"
           unzip docs.zip
 
+      - id: find-changelog
+        run: |
+          if [ -f "${{ runner.temp }}/artifacts/changelog/changelog.zip" ]; then
+            echo "has-changelog=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-changelog=false" >> $GITHUB_OUTPUT
+          fi
+
       - id: unzip-changelog
-        if: ${{ hashFiles(format('{0}/artifacts/changelog/changelog.zip', runner.temp)) != '' }}
+        if: ${{ steps.find-changelog.outputs.has-changelog == 'true' }}
         env:
           ARTIFACT_DIR: ${{ runner.temp }}/artifacts/changelog
         run: |
@@ -112,7 +120,7 @@ jobs:
       # If the PR artifacts include a changelog file, add it to the PR as a comment
       # The changelog contains links to new and changed files in the deployed docs
       - name: Comment on PR (changelog)
-        if: ${{ hashFiles('changelog') != '' }}
+        if: ${{ steps.find-changelog.outputs.has-changelog == 'true' }}
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 #v2
         with:
           number: ${{ steps.get-deploy-id.outputs.deploy-id }}
@@ -123,7 +131,7 @@ jobs:
 
       # If there's no changelog, add a generic comment to the PR
       - name: Comment on PR (no changelog)
-        if: ${{ hashFiles('changelog') == '' }}
+        if: ${{ steps.find-changelog.outputs.has-changelog == 'false' }}
         env:
           DEPLOY_URL: ${{ steps.get-deploy-url.outputs.deploy-url }}
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 #v2


### PR DESCRIPTION
Potential fix for [https://github.com/neo4j/docs-cypher/security/code-scanning/1](https://github.com/neo4j/docs-cypher/security/code-scanning/1)

General approach: Treat all downloaded artifacts as untrusted, extract them into a dedicated temporary directory that cannot overwrite existing repository files, and ensure subsequent steps (unzip and deployment) operate only on that directory. This aligns with the recommendations to isolate artifact contents and reduces the risk that poisoned artifacts affect other parts of the workspace.

Concrete fix here:

1. Adjust the `Download built documentation` script so that it writes `docs.zip` and `changelog.zip` into a subdirectory under `${{ runner.temp }}` instead of `${{ github.workspace }}`. For example, use `${{ runner.temp }}/artifacts`.
2. Add a small shell step to create `${{ runner.temp }}/artifacts` before unzipping.
3. Update the `unzip` steps to:
   - Change into the artifacts directory before unzipping.
   - Explicitly specify `-d` so files are extracted into a known subdirectory (e.g., `site/`).
4. Configure the deploy step to:
   - Use that extracted directory (`SITE_DIR`) as the source path passed to `surge`, instead of `.` (the repo root).
   - Ensure `SITE_DIR` is set consistently from the temp path; we should not reference undefined outputs like `steps.get-top-dir.outputs.top-dir`.

This keeps existing behavior (deploy the built docs and optionally use a changelog) while isolating artifact contents. The main code edits are all inside `.github/workflows/docs-deploy-surge.yml`:
- Modify lines 49–51 and 61 to write into `${{ runner.temp }}/artifacts`.
- Insert a `mkdir -p` step for `${{ runner.temp }}/artifacts`.
- Update the unzip steps (63–68) to operate under that temp directory and extract `docs` into something like `${{ runner.temp }}/artifacts/site`.
- Adjust the deploy step (89–97) to cd into `$SITE_DIR` and run `surge` from there, with `SITE_DIR` set via `env` to `${{ runner.temp }}/artifacts/site`.

No new imports or external libraries are needed, just path and env changes inside the YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
