### PR TITLE
SURF-445 Document GQL labeled predicate (G111 / CIP-249).

### DIFF
--- a/modules/ROOT/pages/appendix/gql-conformance/supported-optional.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/supported-optional.adoc
@@ -89,6 +89,13 @@ These codes order the features in the table below.
 | xref:patterns/reference.adoc#label-expressions[Label expressions]
 |
 
+| [[g111]]G111
+| Labeled predicate
+| xref:expressions/predicates/label-expression-predicates.adoc#is-labeled-predicate[`IS [NOT] LABELED`]
+| Tests a node or relationship against a xref:patterns/reference.adoc#label-expressions[label expression].
+Equivalent to the colon form (`n:expr`), it is only valid in expression context.
+Note that `IS NOT LABELED` negates the entire label expression, unlike the `!` operator used within an expression.
+
 | [[g115]]G115
 | Property exists predicate
 | xref:expressions/predicates/comparison-operators.adoc#property-exists-predicate[`PROPERTY_EXISTS`]

--- a/modules/ROOT/pages/appendix/gql-conformance/supported-optional.adoc
+++ b/modules/ROOT/pages/appendix/gql-conformance/supported-optional.adoc
@@ -93,7 +93,7 @@ These codes order the features in the table below.
 | Labeled predicate
 | xref:expressions/predicates/label-expression-predicates.adoc#is-labeled-predicate[`IS [NOT] LABELED`]
 | Tests a node or relationship against a xref:patterns/reference.adoc#label-expressions[label expression].
-Equivalent to the colon form (`n:expr`), it is only valid in expression context.
+Equivalent to the colon form (`n:expr`), it is only valid in the context of an expression.
 Note that `IS NOT LABELED` negates the entire label expression, unlike the `!` operator used within an expression.
 
 | [[g115]]G115

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -26,6 +26,27 @@ For more information, see xref:queries/select-version.adoc[].
 [[cypher-deprecations-additions-removals-2026.04]]
 == Neo4j 2026.04
 
+=== New in Cypher 25
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:new[]
+[source, cypher, role="noheader"]
+----
+MATCH (n:Person)
+RETURN n IS LABELED Manager AS isManager
+----
+
+a|
+xref:expressions/predicates/label-expression-predicates.adoc#is-labeled-predicate[`IS [NOT] LABELED` predicate]: expression syntax aligned with GQL for testing a node or relationship against a label expression, equivalent to the existing colon form.
+
+|===
+
 === Deprecated in Cypher 25
 
 [cols="2", options="header"]

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -43,7 +43,7 @@ RETURN n IS LABELED Manager AS isManager
 ----
 
 a|
-xref:expressions/predicates/label-expression-predicates.adoc#is-labeled-predicate[`IS [NOT] LABELED` predicate]: expression syntax aligned with GQL for testing a node or relationship against a label expression, equivalent to the existing colon form.
+xref:expressions/predicates/label-expression-predicates.adoc#is-labeled-predicate[`IS [NOT\] LABELED` predicate]: tests a node or relationship against a label expression, equivalent to the existing colon form.
 
 |===
 

--- a/modules/ROOT/pages/expressions/predicates/index.adoc
+++ b/modules/ROOT/pages/expressions/predicates/index.adoc
@@ -9,7 +9,7 @@ This chapter is divided into the following sections:
 * xref:expressions/predicates/comparison-operators.adoc[]: `=`, `<>`, `<`, `>`, `\<=`, `>=`, `IS NULL`, `IS NOT NULL`
 * xref:expressions/predicates/list-operators.adoc[]: `IN`
 * xref:expressions/predicates/string-operators.adoc[]: `STARTS WITH`, `ENDS WITH`, `CONTAINS`, `IS NORMALIZED`, `IS NOT NORMALIZED`, `=~`
-* xref:expressions/predicates/label-expression-predicates.adoc[]: information about how to test whether a node or relationship matches a label expression or not.
+* xref:expressions/predicates/label-expression-predicates.adoc[]: the colon form (`:`) and, as of Neo4j 2026.04, GQL `IS [NOT] LABELED` for testing whether a node or relationship matches a xref:patterns/reference.adoc#label-expressions[label expression].
 * xref:expressions/predicates/path-pattern-expressions.adoc[]: information about filtering queries with path pattern expressions.
 * xref:expressions/predicates/type-predicate-expressions.adoc[]: information about how to verify the value type of a Cypher expression.
 

--- a/modules/ROOT/pages/expressions/predicates/index.adoc
+++ b/modules/ROOT/pages/expressions/predicates/index.adoc
@@ -9,7 +9,7 @@ This chapter is divided into the following sections:
 * xref:expressions/predicates/comparison-operators.adoc[]: `=`, `<>`, `<`, `>`, `\<=`, `>=`, `IS NULL`, `IS NOT NULL`
 * xref:expressions/predicates/list-operators.adoc[]: `IN`
 * xref:expressions/predicates/string-operators.adoc[]: `STARTS WITH`, `ENDS WITH`, `CONTAINS`, `IS NORMALIZED`, `IS NOT NORMALIZED`, `=~`
-* xref:expressions/predicates/label-expression-predicates.adoc[]: the colon form (`:`) and, as of Neo4j 2026.04, GQL `IS [NOT] LABELED` for testing whether a node or relationship matches a xref:patterns/reference.adoc#label-expressions[label expression].
+* xref:expressions/predicates/label-expression-predicates.adoc[]: `:`, `IS [NOT] LABELED`
 * xref:expressions/predicates/path-pattern-expressions.adoc[]: information about filtering queries with path pattern expressions.
 * xref:expressions/predicates/type-predicate-expressions.adoc[]: information about how to verify the value type of a Cypher expression.
 

--- a/modules/ROOT/pages/expressions/predicates/label-expression-predicates.adoc
+++ b/modules/ROOT/pages/expressions/predicates/label-expression-predicates.adoc
@@ -3,8 +3,16 @@
 
 You can use a label expression predicate to verify that the labels of a node or the relationship type of a relationship match a given label expression.
 
+Cypher supports two label expression alternatives:
+
+* Colon form (`<expr>:<label-expression>`)
+* `IS [NOT] LABELED`  form label:new[Introduced in Neo4j 2026.04] label:cypher[Cypher 25 only]
+
 [[label-expression-predicat-syntax]]
 == Syntax
+
+[[label-expression-predicate-colon-syntax]]
+=== Colon form
 
 [source, syntax]
 ----
@@ -12,6 +20,34 @@ You can use a label expression predicate to verify that the labels of a node or 
 ----
 
 Where `<expr>` is any Cypher expression and `<label-expression>` is any Cypher xref::patterns/reference.adoc#label-expressions[label expression].
+
+[[is-labeled-predicate]]
+[role=label--new-Neo4j-2026.04 label--cypher-25-only]
+=== `IS [NOT] LABELED` predicate
+
+[source, syntax]
+----
+<expr> IS LABELED <label-expression>
+<expr> IS NOT LABELED <label-expression>
+<expr> IS NOT <label-expression>
+----
+
+
+* If `<expr>` evaluates to `null`, the predicate result is `null`.
+* Otherwise, the label expression is evaluated against the node's label set or the relationship's single type, and the result is `true` or `false` equivalent to the colon form.
+* `IS NOT LABELED <label-expression>` negates the result of the entire label expression.
+  This is different from using `!` *inside* the label expression.
+For example:
+** `n IS LABELED !A&B` means the node has label `B`, and does not have label `A`.
+** `n IS NOT LABELED A&B` means the node does not have both label `A` and label `B`.
+
+
+[NOTE]
+====
+`IS [NOT] LABELED` is only valid in expression contexts, (for example, xref:clauses/where.adoc[`WHERE`], xref:clauses/return.adoc[`RETURN`], xref:clauses/with.adoc[`WITH`], on the right-hand side of xref:clauses/set.adoc[`SET`] property assignments, or in xref:expressions/conditional-expressions.adoc[`CASE`] branches).
+It cannot be used in place of a label expression inside a xref:patterns/reference.adoc#node-patterns[node pattern] or xref:patterns/reference.adoc#relationship-patterns[relationship pattern] (for example `MATCH (n IS LABELED Person)` is invalid), nor as xref:clauses/set.adoc[`SET`] / xref:clauses/remove.adoc[`REMOVE`] label specification syntax.
+In patterns and when attaching or removing labels, use the colon form instead (for example `(n:Person)`).
+====
 
 [[example-graph]]
 == Example graph
@@ -109,7 +145,7 @@ RETURN p.name AS name,
 2+d|Rows: 5
 |===
 
-When `<exp>` results in ´null`, then the label expression predicate results in `null`, e.g. if `p` is `null`, then `p:!CEO` results in `null`.
+When `<expr>` evaluates to `null`, the label expression predicate results in `null`; for example if `p` is `null`, then `p:!CEO` results in `null`.
 
 [source, cypher]
 ----
@@ -190,7 +226,59 @@ RETURN p.name AS name, p:$any(managerLabels) AS isManager
 2+d|Rows: 6
 |===
 
-[node-label-expression-predicate]
+[[is-labeled-predicate-examples]]
+[role=label--new-Neo4j-2026.04 label--cypher-25-only]
+== Examples using `IS [NOT] LABELED`
+
+.Test a node with `IS LABELED`
+[source, cypher]
+----
+MATCH (p:Person)
+RETURN p.name AS name, p IS LABELED Manager AS isManager
+----
+
+[role="queryresult",options="header,footer",cols="2*<m"]
+|===
+| name | isManager
+
+| "Alice" | true
+| "Cecil" | false
+| "Cecilia" | false
+| "Charlie" | false
+| "Daniel" | false
+| "Eskil" | false
+
+2+d|Rows: 6
+|===
+
+.Simple `CASE` with `IS LABELED` branches
+[source, cypher]
+----
+MATCH (p:Person)
+RETURN p.name AS name,
+       CASE p
+         WHEN IS LABELED CEO THEN 'executive'
+         WHEN IS LABELED Manager|Director THEN 'lead'
+         ELSE 'ic'
+       END AS role
+ORDER BY name
+----
+
+[role="queryresult",options="header,footer",cols="2*<m"]
+|===
+| name | role
+
+| "Alice" | "lead"
+| "Cecil" | "ic"
+| "Cecilia" | "ic"
+| "Charlie" | "ic"
+| "Daniel" | "lead"
+| "Eskil" | "executive"
+
+2+d|Rows: 6
+|===
+
+[relationship-label-expression-predicate]
 == Test whether a relationship has a certain relationship type
 
 Given that `r` is a relationship, `r:WORKS_FOR` tests whether `r` has the relationship type `WORKS_FOR` or not and result in `true` or `false`, respectively.

--- a/modules/ROOT/pages/patterns/reference.adoc
+++ b/modules/ROOT/pages/patterns/reference.adoc
@@ -186,6 +186,8 @@ The following applies to both the label expressions of node patterns and the typ
 A label expression is a boolean predicate composed from label names and a wildcard symbol using disjunction, conjunction, negation and grouping.
 A label expression returns true when it matches the set of labels for a node.
 
+The same grammar appears in xref:expressions/predicates/label-expression-predicates.adoc[label expression predicates] in expression context: the colon form `element:labelExpression`, and as of Neo4j 2026.04, `element IS [NOT] LABELED labelExpression` (see xref:expressions/predicates/label-expression-predicates.adoc#is-labeled-predicate[`IS [NOT] LABELED`]).
+
 Although relationships have a type rather than labels, the syntax for expressions matching a relationship type is identical to that of label expressions.
 
 [[label-expressions-syntax]]
@@ -193,9 +195,13 @@ Although relationships have a type rather than labels, the syntax for expression
 
 [source, syntax, role=noheader]
 ----
-labelExpression ::= ":" labelTerm
+labelExpression ::= 
+    ":" labelTerm
+  | "IS" [ "NOT" ] "LABELED" labelTerm
+  | "IS NOT" labelTerm
 
 labelTerm ::=
+----,search:
     labelIdentifier
   | labelTerm "&" labelTerm
   | labelTerm "|" labelTerm


### PR DESCRIPTION
Add IS [NOT] LABELED syntax, semantics, examples, and GQL conformance/release notes; link from label expressions and simple CASE.

https://linear.app/neo4j/issue/SURF-445/gql-compliance-labeled-predicate