### PR TITLE
Remove SEARCH limitations for IS [NOT] NULL

### DIFF
--- a/modules/ROOT/pages/clauses/search.adoc
+++ b/modules/ROOT/pages/clauses/search.adoc
@@ -800,14 +800,6 @@ The optional `WHERE` subclause used to do _vector search with filters_ is a rest
 | `WHERE movie.rating <> 7.5`
 |
 
-|The xref:expressions/predicates/comparison-operators.adoc[comparison operator] in the predicate cannot be `IS NOT NULL`.
-| `WHERE movie.rating IS NOT NULL`
-| Neo4j 2026.02
-
-|The xref:expressions/predicates/comparison-operators.adoc[comparison operator] in the predicate cannot be `IS NULL`.
-| `WHERE movie.rating IS NULL`
-|
-
 | The predicate cannot include other xref::expressions/predicates/boolean-operators.adoc[boolean operators] than `AND`.
 | `WHERE NOT movie.rating > 8`
 footnote:[`NOT` is allowed for boolean properties.


### PR DESCRIPTION
These have been removed already before GA, so removing them rather than updating the table lifted in column.