### PR TITLE
Clarify vector index and VECTOR storage behavior across editions

### DIFF
--- a/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
@@ -47,7 +47,7 @@ As of Neo4j 2025.10, they can also be more efficiently stored as xref:values-and
 ====
 Vector indexes are available in both Neo4j Enterprise Edition and Community Edition.
 Community Edition can index embeddings stored as `LIST<INTEGER | FLOAT>` properties.
-Storing embeddings as native xref:values-and-types/vector.adoc[`VECTOR`] properties requires block format, which is available in Enterprise Edition and Aura.
+Storing embeddings as native xref:values-and-types/vector.adoc[`VECTOR`] properties requires link:https://neo4j.com/docs/operations-manual/current/database-internals/store-formats/#store-format-overview[block format], which is available in Enterprise Edition and Aura.
 ====
 
 [NOTE]

--- a/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
@@ -45,6 +45,13 @@ As of Neo4j 2025.10, they can also be more efficiently stored as xref:values-and
 
 [NOTE]
 ====
+Vector indexes are available in both Neo4j Enterprise Edition and Community Edition.
+Community Edition can index embeddings stored as `LIST<INTEGER | FLOAT>` properties.
+Storing embeddings as native xref:values-and-types/vector.adoc[`VECTOR`] properties requires block format, which is available in Enterprise Edition and Aura.
+====
+
+[NOTE]
+====
 For information about how embeddings can be generated and stored as properties, see:
 
 * link:https://neo4j.com/docs/genai/plugin/current/embeddings/[GenAI documentation -> Create and store embeddings in a Neo4j database]
@@ -631,4 +638,3 @@ The types are still enforced as `VECTOR \| LIST<INTEGER \| FLOAT>`.
 |
 
 |===
-

--- a/modules/ROOT/pages/introduction/cypher-neo4j.adoc
+++ b/modules/ROOT/pages/introduction/cypher-neo4j.adoc
@@ -45,8 +45,8 @@ Only xref::schema/constraints/create-constraints.adoc#create-property-uniqueness
 | `VECTOR` values cannot be stored as properties using Community Edition.
 
 | xref:indexes/semantic-indexes/vector-indexes.adoc[Vector indexes]
-| Available for embeddings stored as `LIST<INTEGER | FLOAT>` and as `VECTOR` values.
-| Available for embeddings stored as `LIST<INTEGER | FLOAT>`.
+| Available for embeddings stored as `LIST<INTEGER \| FLOAT>` and as `VECTOR` values.
+| Available for embeddings stored as `LIST<INTEGER \| FLOAT>`.
 
 | Runtimes
 a|

--- a/modules/ROOT/pages/introduction/cypher-neo4j.adoc
+++ b/modules/ROOT/pages/introduction/cypher-neo4j.adoc
@@ -44,6 +44,10 @@ Only xref::schema/constraints/create-constraints.adoc#create-property-uniqueness
 | `VECTOR` values can be stored as properties if the database runs on link:{neo4j-docs-base-uri}/operations-manual/current/database-internals/store-formats/#store-format-overview[block format].
 | `VECTOR` values cannot be stored as properties using Community Edition.
 
+| xref:indexes/semantic-indexes/vector-indexes.adoc[Vector indexes]
+| Available for embeddings stored as `LIST<INTEGER | FLOAT>` and as `VECTOR` values.
+| Available for embeddings stored as `LIST<INTEGER | FLOAT>`.
+
 | Runtimes
 a|
 All runtimes:

--- a/modules/ROOT/pages/values-and-types/vector.adoc
+++ b/modules/ROOT/pages/values-and-types/vector.adoc
@@ -114,8 +114,10 @@ RETURN vector($integerList, 5, INTEGER8) AS vector
 To store a `VECTOR` value as a node or relationship property, use the `vector()` function and a write clause.
 
 [NOTE]
-Storing `VECTOR` values on requires the database to be on link:{neo4j-docs-base-uri}/operations-manual/current/database-internals/store-formats/#store-format-overview[block format].
+Storing `VECTOR` values requires the database to use link:{neo4j-docs-base-uri}/operations-manual/current/database-internals/store-formats/#store-format-overview[block format].
 This is the default on Aura instances.
+Community Edition cannot store `VECTOR` values as properties.
+In Community Edition, store embeddings as `LIST<INTEGER | FLOAT>` properties and index them with xref:indexes/semantic-indexes/vector-indexes.adoc[vector indexes].
 
 .Create a node and a `VECTOR` property
 ====


### PR DESCRIPTION
## Summary
- add explicit CE vs EE/Aura note to the vector indexes page
- clarify `VECTOR` property storage requirements and CE fallback on the vectors page
- add vector index availability row to the Cypher editions matrix
- escape table cell pipes to fix AsciiDoc table parsing warning during preview build

## Validation
- `npm run build:preview`