### PR TITLE
Clarify vector index dimension best practice

### DIFF
--- a/modules/ROOT/pages/clauses/search.adoc
+++ b/modules/ROOT/pages/clauses/search.adoc
@@ -637,6 +637,7 @@ RETURN movie.title AS title
 ====
 If the vector index has no configured dimension, the query succeeds.
 However, if there are no vectors in the index of the same dimension as the query vector, the result of the query will be empty.
+For this reason, it is recommended to configure `vector.dimensions` when xref::indexes/syntax.adoc#create-vector-index[creating vector indexes].
 ====
 
 === Using a query vector which evaluates to null

--- a/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
@@ -108,7 +108,9 @@ With `IF NOT EXISTS`, no error is thrown and nothing happens should an index wit
 It may still throw an error should a constraint with the same name exist.
 An informational notification is returned when nothing happens, showing the existing index which blocks the creation.
 <2> To read more about the available configuration settings, see xref:indexes/semantic-indexes/vector-indexes.adoc#configuration-settings[].
-In this example, the vector dimension is explicitly set to `1536` and the vector similarity function to `'cosine'`, which is generally the preferred similarity function for text embeddings.
+In this example, the vector dimension is explicitly set to `1536`.
+Providing dimensions when creating a vector index is recommended, as it ensures that only vectors of that size are indexed and makes dimension mismatches fail clearly at query time.
+The vector similarity function is set to `'cosine'`, which is generally the preferred similarity function for text embeddings.
 To read more about the available similarity functions, see xref:indexes/semantic-indexes/vector-indexes.adoc#similarity-functions[].
 
 You can also create a vector index for relationships with a particular type on a given property using the following syntax:
@@ -180,10 +182,11 @@ For more information about the values accepted by different index providers, see
 The dimensions of the vectors to be indexed.
 For more information, see xref:indexes/semantic-indexes/vector-indexes.adoc#embeddings[].
 This setting can be omitted, and any `LIST<INTEGER | FLOAT>` or, as of Neo4j 2025.10, additionally `VECTOR` value can be indexed and queried, separated by their dimensions, _though only vectors of the same dimension can be compared._
-Setting this value adds additional checks that ensure only vectors with the configured dimensions are indexed, and querying the index with a vector of a different dimensions returns an error.
+Setting this value adds additional checks that ensure only vectors with the configured dimensions are indexed, and querying the index with a vector of a different dimension returns an error.
 
 [NOTE]
 It is recommended to provide dimensions when creating a vector index.
+Doing so avoids the confusing situation where the same index may contain side-by-side vectors of different dimensions, while still only allowing comparisons between vectors of the same dimension.
 
 Accepted values::: `INTEGER` between `1` and `4096` inclusively.
 Default value::: None.

--- a/modules/ROOT/pages/indexes/syntax.adoc
+++ b/modules/ROOT/pages/indexes/syntax.adoc
@@ -206,8 +206,7 @@ ON (r.propertyName)
 [OPTIONS "{" option: value[, ...] "}"]
 ----
 
-[NOTE]
-Multiple labels, multiple relationship types and additional properties were introduced in Neo4j 2026.01.
+label:new[Introduced in Neo4j 2026.01] Vector indexes support multiple labels, multiple relationship types, and additional properties for filtering. A vector index can index only one vector property, and the optional `WITH` clause adds non-vector properties for filtering; it does not create a composite vector index over multiple vector properties.
 
 For a full list of all vector index settings, see xref:indexes/semantic-indexes/vector-indexes.adoc#configuration-settings[Vector index configuration settings].
 
@@ -222,11 +221,8 @@ OPTIONS {
 }
 ----
 
-[NOTE]
-====
-It is not possible to create composite vector indexes on multiple vector properties.
-The additional properties in the index are used for filtering purposes.
-====
+It is recommended to provide `vector.dimensions` when creating a vector index.
+Doing so ensures that only vectors of that size are indexed and makes dimension mismatches fail clearly at query time.
 
 For more information, see xref:indexes/semantic-indexes/vector-indexes.adoc#create-vector-index[Vector indexes - Create and configure vector indexes].
 

--- a/modules/ROOT/pages/indexes/syntax.adoc
+++ b/modules/ROOT/pages/indexes/syntax.adoc
@@ -206,7 +206,8 @@ ON (r.propertyName)
 [OPTIONS "{" option: value[, ...] "}"]
 ----
 
-label:new[Introduced in Neo4j 2026.01] Vector indexes support multiple labels, multiple relationship types, and additional properties for filtering. A vector index can index only one vector property, and the optional `WITH` clause adds non-vector properties for filtering; it does not create a composite vector index over multiple vector properties.
+As of Neo4j 2026.01, vector indexes support multiple labels, multiple relationship types, and additional properties for filtering.
+A vector index can index only one vector property, and the optional `WITH` clause adds non-vector properties for filtering; it does not create a composite vector index over multiple vector properties.
 
 For a full list of all vector index settings, see xref:indexes/semantic-indexes/vector-indexes.adoc#configuration-settings[Vector index configuration settings].
 


### PR DESCRIPTION
## Summary
- strengthen the recommendation to provide `vector.dimensions` when creating vector indexes
- explain why this is best practice in the canonical vector index and syntax docs
- link the `SEARCH` dimensionality note back to vector index creation syntax

## Validation
- `npm run build:preview`