### PR TITLE
Add documentation for new functions (GQL compliance)

### DIFF
--- a/modules/ROOT/pages/appendix/gql-conformance/analogous-cypher.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/analogous-cypher.adoc
@@ -18,18 +18,27 @@ These codes order the features in the table below.
 
 | GF04
 | Enhanced path functions
-| GQL's `PATH_LENGTH()` function is equivalent to Cypher's xref:functions/scalar.adoc#functions-length[`length()`] function.
+| Cypher provides the xref:functions/scalar.adoc#functions-path-length[path_length()] function, which is an alias to Cypher's xref:functions/scalar.adoc#functions-length[length()] function
+
+| GF07
+| Temporal duration functions
+| Cypher provides the GQL naming alias xref:functions/temporal/duration.adoc#functions-duration-between-alias[`duration_between()`] function, which is an alias to Cypher's xref:functions/temporal/duration.adoc#functions-duration-between[`duration.between()`]..
+In GQL, if either argument is not a temporal instant type, a data exception is raised (22G03).
+In Cypher, a different error (e.g. invalid call signature) may be reported, but with the same severity.
+Cypher returns the date difference in years, months, and days; GQL returns the date difference in days only.
+For the same interval the results can therefore differ (e.g. P1M1D in Cypher vs P29D in GQL for 2026-02-01 to 2026-03-02).
 
 | GF10
 | Advanced aggregate functions: general set functions
-| * GQL's `COLLECT_LIST()` function is equivalent to Cypher's xref:functions/aggregating.adoc#functions-collect[`collect()`] function.
-* GQL's `STDEV_SAMP()` function is equivalent to Cypher's xref:functions/aggregating.adoc#functions-stdev[`stDev()`] function.
+| * GQL's `STDEV_SAMP()` function is equivalent to Cypher's xref:functions/aggregating.adoc#functions-stdev[`stDev()`] function.
 * GQL's `STDEV_POP()` function is equivalent to Cypher's xref:functions/aggregating.adoc#functions-stdevp[`stDevP()`] function.
+Cypher provides the GQL naming aliases xref:functions/aggregating.adoc#functions-collect-list[`collect_list()`], xref:functions/aggregating.adoc#functions-stdev-samp[`stdev_samp()`], and xref:functions/aggregating.adoc#functions-stdev-pop[`stdev_pop()`].
 
 | GF11
 | Advanced aggregate functions: binary set functions
 | * GQL's `PERCENTILE_CONT()` function is equivalent to Cypher's xref:functions/aggregating.adoc#functions-percentilecont[`percentileCont()`] function.
 * GQL's `PERCENTILE_DISC()` function is equivalent to Cypher's xref:functions/aggregating.adoc#functions-percentiledisc[`percentileDisc()`] function.
+Cypher provides the GQL naming aliases xref:functions/aggregating.adoc#functions-percentile-cont[`percentile_cont()`] and xref:functions/aggregating.adoc#functions-percentile-disc[`percentile_disc()`].
 
 | GQ10, GQ11, GQ23, GQ24
 | `FOR` statement: list value support, binding table support, `WITH ORDINALITY`, `WITH OFFSET`

--- a/modules/ROOT/pages/appendix/gql-conformance/supported-optional.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/supported-optional.adoc
@@ -114,14 +114,12 @@ Cypher Shell also offers specific link:{neo4j-docs-base-uri}/operations-manual/c
 * Feature GD01 implies conformance to GQL's `<set-statement>` (subclause 13.3).
 GQL’s `SET` has no order dependencies because all right-hand side operations are completed before any assignments occur.
 However, In Cypher’s `SET`, the order of rows can affect the outcome because changes made during execution may depend on the sequence of assignments.
-The only way to guarantee row order in Neo4j is to use xref:clauses/order-by.adoc[`ORDER BY`]. 
-
+The only way to guarantee row order in Neo4j is to use xref:clauses/order-by.adoc[`ORDER BY`].
 | GF01
 | Enhanced numeric functions
 | xref:functions/mathematical-numeric.adoc#functions-abs[`abs()`], xref:functions/mathematical-numeric.adoc#functions-floor[`floor()`], xref:functions/mathematical-logarithmic.adoc#functions-sqrt[`sqrt()`].
-| Note the following exceptions:
-GQL supports `CEILING()` as a synonym for the `CEIL()` function.
-Cypher only supports xref:functions/mathematical-numeric.adoc#functions-ceil[`ceil()`].
+| GQL supports `CEILING()` as a synonym for the `CEIL()` function.
+Cypher supports xref:functions/mathematical-numeric.adoc#functions-ceil[`ceil()`] and provides the GQL naming alias xref:functions/mathematical-numeric.adoc#functions-ceiling[`ceiling()`].
 
 | GF02
 | Trigonometric functions
@@ -130,12 +128,11 @@ Cypher only supports xref:functions/mathematical-numeric.adoc#functions-ceil[`ce
 
 | GF03
 | Logarithmic functions
-| xref:functions/mathematical-logarithmic.adoc#functions-exp[`exp()`], xref:functions/mathematical-logarithmic.adoc#functions-log10[`log10()`].
-| Note the following exceptions:
-
- * Cypher uses the xref:functions/mathematical-logarithmic.adoc#functions-log[`log()`] function instead of GQL's `LN()` function.
+| xref:functions/mathematical-logarithmic.adoc#functions-exp[`exp()`], xref:functions/mathematical-logarithmic.adoc#functions-log10[`log10()`], xref:functions/mathematical-logarithmic.adoc#functions-ln[`ln()`] .
+| * Cypher uses the xref:functions/mathematical-logarithmic.adoc#functions-log[`log()`] function instead of GQL's `LN()` function.
+In GQL, the natural logarithm function must raise an exception for input zero or negative.
+In Cypher, `ln(0)` returns `-Infinity` and `ln(negative)` returns `NaN`.
 * Cypher uses the xref:expressions/mathematical-operators.adoc[exponentiation operator (`^`)] instead of GQL's `POWER()` function.
-
 | GF05
 | Multi-character trim functions
 | xref:functions/string.adoc#functions-btrim[`btrim()`], xref:functions/string.adoc#functions-ltrim[`ltrim()`], xref:functions/string.adoc#functions-rtrim[`rtrim()`]
@@ -151,7 +148,6 @@ In Cypher, `trim()` removes any whitespace character.
 | Graph with open graph type
 |
 |
-
 | GP01
 | Inline procedure
 | xref:subqueries/call-subquery.adoc[`CALL` subqueries]
@@ -173,7 +169,6 @@ In Cypher, `trim()` removes any whitespace character.
 | Cypher’s `USE` clause supports static graph references (e.g. `USE myComposite.myGraph`)and dynamic graph references (e.g. `USE graph.byName(<expression>)`).
 However, Cypher does not support GQL’s full graph reference syntax.
 For example, GQL’s graph reference values `CURRENT_GRAPH` and `CURRENT_PROPERTY_GRAPH` cannot be used in Cypher.
-
 | GQ03
 | Composite query: `UNION`
 | xref:queries/composed-queries/combined-queries.adoc[`UNION`]
@@ -193,33 +188,39 @@ For example, GQL’s graph reference values `CURRENT_GRAPH` and `CURRENT_PROPERT
 | `ORDER BY` and page statement: `LIMIT`
 | xref:clauses/limit.adoc[`LIMIT`], xref:clauses/order-by.adoc[`ORDER BY`]
 | Cypher requires using the xref:clauses/with.adoc[`WITH`] clause, which GQL does not.
-
 | GQ20
 | Advanced linear composition with NEXT
 | xref:queries/composed-queries/sequential-queries.adoc[]
 | The GQL standard includes a `YIELD` clause for its `NEXT` statement which Cypher does not implement.
-
 | GV39
 | Temporal types: date, local datetime, and local time support
-| xref:values-and-types/temporal.adoc[Temporal types], xref:functions/temporal/index.adoc#functions-date[`date()`]
+| xref:values-and-types/temporal.adoc[Temporal types], xref:functions/temporal/index.adoc#functions-date[`date()`], xref:functions/temporal/index.adoc#functions-local-datetime[`local_datetime()`], xref:functions/temporal/index.adoc#functions-local-time[`local_time()`]
 | Note the following exceptions:
 
 * GQL defines a parameterless version of the xref:functions/temporal/index.adoc#functions-date[`date()`] function not in Cypher: `CURRENT_DATE`.
-* GQL’s `LOCAL_TIME()` function is equivalent to Cypher’s xref:functions/temporal/index.adoc#functions-localtime[`localtime()`] function.
-GQL also defines a parameterless version of the function not in Cypher: `LOCAL_TIME`.
-* GQL’s `LOCAL_DATETIME()` function is equivalent to Cypher’s xref:functions/temporal/index.adoc#functions-localdatetime[`localdatetime()`] function.
-GQL also defines a parameterless version of the function not in Cypher: `LOCAL_DATETIME`.
+* GQL supports local_time() as a synonym for the localtime() function. Cypher supports localtime() and provides the GQL naming alias local_time().
+* GQL supports local_datetime() as a synonym for the localdatetime() function. Cypher supports localdatetime() and provides the GQL naming alias local_datetime().
+
+In GQL, invalid sets of time field names raise a data exception (22G05); Cypher uses an error of equivalent severity (22007/22N12).
+Cypher also allows an optional `pattern` argument.
+The GQL keyword `LOCAL_TIMESTAMP` is not introduced as a reserved keyword in Cypher.
 
 | GV40
 | Temporal types: zoned datetime and zoned time support
-| xref:values-and-types/temporal.adoc[Temporal types]
+| xref:values-and-types/temporal.adoc[Temporal types], xref:functions/temporal/index.adoc#functions-zoned-time[`zoned_time()`], xref:functions/temporal/index.adoc#functions-zoned-datetime[`zoned_datetime()`].
 | Note the following exceptions:
 
 * GQL’s `ZONED_TIME()` function is equivalent to Cypher’s xref:functions/temporal/index.adoc#functions-time[`time()`] function.
-GQL also defines a parameterless version of the function not in Cypher: `CURRENT_TIME`.
-* GQL’s `ZONED_DATETIME()` function is equivalent to Cypher’s xref:functions/temporal/index.adoc#functions-datetime[`datetime()`] function.
-GQL also defines a parameterless version of the function not in Cypher: `CURRENT_TIMESTAMP`.
 
+In GQL, invalid sets of time (or timezone) field names raise a data exception (22G05); Cypher uses an error of equivalent severity (22007/22N12).
+Cypher also allows an optional `pattern` argument.
+The GQL keyword `CURRENT_TIME` is not introduced as a reserved keyword in Cypher.
+
+* GQL’s `ZONED_DATETIME()` function is equivalent to Cypher’s xref:functions/temporal/index.adoc#functions-datetime[`datetime()`] function.
+
+In GQL, invalid sets of datetime (or timezone) field names raise a data exception (22G05); Cypher uses an error of equivalent severity (22007/22N12).
+Cypher also allows an optional `pattern` argument.
+The GQL keyword `CURRENT_TIMESTAMP` is not introduced as a reserved keyword in Cypher.
 | GV50
 | List value types
 | xref:values-and-types/lists.adoc[Lists]
@@ -244,12 +245,10 @@ GQL also defines a parameterless version of the function not in Cypher: `CURRENT
 | Immaterial value types: null type support (`null`)
 | xref:values-and-types/working-with-null.adoc[Working with `null`]
 |
-
 | GV71
-| Immaterial value types: empty type support (`NOTHING`)]
+| Immaterial value types: empty type support (`NOTHING`)
 | xref:expressions/predicates/type-predicate-expressions.adoc#type-predicate-any-and-nothing[Type predicate expressions -> `ANY` and `NOTHING`]
 |
-
 |===
 
 [NOTE]

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -23,7 +23,6 @@ Cypher 25 was introduced in Neo4j 2025.06 and can only be used on Neo4j 2025.06+
 Features removed in Cypher 25 are still available on Neo4j 2025.06+ databases either by prepending a query with `CYPHER 5` or by having Cypher 5 as the default language for the database.
 For more information, see xref:queries/select-version.adoc[].
 
-
 [[cypher-deprecations-additions-removals-2026.02]]
 == Neo4j 2026.02
 
@@ -178,6 +177,45 @@ ALTER CURRENT GRAPH DROP {
 
 | Introduced the ability to drop element types and constraints from graph types using the `ALTER CURRENT GRAPH TYPE DROP` command.
 For more information, see xref:schema/graph-types/drop-graph-type-elements.adoc[].
+
+a|
+label:functionality[]
+label:new[]
+GQL naming aliases for functions
+
+[source, cypher]
+----
+RETURN ceiling(1.2) AS c, ln(2.0) AS natural_log,
+       char_length("Hello") AS len, lower("Neo4j") AS lower, upper("Neo4j") AS upper;
+----
+[source, cypher]
+----
+RETURN local_time() AS t, local_datetime() AS ldt,
+       zoned_time() AS zt, zoned_datetime() AS zdt;
+----
+[source, cypher]
+----
+RETURN duration_between(date("2020-01-01"), date("2020-02-01")) AS d;
+----
+[source, cypher]
+----
+MATCH p = (a)-[r]->(b)
+RETURN path_length(p) AS path_len;
+----
+[source, cypher]
+----
+UNWIND [1, 2, 3] AS n
+RETURN collect_list(n) AS list,
+       percentile_cont(n, 0.5) AS p50,
+       percentile_disc(n, 0.5) AS p50_disc,
+       stdev_samp(n) AS sd_samp,
+       stdev_pop(n) AS sd_pop;
+----
+
+a|
+Cypher now provides GQL naming aliases so that queries written for other GQL implementations can run with minimal changes.
+Aliases added: xref:functions/mathematical-numeric.adoc#functions-ceiling[`ceiling()`], xref:functions/temporal/index.adoc#functions-local-time[`local_time()`], xref:functions/temporal/index.adoc#functions-local-datetime[`local_datetime()`], xref:functions/temporal/index.adoc#functions-zoned-time[`zoned_time()`], xref:functions/temporal/index.adoc#functions-zoned-datetime[`zoned_datetime()`], xref:functions/temporal/duration.adoc#functions-duration-between-alias[`duration_between()`], xref:functions/scalar.adoc#functions-path-length[`path_length()`], xref:functions/mathematical-logarithmic.adoc#functions-ln[`ln()`], xref:functions/aggregating.adoc#functions-collect-list[`collect_list()`], xref:functions/aggregating.adoc#functions-percentile-cont[`percentile_cont()`], xref:functions/aggregating.adoc#functions-percentile-disc[`percentile_disc()`], xref:functions/aggregating.adoc#functions-stdev-samp[`stdev_samp()`], xref:functions/aggregating.adoc#functions-stdev-pop[`stdev_pop()`] and xref:functions/scalar.adoc#functions-char_length[`char_length()`].
+
 |===
 
 [[cypher-deprecations-additions-removals-2026.01]]

--- a/modules/ROOT/pages/functions/aggregating.adoc
+++ b/modules/ROOT/pages/functions/aggregating.adoc
@@ -159,6 +159,57 @@ All the values are collected and returned in a single list:
 ======
 
 
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
+[[functions-collect-list]]
+== collect_list()
+
+.Details
+|===
+| *Syntax* 3+| `collect_list(input)`
+| *Description* 3+| Returns a list containing the values returned by an expression.
+.2+| *Arguments* | *Name* | *Type* | *Description*
+| `input` | `ANY` | A value aggregated into a list.
+| *Returns* 3+| `LIST<ANY>`
+|===
+
+This function is an alias to the xref:functions/aggregating.adoc#functions-collect[`collect()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+
+.Considerations
+|===
+
+| Any `null` values are ignored and will not be added to the list.
+| `collect_list(null)` returns an empty list.
+
+|===
+
+
+.+collect_list()+
+======
+
+.Query
+// tag::functions_aggregating_collect_list[]
+[source, cypher]
+----
+MATCH (p:Person)
+RETURN collect_list(p.age)
+----
+// end::functions_aggregating_collect_list[]
+
+All the values are collected and returned in a single list:
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| collect_list(p.age)
+| [58, 70, 55, 55, 71]
+1+d|Rows: 1
+
+|===
+
+======
+
+
 [[functions-count]]
 == count()
 
@@ -567,6 +618,57 @@ The 40th percentile of the values in the property `age` is returned, calculated 
 ======
 
 
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
+[[functions-percentile-cont]]
+== percentile_cont()
+
+.Details
+|===
+| *Syntax* 3+| `percentile_cont(input, percentile)`
+| *Description* 3+| Returns the percentile of a value over a group using linear interpolation.
+.3+| *Arguments* | *Name* | *Type* | *Description*
+| `input` | `FLOAT` | A value to be aggregated.
+| `percentile` | `FLOAT` | A percentile between 0.0 and 1.0.
+| *Returns* 3+| `FLOAT`
+|===
+
+This function is an alias to the xref:functions/aggregating.adoc#functions-percentilecont[`percentileCont()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+
+.Considerations
+|===
+
+| Any `null` values are excluded from the calculation.
+| `percentile_cont(null, percentile)` returns `null`.
+
+|===
+
+.+percentile_cont()+
+======
+
+.Query
+// tag::functions_aggregating_percentile_cont_alias[]
+[source, cypher]
+----
+MATCH (p:Person)
+RETURN percentile_cont(p.age, 0.4)
+----
+// end::functions_aggregating_percentile_cont_alias[]
+
+The 40th percentile of the values in the property `age` is returned, calculated with a weighted average:
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| percentile_cont(p.age, 0.4)
+| 56.8
+1+d|Rows: 1
+
+|===
+
+======
+
+
 [[functions-percentiledisc]]
 == percentileDisc()
 
@@ -608,6 +710,57 @@ The 50th percentile of the values in the property `age` is returned:
 |===
 
 | percentileDisc(p.age, 0.5)
+| 58
+1+d|Rows: 1
+
+|===
+
+======
+
+
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
+[[functions-percentile-disc]]
+== percentile_disc()
+
+.Details
+|===
+| *Syntax* 3+| `percentile_disc(input, percentile)`
+| *Description* 3+| Returns the nearest `INTEGER` or `FLOAT` value to the given percentile over a group using a rounding method.
+.3+| *Arguments* | *Name* | *Type* | *Description*
+| `input` | `INTEGER \| FLOAT` | A value to be aggregated.
+| `percentile` | `FLOAT` | A percentile between 0.0 and 1.0.
+| *Returns* 3+| `INTEGER \| FLOAT`
+|===
+
+This function is an alias to the xref:functions/aggregating.adoc#functions-percentiledisc[`percentileDisc()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+
+.Considerations
+|===
+
+| Any `null` values are excluded from the calculation.
+| `percentile_disc(null, percentile)` returns `null`.
+
+|===
+
+.+percentile_disc()+
+======
+
+.Query
+// tag::functions_aggregating_percentile_disc_alias[]
+[source, cypher]
+----
+MATCH (p:Person)
+RETURN percentile_disc(p.age, 0.5)
+----
+// end::functions_aggregating_percentile_disc_alias[]
+
+The 50th percentile of the values in the property `age` is returned:
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| percentile_disc(p.age, 0.5)
 | 58
 1+d|Rows: 1
 
@@ -665,6 +818,57 @@ The standard deviation of the values in the property `age` is returned:
 ======
 
 
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
+[[functions-stdev-samp]]
+== stdev_samp()
+
+.Details
+|===
+| *Syntax* 3+| `stdev_samp(input)`
+| *Description* 3+| Returns the standard deviation for the given value over a group for a sample of a population.
+.2+| *Arguments* | *Name* | *Type* | *Description*
+| `input` | `FLOAT` | The value to calculate the standard deviation of.
+| *Returns* 3+| `FLOAT`
+|===
+
+This function is an alias to the xref:functions/aggregating.adoc#functions-stdev[`stDev()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+
+.Considerations
+|===
+
+| Any `null` values are excluded from the calculation.
+| `stdev_samp(null)` returns `0`.
+
+|===
+
+.+stdev_samp()+
+======
+
+.Query
+// tag::functions_aggregating_stdev_samp[]
+[source, cypher]
+----
+MATCH (p:Person)
+WHERE p.name IN ['Keanu Reeves', 'Liam Neeson', 'Carrie Anne Moss']
+RETURN stdev_samp(p.age)
+----
+// end::functions_aggregating_stdev_samp[]
+
+The standard deviation of the values in the property `age` is returned:
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| stdev_samp(p.age)
+| 7.937253933193772
+1+d|Rows: 1
+
+|===
+
+======
+
+
 [[functions-stdevp]]
 == stDevP()
 
@@ -706,6 +910,57 @@ The population standard deviation of the values in the property `age` is returne
 |===
 
 | stDevP(p.age)
+| 6.48074069840786
+1+d|Rows: 1
+
+|===
+
+======
+
+
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
+[[functions-stdev-pop]]
+== stdev_pop()
+
+.Details
+|===
+| *Syntax* 3+| `stdev_pop(input)`
+| *Description* 3+| Returns the standard deviation for the given value over a group for an entire population.
+.2+| *Arguments* | *Name* | *Type* | *Description*
+| `input` | `FLOAT` | The value to calculate the population standard deviation of.
+| *Returns* 3+| `FLOAT`
+|===
+
+This function is an alias to the xref:functions/aggregating.adoc#functions-stdevp[`stDevP()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+
+.Considerations
+|===
+
+| Any `null` values are excluded from the calculation.
+| `stdev_pop(null)` returns `0`.
+
+|===
+
+.+stdev_pop()+
+======
+
+.Query
+// tag::functions_aggregating_stdev_pop[]
+[source, cypher]
+----
+MATCH (p:Person)
+WHERE p.name IN ['Keanu Reeves', 'Liam Neeson', 'Carrie Anne Moss']
+RETURN stdev_pop(p.age)
+----
+// end::functions_aggregating_stdev_pop[]
+
+The population standard deviation of the values in the property `age` is returned:
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| stdev_pop(p.age)
 | 6.48074069840786
 1+d|Rows: 1
 

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -658,7 +658,6 @@ These functions are used to manipulate `STRING` values or to create a `STRING` r
 1.1+| xref::functions/string.adoc#functions-upper[`upper()`]
 | `upper(input :: STRING) :: STRING`
 | Returns the given `STRING` in uppercase. This function is an alias to the xref:functions/string.adoc#functions-toupper[`toUpper()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
-label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
 |===
 
 [[header-query-functions-spatial]]

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -602,7 +602,6 @@ These functions are used to manipulate `STRING` values or to create a `STRING` r
 1.1+| xref::functions/string.adoc#functions-lower[`lower()`]
 | `lower(input :: STRING) :: STRING`
 | Returns the given `STRING` in lowercase. This function is an alias to the xref:functions/string.adoc#functions-tolower[`toLower()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
-label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
 
 1.1+| xref::functions/string.adoc#functions-ltrim[`ltrim()`]
 | `ltrim(input :: STRING [, trimCharacterString :: STRING]) :: STRING`

--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -38,6 +38,11 @@ These functions take multiple values as arguments, and calculate and return an a
 | `collect(input :: ANY) :: LIST<ANY>`
 | Returns a list containing the values returned by an expression.
 
+1.1+| xref::functions/aggregating.adoc#functions-collect-list[`collect_list()`]
+| `collect_list(input :: ANY) :: LIST<ANY>`
+| Returns a list containing the values returned by an expression. This function is an alias to the xref:functions/aggregating.adoc#functions-collect[`collect()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
+
 1.1+| xref::functions/aggregating.adoc#functions-count[`count()`]
 | `count(input :: ANY) :: INTEGER`
 | Returns the number of values or rows.
@@ -54,17 +59,37 @@ These functions take multiple values as arguments, and calculate and return an a
 | `percentileCont(input :: FLOAT, percentile :: FLOAT) :: FLOAT`
 | Returns the percentile of a value over a group using linear interpolation.
 
+1.1+| xref::functions/aggregating.adoc#functions-percentile-cont[`percentile_cont()`]
+| `percentile_cont(input :: FLOAT, percentile :: FLOAT) :: FLOAT`
+| Returns the percentile of a value over a group using linear interpolation. This function is an alias to the xref:functions/aggregating.adoc#functions-percentilecont[`percentileCont()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
+
 1.1+| xref::functions/aggregating.adoc#functions-percentiledisc[`percentileDisc()`]
 | `percentileDisc(input ::  INTEGER \| FLOAT, percentile :: FLOAT) :: FLOAT`
 | Returns the nearest `INTEGER` or `FLOAT` value to the given percentile over a group using a rounding method.
+
+1.1+| xref::functions/aggregating.adoc#functions-percentile-disc[`percentile_disc()`]
+| `percentile_disc(input :: INTEGER \| FLOAT, percentile :: FLOAT) :: INTEGER \| FLOAT`
+| Returns the nearest `INTEGER` or `FLOAT` value to the given percentile over a group using a rounding method. This function is an alias to the xref:functions/aggregating.adoc#functions-percentiledisc[`percentileDisc()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
 
 1.1+| xref::functions/aggregating.adoc#functions-stdev[`stDev()`]
 | `stDev(input :: FLOAT) :: FLOAT`
 | Returns the standard deviation for the given value over a group for a sample of a population.
 
+1.1+| xref::functions/aggregating.adoc#functions-stdev-samp[`stdev_samp()`]
+| `stdev_samp(input :: FLOAT) :: FLOAT`
+| Returns the standard deviation for the given value over a group for a sample of a population. This function is an alias to the xref:functions/aggregating.adoc#functions-stdev[`stDev()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
+
 1.1+| xref::functions/aggregating.adoc#functions-stdevp[`stDevP()`]
 | `stDevP(input :: FLOAT) :: FLOAT`
 | Returns the standard deviation for the given value over a group for an entire population.
+
+1.1+| xref::functions/aggregating.adoc#functions-stdev-pop[`stdev_pop()`]
+| `stdev_pop(input :: FLOAT) :: FLOAT`
+| Returns the standard deviation for the given value over a group for an entire population. This function is an alias to the xref:functions/aggregating.adoc#functions-stdevp[`stDevP()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
 
 1.1+| xref::functions/aggregating.adoc#functions-sum[`sum()`]
 | `sum(input :: INTEGER \| FLOAT \| DURATION) ::  INTEGER \| FLOAT \| DURATION`
@@ -261,6 +286,11 @@ These functions all operate on numerical expressions only, and will return an er
 | `log(input :: FLOAT) :: FLOAT`
 | Returns the natural logarithm of a `FLOAT`.
 
+1.1+| xref::functions/mathematical-logarithmic.adoc#functions-ln[`ln()`]
+| `ln(input :: FLOAT) :: FLOAT`
+| Returns the natural logarithm of a `FLOAT`. This function is an alias to the xref:functions/mathematical-logarithmic.adoc#functions-log[`log()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
+
 1.1+| xref::functions/mathematical-logarithmic.adoc#functions-log10[`log10()`]
 | `log10(input :: FLOAT) :: FLOAT`
 | Returns the common logarithm (base 10) of a `FLOAT`.
@@ -288,6 +318,11 @@ These functions all operate on numerical expressions only, and will return an er
 1.1+| xref::functions/mathematical-numeric.adoc#functions-ceil[`ceil()`]
 | `ceil(input :: FLOAT) :: FLOAT`
 | Returns the smallest `FLOAT` that is greater than or equal to a number and equal to an `INTEGER`.
+
+1.1+| xref::functions/mathematical-numeric.adoc#functions-ceiling[`ceiling()`]
+| `ceiling(input :: FLOAT) :: FLOAT`
+| Returns the smallest `FLOAT` that is greater than or equal to a number and equal to an `INTEGER`. This function is an alias to the xref:functions/mathematical-numeric.adoc#functions-ceil[`ceil()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
 
 1.1+| xref::functions/mathematical-numeric.adoc#functions-floor[`floor()`]
 | `floor(input :: FLOAT) :: FLOAT`
@@ -447,7 +482,7 @@ These functions return a single value.
 1.1+| xref::functions/scalar.adoc#functions-char_length[`char_length()`]
 | `char_length(input :: STRING) :: INTEGER`
 | Returns the number of Unicode characters in a `STRING`.
-
+label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
 
 1.1+| xref::functions/scalar.adoc#functions-character_length[`character_length()`]
 | `character_length(input :: STRING) :: INTEGER`
@@ -482,6 +517,11 @@ Replaced by xref:functions/scalar.adoc#functions-elementid[`elementId()`].
 1.1+| xref::functions/scalar.adoc#functions-length[`length()`]
 | `length(input :: PATH) :: INTEGER`
 | Returns the length of a `PATH`.
+
+1.1+| xref::functions/scalar.adoc#functions-path-length[`path_length()`]
+| `path_length(input :: PATH) :: INTEGER`
+| Returns the length of a `PATH`. This function is an alias to the xref:functions/scalar.adoc#functions-length[`length()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
 
 1.1+| xref::functions/scalar.adoc#functions-nullIf[`nullIf()`]
 | `nullIf(v1 :: ANY, v2 :: ANY) :: ANY`
@@ -562,6 +602,7 @@ These functions are used to manipulate `STRING` values or to create a `STRING` r
 1.1+| xref::functions/string.adoc#functions-lower[`lower()`]
 | `lower(input :: STRING) :: STRING`
 | Returns the given `STRING` in lowercase. This function is an alias to the xref:functions/string.adoc#functions-tolower[`toLower()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
 
 1.1+| xref::functions/string.adoc#functions-ltrim[`ltrim()`]
 | `ltrim(input :: STRING [, trimCharacterString :: STRING]) :: STRING`
@@ -618,6 +659,7 @@ These functions are used to manipulate `STRING` values or to create a `STRING` r
 1.1+| xref::functions/string.adoc#functions-upper[`upper()`]
 | `upper(input :: STRING) :: STRING`
 | Returns the given `STRING` in uppercase. This function is an alias to the xref:functions/string.adoc#functions-toupper[`toUpper()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
 |===
 
 [[header-query-functions-spatial]]
@@ -667,6 +709,10 @@ If the points are in a Cartesian CRS, the function returns the Euclidean distanc
 | `duration.between(from :: ANY, to :: ANY) :: DURATION`
 | Computes the `DURATION` between the `from` instant (inclusive) and the `to` instant (exclusive) in logical units.
 
+1.1+| xref::functions/temporal/duration.adoc#functions-duration-between-alias[`duration_between()`]
+| `duration_between(from :: ANY, to :: ANY) :: DURATION`
+| Computes the `DURATION` between the `from` instant (inclusive) and the `to` instant (exclusive) in logical units. This function is an alias to the xref:functions/temporal/duration.adoc#functions-duration-between[`duration.between()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+
 1.1+| xref::functions/temporal/duration.adoc#functions-duration-indays[`duration.inDays()`]
 | `duration.inDays(from :: ANY, to :: ANY) :: DURATION`
 | Computes the `DURATION` between the `from` instant (inclusive) and the `to` instant (exclusive) in days.
@@ -714,6 +760,10 @@ Values of the xref::values-and-types/temporal.adoc[temporal types] -- `DATE`, `Z
 | `datetime(input = DEFAULT_TEMPORAL_ARGUMENT :: ANY) :: ZONED DATETIME`
 | Creates a `ZONED DATETIME` instant.
 
+1.1+| xref::functions/temporal/index.adoc#functions-zoned-datetime[`zoned_datetime()`]
+| `zoned_datetime(input = DEFAULT_TEMPORAL_ARGUMENT :: ANY) :: ZONED DATETIME`
+| Creates a `ZONED DATETIME` instant. This function is an alias to the xref:functions/temporal/index.adoc#functions-datetime[`datetime()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+
 1.1+| xref::functions/temporal/index.adoc#functions-datetime-fromepoch[`datetime.fromEpoch()`]
 | `datetime.fromEpoch(seconds :: INTEGER \| FLOAT, nanoseconds :: INTEGER \| FLOAT) :: ZONED DATETIME`
 | Creates a `ZONED DATETIME` given the seconds and nanoseconds since the start of the epoch.
@@ -742,6 +792,10 @@ Values of the xref::values-and-types/temporal.adoc[temporal types] -- `DATE`, `Z
 | `localdatetime(input = DEFAULT_TEMPORAL_ARGUMENT :: ANY) :: LOCAL DATETIME`
 | Creates a `LOCAL DATETIME` instant.
 
+1.1+| xref::functions/temporal/index.adoc#functions-local-datetime[`local_datetime()`]
+| `local_datetime(input = DEFAULT_TEMPORAL_ARGUMENT :: ANY) :: LOCAL DATETIME`
+| Creates a `LOCAL DATETIME` instant. This function is an alias to the xref:functions/temporal/index.adoc#functions-localdatetime[`localdatetime()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+
 1.1+| xref::functions/temporal/index.adoc#functions-localdatetime-realtime[`localdatetime.realtime()`]
 | `localdatetime.realtime(timezone = DEFAULT_TEMPORAL_ARGUMENT :: ANY) :: LOCAL DATETIME`
 | Returns the current `LOCAL DATETIME` instant using the realtime clock.
@@ -762,6 +816,10 @@ Values of the xref::values-and-types/temporal.adoc[temporal types] -- `DATE`, `Z
 | `localtime(input = DEFAULT_TEMPORAL_ARGUMENT :: ANY) :: LOCAL TIME`
 | Creates a `LOCAL TIME` instant.
 
+1.1+| xref::functions/temporal/index.adoc#functions-local-time[`local_time()`]
+| `local_time(input = DEFAULT_TEMPORAL_ARGUMENT :: ANY) :: LOCAL TIME`
+| Creates a `LOCAL TIME` instant. This function is an alias to the xref:functions/temporal/index.adoc#functions-localtime[`localtime()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+
 1.1+| xref::functions/temporal/index.adoc#functions-localtime-realtime[`localtime.realtime()`]
 | `localtime.realtime(timezone = DEFAULT_TEMPORAL_ARGUMENT :: ANY) :: LOCAL TIME`
 | Returns the current `LOCAL TIME` instant using the realtime clock.
@@ -781,6 +839,10 @@ Values of the xref::values-and-types/temporal.adoc[temporal types] -- `DATE`, `Z
 1.1+| xref::functions/temporal/index.adoc#functions-time[`time()`]
 | `time(input = DEFAULT_TEMPORAL_ARGUMENT :: ANY) :: ZONED TIME`
 | Creates a `ZONED TIME` instant.
+
+1.1+| xref::functions/temporal/index.adoc#functions-zoned-time[`zoned_time()`]
+| `zoned_time(input = DEFAULT_TEMPORAL_ARGUMENT :: ANY) :: ZONED TIME`
+| Creates a `ZONED TIME` instant. This function is an alias to the xref:functions/temporal/index.adoc#functions-time[`time()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
 
 1.1+| xref::functions/temporal/index.adoc#functions-time-realtime[`time.realtime()`]
 | `time.realtime(timezone = DEFAULT_TEMPORAL_ARGUMENT :: ANY) :: ZONED TIME`

--- a/modules/ROOT/pages/functions/mathematical-logarithmic.adoc
+++ b/modules/ROOT/pages/functions/mathematical-logarithmic.adoc
@@ -138,6 +138,62 @@ The natural logarithm of `27` is returned.
 ======
 
 
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
+[[functions-ln]]
+== ln()
+
+.Details
+|===
+| *Syntax* 3+| `ln(input)`
+| *Description* 3+| Returns the natural logarithm of a `FLOAT`.
+.2+| *Arguments* | *Name* | *Type* | *Description*
+| `input` | `FLOAT` | A value for which the natural logarithm will be returned.
+| *Returns* 3+| `FLOAT`
+|===
+
+This function is an alias to the xref:functions/mathematical-logarithmic.adoc#functions-log[`log()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+
+.Differences from GQL
+In GQL, the natural logarithm function must raise an exception when the input is zero or negative.
+In Cypher, `ln(0)` returns `-Infinity` and `ln(negative)` returns `NaN`.
+Changing Cypher to raise an error for these inputs would be a breaking change, so the difference is documented here and in the xref:appendix/gql-conformance/supported-optional.adoc[GQL conformance section].
+
+.Considerations
+|===
+
+| `ln(null)` returns `null`.
+| `ln(0)` returns `-Infinity`.
+| If (`input` < 0), then (`ln(input)`) returns `NaN`.
+
+|===
+
+
+.+ln()+
+======
+
+.Query
+// tag::functions_mathematical_logarithmic_ln[]
+[source, cypher, indent=0]
+----
+RETURN ln(27)
+----
+// end::functions_mathematical_logarithmic_ln[]
+
+The natural logarithm of `27` is returned.
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| ln(27)
+| 3.295836866004329
+1+d|Rows: 1
+
+|===
+
+======
+
+
 [[functions-log10]]
 == log10()
 

--- a/modules/ROOT/pages/functions/mathematical-numeric.adoc
+++ b/modules/ROOT/pages/functions/mathematical-numeric.adoc
@@ -124,6 +124,56 @@ The ceil of `0.1` is returned.
 ======
 
 
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
+[[functions-ceiling]]
+== ceiling()
+
+.Details
+|===
+| *Syntax* 3+| `ceiling(input)`
+| *Description* 3+| Returns the smallest `FLOAT` that is greater than or equal to a number and equal to an `INTEGER`.
+.2+| *Arguments* | *Name* | *Type* | *Description*
+| `input` | `FLOAT` | A value to be rounded to the nearest higher integer.
+| *Returns* 3+| `FLOAT`
+|===
+
+This function is an alias to the xref:functions/mathematical-numeric.adoc#functions-ceil[`ceil()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+The underlying `ceil()` function is already GQL compliant; only the GQL naming alias is added.
+
+.Considerations
+|===
+
+| `ceiling(null)` returns `null`.
+
+|===
+
+
+.+ceiling()+
+======
+
+.Query
+// tag::functions_mathematical_numeric_ceiling[]
+[source, cypher, indent=0]
+----
+RETURN ceiling(0.1)
+----
+// end::functions_mathematical_numeric_ceiling[]
+
+The ceiling of `0.1` is returned.
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| ceiling(0.1)
+| 1.0
+1+d|Rows: 1
+
+|===
+
+======
+
+
 [[functions-floor]]
 == floor()
 

--- a/modules/ROOT/pages/functions/scalar.adoc
+++ b/modules/ROOT/pages/functions/scalar.adoc
@@ -31,6 +31,7 @@ CREATE
 ----
 
 
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
 [[functions-char_length]]
 == char_length()
 
@@ -518,6 +519,62 @@ The length of the path `p` is returned.
 |===
 
 | length(p)
+| 2
+| 2
+| 2
+1+d|Rows: 3
+
+|===
+
+======
+
+
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
+[[functions-path-length]]
+== path_length()
+
+This function is an alias to the xref:functions/scalar.adoc#functions-length[`length()`] function when applied to a path, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+Apart from naming and GQL's path value expression/concatenation rules, the function is GQL compliant.
+
+.Details
+|===
+| *Syntax* 3+| `path_length(input)`
+| *Description* 3+| Returns the length of a `PATH`.
+.2+| *Arguments* | *Name* | *Type* | *Description*
+| `input` | `PATH` | A path whose relationships will be counted.
+| *Returns* 3+| `INTEGER`
+|===
+
+.Considerations
+|===
+
+| `path_length(null)` returns `null`.
+
+|===
+
+[NOTE]
+To calculate the length of a `LIST` or the number of Unicode characters in a `STRING`, see xref:functions/scalar.adoc#functions-size[`size()`]
+
+.+path_length()+
+======
+
+.Query
+// tag::functions_scalar_path_length[]
+[source, cypher, indent=0]
+----
+MATCH p = (a)-->(b)-->(c)
+WHERE a.name = 'Alice'
+RETURN path_length(p)
+----
+// end::functions_scalar_path_length[]
+
+The length of the path `p` is returned.
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| path_length(p)
 | 2
 | 2
 | 2

--- a/modules/ROOT/pages/functions/temporal/duration.adoc
+++ b/modules/ROOT/pages/functions/temporal/duration.adoc
@@ -175,6 +175,64 @@ RETURN aDuration
 ======
 
 
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
+[[functions-duration-between-alias]]
+== duration_between()
+
+.Details
+|===
+| *Syntax* 3+| `duration_between(from, to)`
+| *Description* 3+| Computes the `DURATION` between the `from` instant (inclusive) and the `to` instant (exclusive) in logical units.
+.3+| *Arguments* | *Name* | *Type* | *Description*
+| `from` | `ANY` | A temporal instant type (`DATE`, `LOCAL TIME`, `ZONED TIME`, `LOCAL DATETIME`, `ZONED DATETIME`) representing the starting instant.
+| `to` | `ANY` | A temporal instant type (`DATE`, `LOCAL TIME`, `ZONED TIME`, `LOCAL DATETIME`, `ZONED DATETIME`) representing the ending instant.
+| *Returns* 3+| `DURATION`
+|===
+
+This function is an alias to the xref:functions/temporal/duration.adoc#functions-duration-between[`duration.between()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+
+.Differences from GQL
+In GQL, if either argument is not a temporal instant type, a data exception is raised (22G03).
+In Cypher, a different error (e.g. invalid call signature) may be reported, but with the same severity.
+Cypher's `duration.between()` returns the date difference in years, months, and days; GQL's `duration_between()` returns the date difference in days only.
+For the same two dates the results can therefore differ (e.g. for 2026-02-01 to 2026-03-02, Cypher returns P1M1D and GQL returns P29D).
+Whenever the span includes one or more full months, the Cypher result may differ from the GQL result.
+
+.Considerations
+|===
+
+| If `to` occurs earlier than `from`, the resulting `DURATION` will be negative.
+| If `from` has a time component and `to` does not, the time component of `to` is assumed to be midnight, and vice versa.
+| If `from` has a time zone component and `to` does not, the time zone component of `to` is assumed to be the same as that of `from`, and vice versa.
+| If `to` has a date component and `from` does not, the date component of `from` is assumed to be the same as that of `to`, and vice versa.
+
+|===
+
+
+.+duration_between()+
+======
+
+.Query
+// tag::functions_duration_between_alias[]
+[source, cypher, indent=0]
+----
+RETURN duration_between(date("1984-10-11"), date("1985-11-25")) AS aDuration
+----
+// end::functions_duration_between_alias[]
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| aDuration
+| P1Y1M14D
+1+d|Rows: 1
+
+|===
+
+======
+
+
 [[functions-duration-indays]]
 == duration.inDays()
 

--- a/modules/ROOT/pages/functions/temporal/index.adoc
+++ b/modules/ROOT/pages/functions/temporal/index.adoc
@@ -18,17 +18,9 @@ The following functions are included on this page:
 | xref::functions/temporal/index.adoc#functions-localtime[localtime()]
 | xref::functions/temporal/index.adoc#functions-time[time()]
 
-|
-| xref::functions/temporal/index.adoc#functions-datetime-fromepoch[datetime.fromEpoch()]
-|
-|
-|
-
-|
-| xref::functions/temporal/index.adoc#functions-datetime-fromepochmillis[datetime.fromEpochMillis()]
-|
-|
-|
+| | xref::functions/temporal/index.adoc#functions-zoned-datetime[zoned_datetime()] | xref::functions/temporal/index.adoc#functions-local-datetime[local_datetime()] | xref::functions/temporal/index.adoc#functions-local-time[local_time()] | xref::functions/temporal/index.adoc#functions-zoned-time[zoned_time()]
+| | xref::functions/temporal/index.adoc#functions-datetime-fromepoch[datetime.fromEpoch()] | | |
+| | xref::functions/temporal/index.adoc#functions-datetime-fromepochmillis[datetime.fromEpochMillis()] | | |
 
 | xref::functions/temporal/index.adoc#functions-date-realtime[date.realtime()]
 | xref::functions/temporal/index.adoc#functions-datetime-realtime[datetime.realtime()]
@@ -1322,6 +1314,52 @@ RETURN datetime({epochMillis: 424797300000}) AS theDate
 ======
 
 
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
+[[functions-zoned-datetime]]
+== zoned_datetime()
+
+.Details
+|===
+| *Syntax* 3+| `zoned_datetime([ input, pattern ])`
+| *Description* 3+| Creates a `ZONED DATETIME` instant.
+| *Arguments* | *Name* | *Type* | *Description*
+| | `input` | `ANY` | A temporal value or a map containing temporal components.
+| | `pattern` | `STRING` | A pattern used to parse the input. If a pattern is provided, `input` must be `STRING`.
+| *Returns* 3+| `ZONED DATETIME`
+|===
+
+This function is an alias to the xref:functions/temporal/index.adoc#functions-datetime[`datetime()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+For details on supported components and parsing behavior, see xref:functions/temporal/index.adoc#functions-datetime[`datetime()`].
+
+.Differences from GQL
+In GQL, invalid sets of datetime (or timezone) field names raise a data exception (22G05); Cypher uses an equivalent-severity error (22007/22N12).
+Cypher also allows an optional `pattern` argument for parsing; this alias supports it as well.
+The GQL keyword `CURRENT_TIMESTAMP` is not introduced as a reserved keyword in Cypher, as that would break existing queries using that name as a variable.
+
+.+zoned_datetime()+
+======
+
+.Query
+// tag::functions_temporal_zoned_datetime[]
+[source, cypher]
+----
+RETURN zoned_datetime('2022-06-14T10:02:30Z') AS theDateTime
+----
+// end::functions_temporal_zoned_datetime[]
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| theDateTime
+| 2022-06-14T10:02:30Z
+1+d|Rows: 1
+
+|===
+
+======
+
+
 [[functions-datetime-fromepoch]]
 == datetime.fromEpoch()
 
@@ -1978,6 +2016,52 @@ RETURN
 ======
 
 
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
+[[functions-local-datetime]]
+== local_datetime()
+
+.Details
+|===
+| *Syntax* 3+| `local_datetime([ input, pattern ])`
+| *Description* 3+| Creates a `LOCAL DATETIME` instant.
+| *Arguments* | *Name* | *Type* | *Description*
+| | `input` | `ANY` | A temporal value or a map containing temporal components.
+| | `pattern` | `STRING` | A pattern used to parse the input. If a pattern is provided, `input` must be `STRING`.
+| *Returns* 3+| `LOCAL DATETIME`
+|===
+
+This function is an alias to the xref:functions/temporal/index.adoc#functions-localdatetime[`localdatetime()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+For details on supported components and parsing behavior, see xref:functions/temporal/index.adoc#functions-localdatetime[`localdatetime()`].
+
+.Differences from GQL
+In GQL, invalid sets of datetime field names raise a data exception (22G05); Cypher uses an error of equivalent severity (22007/22N12).
+Cypher also allows an optional `pattern` argument for parsing; this alias supports it as well.
+The GQL keyword `LOCAL_TIMESTAMP` is not introduced as a reserved keyword in Cypher, as that would break existing queries using that name as a variable.
+
+.+local_datetime()+
+======
+
+.Query
+// tag::functions_temporal_local_datetime[]
+[source, cypher]
+----
+RETURN local_datetime('2015-07-21T21:40:32.142') AS theDateTime
+----
+// end::functions_temporal_local_datetime[]
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| theDateTime
+| 2015-07-21T21:40:32.142
+1+d|Rows: 1
+
+|===
+
+======
+
+
 [[functions-localdatetime-realtime]]
 == localdatetime.realtime()
 
@@ -2377,6 +2461,52 @@ RETURN
 | timeOnly | timeSS
 | 12:31:14.645876 | 12:31:42.645876
 2+d|Rows: 1
+
+|===
+
+======
+
+
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
+[[functions-local-time]]
+== local_time()
+
+.Details
+|===
+| *Syntax* 3+| `local_time([ input, pattern ])`
+| *Description* 3+| Creates a `LOCAL TIME` instant.
+| *Arguments* | *Name* | *Type* | *Description*
+| | `input` | `ANY` | A temporal value or a map containing temporal components.
+| | `pattern` | `STRING` | A pattern used to parse the input. If a pattern is provided, `input` must be `STRING`.
+| *Returns* 3+| `LOCAL TIME`
+|===
+
+This function is an alias to the xref:functions/temporal/index.adoc#functions-localtime[`localtime()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+For details on supported components and parsing behavior, see xref:functions/temporal/index.adoc#functions-localtime[`localtime()`].
+
+.Differences from GQL
+In GQL, invalid sets of time field names raise a data exception (22G05); Cypher uses an error of equivalent severity (22007/22N12).
+Cypher also allows an optional `pattern` argument for parsing; this alias supports it as well.
+The GQL keyword `LOCAL_TIME` (parameterless) is not introduced as a reserved keyword in Cypher, as that would break existing queries that use `LOCAL_TIME` as a variable name.
+
+.+local_time()+
+======
+
+.Query
+// tag::functions_temporal_local_time[]
+[source, cypher]
+----
+RETURN local_time('21:40:32.142') AS theTime
+----
+// end::functions_temporal_local_time[]
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| theTime
+| 21:40:32.142
+1+d|Rows: 1
 
 |===
 
@@ -2804,6 +2934,52 @@ RETURN
 |===
 
 ======
+
+[role=label--new-Neo4j-2026.02 label--cypher-25-only]
+[[functions-zoned-time]]
+== zoned_time()
+
+.Details
+|===
+| *Syntax* 3+| `zoned_time([ input, pattern ])`
+| *Description* 3+| Creates a `ZONED TIME` instant.
+| *Arguments* | *Name* | *Type* | *Description*
+| | `input` | `ANY` | A temporal value or a map containing temporal components.
+| | `pattern` | `STRING` | A pattern used to parse the input. If a pattern is provided, `input` must be `STRING`.
+| *Returns* 3+| `ZONED TIME`
+|===
+
+This function is an alias to the xref:functions/temporal/index.adoc#functions-time[`time()`] function, and it was introduced as part of Cypher's xref:appendix/gql-conformance/index.adoc[].
+For details on supported components and parsing behavior, see xref:functions/temporal/index.adoc#functions-time[`time()`].
+
+.Differences from GQL
+In GQL, invalid sets of time (or timezone) field names raise a data exception (22G05); Cypher uses an equivalent-severity error (22007/22N12).
+Cypher also allows an optional `pattern` argument for parsing; this alias supports it as well.
+The GQL keyword `CURRENT_TIME` is not introduced as a reserved keyword in Cypher, as that would break existing queries using that name as a variable.
+
+.+zoned_time()+
+======
+
+.Query
+// tag::functions_temporal_zoned_time[]
+[source, cypher]
+----
+RETURN zoned_time('21:40:32.142+01:00') AS theTime
+----
+// end::functions_temporal_zoned_time[]
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+
+| theTime
+| 21:40:32.142+01:00
+1+d|Rows: 1
+
+|===
+
+======
+
 
 [[functions-time-realtime]]
 == time.realtime()

--- a/modules/ROOT/pages/functions/temporal/index.adoc
+++ b/modules/ROOT/pages/functions/temporal/index.adoc
@@ -1332,7 +1332,7 @@ This function is an alias to the xref:functions/temporal/index.adoc#functions-da
 For details on supported components and parsing behavior, see xref:functions/temporal/index.adoc#functions-datetime[`datetime()`].
 
 .Differences from GQL
-In GQL, invalid sets of datetime (or timezone) field names raise a data exception (22G05); Cypher uses an equivalent-severity error (22007/22N12).
+In GQL, invalid sets of datetime (or timezone) field names raise a data exception (22G05); Cypher uses an error of equivalent severity (22007/22N12).
 Cypher also allows an optional `pattern` argument for parsing; this alias supports it as well.
 The GQL keyword `CURRENT_TIMESTAMP` is not introduced as a reserved keyword in Cypher, as that would break existing queries using that name as a variable.
 
@@ -2953,7 +2953,7 @@ This function is an alias to the xref:functions/temporal/index.adoc#functions-ti
 For details on supported components and parsing behavior, see xref:functions/temporal/index.adoc#functions-time[`time()`].
 
 .Differences from GQL
-In GQL, invalid sets of time (or timezone) field names raise a data exception (22G05); Cypher uses an equivalent-severity error (22007/22N12).
+In GQL, invalid sets of time (or timezone) field names raise a data exception (22G05); Cypher uses an error of equivalent severity (22007/22N12).
 Cypher also allows an optional `pattern` argument for parsing; this alias supports it as well.
 The GQL keyword `CURRENT_TIME` is not introduced as a reserved keyword in Cypher, as that would break existing queries using that name as a variable.
 


### PR DESCRIPTION
These new functions are aliases for existing cypher functions. They have been added to make it GQL compliant. These functions are:
`ceiling, local_time, local_datetime, zoned_time, zoned_datetime, duration_between, path_length, ln, collect_list, percentile_disc, percentile_cont, stdev_pop, stdev_samp`