### PR TITLE
Complete vector index release-note examples

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -271,19 +271,22 @@ label:new[]
 CREATE VECTOR INDEX multiLabel
 FOR (n:Label1\|Label2)
 ON n.embedding
+OPTIONS {indexConfig: {`vector.dimensions`: 1536, `vector.similarity_function`: 'cosine'}}
 ----
 [source, cypher]
 ----
 CREATE VECTOR INDEX multiRelType
 FOR ()-[r:REL_TYPE1\|REL_TYPE2]-()
 ON r.embedding
+OPTIONS {indexConfig: {`vector.dimensions`: 1536, `vector.similarity_function`: 'cosine'}}
 ----
 [source, cypher]
 ----
 CREATE VECTOR INDEX additionalProperties
 FOR (n:Label)
 ON n.embedding
-WITH [n.propety1, n.property2]
+WITH [n.property1, n.property2]
+OPTIONS {indexConfig: {`vector.dimensions`: 1536, `vector.similarity_function`: 'cosine'}}
 ----
 | xref:indexes/semantic-indexes/vector-indexes.adoc[Vector indexes] can now have multiple labels, relationship types or include additional properties for filtering.
 |===


### PR DESCRIPTION
## Summary
- add complete vector index configuration to the Cypher 25 release-note examples for multi-label, multi-relationship-type, and additional-property vector indexes
- include both `vector.dimensions` and `vector.similarity_function` so the snippets stay consistent with the current best-practice guidance
- fix the `property1` typo in the additional-properties example

## Validation
- `git diff --check`
- `npm run build:preview`
