### PR TITLE
SURF-446 Add doc for new predicate PROPERTY_EXISTS

### DIFF
--- a/modules/ROOT/pages/appendix/gql-conformance/supported-optional.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/supported-optional.adoc
@@ -89,6 +89,13 @@ These codes order the features in the table below.
 | xref:patterns/reference.adoc#label-expressions[Label expressions]
 |
 
+| [[g115]]G115
+| Property exists predicate
+| xref:expressions/predicates/comparison-operators.adoc#property-exists-predicate[`PROPERTY_EXISTS`]
+| GQL allows testing whether a value exists and is not null.
+In Cypher, the same semantics are expressed with the xref:expressions/predicates/comparison-operators.adoc[`IS NOT NULL`] predicate: for nodes and relationships, a missing property evaluates to `null`, so `n.prop IS NOT NULL` is true when the property is present and not null.
+As of Neo4j 2026.03, the same semantics can also be expressed with the `PROPERTY_EXISTS(variable, propertyName)` predicate (e.g. `WHERE PROPERTY_EXISTS(n, name)`).
+
 | GA06
 | Value type predicates
 | xref:expressions/predicates/type-predicate-expressions.adoc[Type predicate expressions]

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -23,6 +23,26 @@ Cypher 25 was introduced in Neo4j 2025.06 and can only be used on Neo4j 2025.06+
 Features removed in Cypher 25 are still available on Neo4j 2025.06+ databases either by prepending a query with `CYPHER 5` or by having Cypher 5 as the default language for the database.
 For more information, see xref:queries/select-version.adoc[].
 
+[[cypher-deprecations-additions-removals-2026.03]]
+== Neo4j 2026.03
+
+=== New in Cypher 25
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:new[]
+
+`PROPERTY_EXISTS` predicate
+
+| A new `PROPERTY_EXISTS(element, propertyName)` predicate had been added for testing whether a property exists on a node or relationship and is not `NULL`.
+
+|===
+
 [[cypher-deprecations-additions-removals-2026.02]]
 == Neo4j 2026.02
 

--- a/modules/ROOT/pages/expressions/predicates/comparison-operators.adoc
+++ b/modules/ROOT/pages/expressions/predicates/comparison-operators.adoc
@@ -197,6 +197,7 @@ RETURN n.name AS name
 1+d|Rows: 2
 |===
 
+[[is-not-null-operator]]
 .`IS NOT NULL` operator
 // tag::expressions_predicates_comparison_operators_is_not_null[]
 [source, cypher]
@@ -220,7 +221,37 @@ RETURN n.name AS name, n.email AS email
 2+d|Rows: 4
 |===
 
+The `IS NOT NULL` predicate tests whether an expression evaluates to a non-`NULL` value.
+For the GQL property existence predicate (GQL feature G115), see xref:property-exists-predicate[].
+
 =====
+[[property-exists-predicate]]
+.`PROPERTY_EXISTS` predicate
+The optional GQL feature G115 defines a `PROPERTY_EXISTS(element, propertyName)` predicate for testing whether a property exists on a node or relationship and is not `NULL`.
+
+As of Neo4j 2026.03, Cypher supports the GQL syntax:
+
+[source, cypher]
+----
+MATCH (n:Person)
+WHERE PROPERTY_EXISTS(n, email)
+RETURN n.name AS name, n.email AS email
+----
+
+For node and relationship properties, this is equivalent to:
+
+[source, cypher]
+----
+MATCH (n:Person)
+WHERE n.email IS NOT NULL
+RETURN n.name AS name, n.email AS email
+----
+
+Notes and differences:
+
+* The second argument must be a property name identifier (for example, `email`). String literals and expressions are not allowed.
+* If the element argument is `NULL`, `PROPERTY_EXISTS` returns `NULL` (consistent with GQL semantics).
+* `PROPERTY_EXISTS` applies to node and relationship properties only. `IS NOT NULL` is more general and can be applied to any expression.
 
 [[chaining-comparison-oeprators]]
 == Chaining comparison operators

--- a/modules/ROOT/pages/expressions/predicates/comparison-operators.adoc
+++ b/modules/ROOT/pages/expressions/predicates/comparison-operators.adoc
@@ -12,7 +12,7 @@ Cypher contains the following comparison operators:
 * Less than or equal to: `\<=`
 * Greater than or equal to: `>=`
 * `IS NULL`
-* `IS NOT NULL`
+* `IS NOT NULL` as well as the xref:property-exists-predicate[]
 
 [NOTE]
 For more information about how Cypher orders and compares different value types, see xref:values-and-types/ordering-equality-comparison.adoc[Values and types -> Equality, ordering, and comparison of value types]
@@ -225,8 +225,10 @@ The `IS NOT NULL` predicate tests whether an expression evaluates to a non-`NULL
 For the GQL property existence predicate (GQL feature G115), see xref:property-exists-predicate[].
 
 =====
+
 [[property-exists-predicate]]
-.`PROPERTY_EXISTS` predicate
+[discrete]
+=== `PROPERTY_EXISTS` predicate
 The optional GQL feature G115 defines a `PROPERTY_EXISTS(element, propertyName)` predicate for testing whether a property exists on a node or relationship and is not `NULL`.
 
 As of Neo4j 2026.03, Cypher supports the GQL syntax:

--- a/modules/ROOT/pages/values-and-types/working-with-null.adoc
+++ b/modules/ROOT/pages/values-and-types/working-with-null.adoc
@@ -98,5 +98,6 @@ a[coalesce($lower,0)..coalesce($upper,size(a))]
 [[is-null-is-not-null]]
 == Using `IS NULL` and `IS NOT NULL`
 Testing any value against `null`, either with the `=` operator or with the `<>` operator, always evaluates to `null`.
-Therefore,  use the special equality operators xref:expressions/predicates/comparison-operators.adoc[`IS NULL` or `IS NOT NULL`].
+Therefore, use the special equality operators xref:expressions/predicates/comparison-operators.adoc[`IS NULL` or `IS NOT NULL`].
+Using `IS NOT NULL` on a property (e.g. `n.prop IS NOT NULL`) tests that the property exists and is not null.
 


### PR DESCRIPTION
As part of making cypher GQL compliant we have introduced PROPERTY_EXISTS predicate.

Details: https://linear.app/neo4j/issue/SURF-446/gql-compliance-property-exists-g115