### PR TITLE
Add information and example of combining SHOW and TERMINATE commands with regular Cypher

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -55,7 +55,7 @@ WITH name, collect(signature) AS signatures
 FILTER size(signatures) > 1
 RETURN name, signatures
 ----
-a| Show indexes, constraints, current graph type, functions, procedures, settings, databases, and transactions, and terminate transactions can be combined with general Cypher clauses in a single query.
+a| Show indexes, constraints, current graph type, functions, procedures, settings, databases, and transactions, and terminate transactions can be combined with each other and general Cypher clauses in a single query.
 When combined with other clauses, the `YIELD` clause is mandatory. `YIELD *` is not permitted, and the query must end with a valid last clause (like a `RETURN` or an updating clause).
 For `SHOW DATABASES`, all parts of the query must be allowed on the system database.
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -44,6 +44,21 @@ RETURN p
 | Explicit path modes such as `ACYCLIC` can now be combined with restrictive path selectors, such as `SHORTEST`.
 For more information, see xref:patterns/reference.adoc#mixing-restrictive-path-selectors-and-explicit-path-modes[Patterns -> Mixing restrictive path selectors and explicit path modes].
 
+a|
+label:functionality[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+SHOW FUNCTIONS
+YIELD name, signature
+WITH name, collect(signature) AS signatures
+FILTER size(signatures) > 1
+RETURN name, signatures
+----
+a| Show indexes, constraints, current graph type, functions, procedures, settings, databases, and transactions and terminate transactions can now be combined with general Cypher clauses in a single query.
+When combined with other clauses the `YIELD` clause is mandatory, `YIELD *` is not permitted and the query needs to end with a valid last clause (like a `RETURN` or an updating clause).
+For show databases, the all parts of the query need to be allowed on the system database.
+
 |===
 
 === New in Cypher 25

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -59,6 +59,28 @@ a| Show indexes, constraints, current graph type, functions, procedures, setting
 When combined with other clauses the `YIELD` clause is mandatory, `YIELD *` is not permitted and the query needs to end with a valid last clause (like a `RETURN` or an updating clause).
 For show databases, the all parts of the query need to be allowed on the system database.
 
+a|
+label:functionality[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+SHOW SETTINGS null
+----
+[source, cypher, role="noheader"]
+----
+SHOW TRANSACTIONS null
+----
+[source, cypher, role="noheader"]
+----
+TERMINATE TRANSACTIONS null
+----
+[source, cypher, role="noheader"]
+----
+SHOW DATABASE $nullParam
+----
+a| Show settings, databases, and transactions and terminate transactions now treat `null` input the same as non-existent input.
+So the show commands filter them out and terminate transactions return a row about transaction not found.
+
 |===
 
 === New in Cypher 25

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -56,8 +56,9 @@ FILTER size(signatures) > 1
 RETURN name, signatures
 ----
 a| Show indexes, constraints, current graph type, functions, procedures, settings, databases, and transactions, and terminate transactions can be combined with each other and general Cypher clauses in a single query.
-When combined with other clauses, the `YIELD` clause is mandatory. `YIELD *` is not permitted, and the query must end with a valid last clause (like a `RETURN` or an updating clause).
+For more information, see xref:clauses/show.adoc#composable-show-commands[SHOW -> Composable `SHOW` commands].
 For `SHOW DATABASES`, all parts of the query must be allowed on the system database.
+For more information, see the link:{neo4j-docs-base-uri}/operations-manual/current/database-administration/standard-databases/listing-databases/#_show_quarantined_databases_and_lift_their_quarantine[Operations Manual -> Show databases].
 
 a|
 label:functionality[]
@@ -81,6 +82,12 @@ SHOW DATABASE $nullParam
 a| Show settings, databases, and transactions, and terminate transactions treat `null` input the same as non-existent input. 
 The show commands filter out the `null` input.
 Terminate transactions return a row about the transaction not being found.
+
+For full information about these commands, see the following pages in the Operations Manual:
+
+* link:{neo4j-docs-base-uri}/operations-manual/current/database-administration/standard-databases/listing-databases/[Show databases]
+* link:{neo4j-docs-base-uri}/operations-manual/current/configuration/show-settings/[Show settings]
+*  link:{neo4j-docs-base-uri}/operations-manual/current/database-internals/show-and-terminate-transactions/[Show and terminate transactions]
 
 |===
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -79,7 +79,8 @@ TERMINATE TRANSACTIONS null
 SHOW DATABASE $nullParam
 ----
 a| Show settings, databases, and transactions, and terminate transactions treat `null` input the same as non-existent input. 
-So the show commands filter them out and terminate transactions return a row about transaction not found.
+The show commands filter out the `null` input.
+Terminate transactions return a row about the transaction not being found.
 
 |===
 

--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -55,9 +55,9 @@ WITH name, collect(signature) AS signatures
 FILTER size(signatures) > 1
 RETURN name, signatures
 ----
-a| Show indexes, constraints, current graph type, functions, procedures, settings, databases, and transactions and terminate transactions can now be combined with general Cypher clauses in a single query.
-When combined with other clauses the `YIELD` clause is mandatory, `YIELD *` is not permitted and the query needs to end with a valid last clause (like a `RETURN` or an updating clause).
-For show databases, the all parts of the query need to be allowed on the system database.
+a| Show indexes, constraints, current graph type, functions, procedures, settings, databases, and transactions, and terminate transactions can be combined with general Cypher clauses in a single query.
+When combined with other clauses, the `YIELD` clause is mandatory. `YIELD *` is not permitted, and the query must end with a valid last clause (like a `RETURN` or an updating clause).
+For `SHOW DATABASES`, all parts of the query must be allowed on the system database.
 
 a|
 label:functionality[]
@@ -78,7 +78,7 @@ TERMINATE TRANSACTIONS null
 ----
 SHOW DATABASE $nullParam
 ----
-a| Show settings, databases, and transactions and terminate transactions now treat `null` input the same as non-existent input.
+a| Show settings, databases, and transactions, and terminate transactions treat `null` input the same as non-existent input. 
 So the show commands filter them out and terminate transactions return a row about transaction not found.
 
 |===

--- a/modules/ROOT/pages/indexes/search-performance-indexes/list-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/list-indexes.adoc
@@ -30,6 +30,7 @@ CREATE CONSTRAINT bookRecommendations FOR (book:Book) REQUIRE (book.recommend) I
 ////
 
 Listing indexes can be done with `SHOW INDEXES`.
+For general information about the `SHOW` command, see the xref:clauses/show.adoc[`SHOW`] page.
 
 [NOTE]
 ====
@@ -43,7 +44,7 @@ Listing indexes requires link:{neo4j-docs-base-uri}/operations-manual/current/au
 * xref:indexes/search-performance-indexes/list-indexes.adoc#listing-all-indexes[]
 * xref:indexes/search-performance-indexes/list-indexes.adoc#listing-specific-columns[]
 * xref:indexes/search-performance-indexes/list-indexes.adoc#listing-indexes-with-filtering[]
-* xref:indexes/search-performance-indexes/list-indexes.adoc#listing-indexes-with-general-cypher[]
+* xref:indexes/search-performance-indexes/list-indexes.adoc#composable-show-indexes[]
 
 
 [[listing-all-indexes]]

--- a/modules/ROOT/pages/indexes/search-performance-indexes/list-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/list-indexes.adoc
@@ -211,8 +211,8 @@ RETURN reduce(acc = head(dropCommands), dc IN tail(dropCommands) | acc + " " + d
 [NOTE]
 ====
 When combining `SHOW INDEXES` with other clauses, the `YIELD` clause is mandatory and must not be omitted.
-In addition, `YIELD *` is not permitted.
-Instead, the `YIELD` clause needs to explicitly list the yielded columns.
+`YIELD` must explicitly list the yielded columns.
+`YIELD *` is not permitted.
 The query must also end with a valid last clause (like a `RETURN` or an updating clause).
 ====
 

--- a/modules/ROOT/pages/indexes/search-performance-indexes/list-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/list-indexes.adoc
@@ -179,8 +179,8 @@ SHOW RANGE INDEXES YIELD * WHERE owningConstraint IS NULL
 ----
 
 [role=label--cypher-25-only label--new-Neo4j-2026.05]
-[[listing-indexes-with-general-cypher]]
-=== Listing indexes combined with general Cypher
+[[composable-show-indexes]]
+=== Combine `SHOW INDEXES` with other Cypher clauses
 
 The `SHOW INDEXES` command can be combined with general Cypher clauses in a single query.
 

--- a/modules/ROOT/pages/indexes/search-performance-indexes/list-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/list-indexes.adoc
@@ -43,6 +43,7 @@ Listing indexes requires link:{neo4j-docs-base-uri}/operations-manual/current/au
 * xref:indexes/search-performance-indexes/list-indexes.adoc#listing-all-indexes[]
 * xref:indexes/search-performance-indexes/list-indexes.adoc#listing-specific-columns[]
 * xref:indexes/search-performance-indexes/list-indexes.adoc#listing-indexes-with-filtering[]
+* xref:indexes/search-performance-indexes/list-indexes.adoc#listing-indexes-with-general-cypher[]
 
 
 [[listing-all-indexes]]
@@ -176,6 +177,44 @@ To get all columns, use:
 ----
 SHOW RANGE INDEXES YIELD * WHERE owningConstraint IS NULL
 ----
+
+[role=label--cypher-25-only label--new-Neo4j-2026.XX]
+[[listing-indexes-with-general-cypher]]
+=== Listing indexes combined with general Cypher
+
+The `SHOW INDEXES` command can be combined with general Cypher clauses in a single query.
+
+For example, returning a string of drop index commands for all indexes except token lookup indexes and indexes backing constraints.
+
+.Return commands to drop all indexes as a single string
+[source, cypher, role=test-result-skip]
+----
+SHOW INDEXES
+YIELD name, type, owningConstraint
+WHERE type <> 'LOOKUP' AND owningConstraint IS NULL
+WITH "DROP INDEX `" + name + "`;" AS dropCommand
+WITH collect(dropCommand) AS dropCommands
+RETURN reduce(acc = head(dropCommands), dc IN tail(dropCommands) | acc + " " + dc) AS result
+----
+
+.Result
+[queryresult]
+----
++-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| result                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
++-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| "DROP INDEX `composite_range_node_index_name`; DROP INDEX `composite_range_rel_index_name`; DROP INDEX `example_index`; DROP INDEX `indexOnBooks`; DROP INDEX `node_point_index_name`; DROP INDEX `node_range_index_name`; DROP INDEX `node_text_index_nickname`; DROP INDEX `point_index_param`; DROP INDEX `point_index_with_config`; DROP INDEX `range_index_param`; DROP INDEX `rel_point_index_name`; DROP INDEX `rel_range_index_name`; DROP INDEX `rel_text_index_name`; DROP INDEX `text_index_param`;" |
++-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+1 row
+----
+
+[NOTE]
+====
+When combining `SHOW INDEXES` with other clauses, the `YIELD` clause is mandatory and must not be omitted.
+In addition, `YIELD *` is not permitted.
+Instead, the `YIELD` clause needs to explicitly list the yielded columns.
+The query must also end with a valid last clause (like a `RETURN` or an updating clause).
+====
 
 [[listing-indexes-result-columns]]
 == Result columns for listing indexes

--- a/modules/ROOT/pages/indexes/search-performance-indexes/list-indexes.adoc
+++ b/modules/ROOT/pages/indexes/search-performance-indexes/list-indexes.adoc
@@ -178,7 +178,7 @@ To get all columns, use:
 SHOW RANGE INDEXES YIELD * WHERE owningConstraint IS NULL
 ----
 
-[role=label--cypher-25-only label--new-Neo4j-2026.XX]
+[role=label--cypher-25-only label--new-Neo4j-2026.05]
 [[listing-indexes-with-general-cypher]]
 === Listing indexes combined with general Cypher
 

--- a/modules/ROOT/pages/indexes/syntax.adoc
+++ b/modules/ROOT/pages/indexes/syntax.adoc
@@ -245,6 +245,8 @@ When using the `RETURN` clause, the `YIELD` clause is mandatory.
 
 For more information, see xref:indexes/search-performance-indexes/list-indexes.adoc[].
 
+In Cypher 25 from 2026.XX, it is possible to combine `SHOW INDEXES` with general Cypher clauses in a single query.
+
 [[query-semantic-indexes]]
 == Query semantic indexes
 

--- a/modules/ROOT/pages/indexes/syntax.adoc
+++ b/modules/ROOT/pages/indexes/syntax.adoc
@@ -245,7 +245,7 @@ When using the `RETURN` clause, the `YIELD` clause is mandatory.
 
 For more information, see xref:indexes/search-performance-indexes/list-indexes.adoc[].
 
-In Cypher 25 from 2026.XX, it is possible to combine `SHOW INDEXES` with general Cypher clauses in a single query.
+In Cypher 25 from 2026.05, it is possible to combine `SHOW INDEXES` with general Cypher clauses in a single query.
 
 [[query-semantic-indexes]]
 == Query semantic indexes

--- a/modules/ROOT/pages/planning-and-tuning/operators/index.adoc
+++ b/modules/ROOT/pages/planning-and-tuning/operators/index.adoc
@@ -792,6 +792,12 @@ Tests for the absence of a pattern predicate if an expression predicate evaluate
 |
 |label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
 
+| xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-show-databases[ShowDatabases]
+| Lists the available databases.
+| label:yes[]
+|
+|label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.XX]
+
 | xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-show-functions[ShowFunctions]
 | Lists the available functions.
 | label:yes[]

--- a/modules/ROOT/pages/planning-and-tuning/operators/index.adoc
+++ b/modules/ROOT/pages/planning-and-tuning/operators/index.adoc
@@ -796,7 +796,7 @@ Tests for the absence of a pattern predicate if an expression predicate evaluate
 | Lists the available databases.
 | label:yes[]
 |
-|label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.XX]
+|label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.05]
 
 | xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-show-functions[ShowFunctions]
 | Lists the available functions.

--- a/modules/ROOT/pages/planning-and-tuning/operators/index.adoc
+++ b/modules/ROOT/pages/planning-and-tuning/operators/index.adoc
@@ -29,6 +29,30 @@ This table comprises all the execution plan operators ordered lexicographically.
 |
 |
 
+| xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-alter-current-graph-type-add[AlterCurrentGraphTypeAdd]
+| Adds elements to the current graph type.
+| label:yes[]
+|
+|label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
+
+| xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-alter-current-graph-type-alter[AlterCurrentGraphTypeAlter]
+| Alters elements of the current graph type.
+| label:yes[]
+|
+|label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
+
+| xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-alter-current-graph-type-drop[AlterCurrentGraphTypeDrop]
+| Drops elements from the current graph type.
+| label:yes[]
+|
+|label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
+
+| xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-alter-current-graph-type-set[AlterCurrentGraphTypeSet]
+| Replaces the current graph type.
+| label:yes[]
+|
+|label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
+
 | xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-anti[Anti]
 | Tests for the absence of a pattern.
 |
@@ -761,6 +785,12 @@ Tests for the absence of a pattern predicate if an expression predicate evaluate
 | label:yes[]
 |
 |
+
+| xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-show-current-graph-type[ShowCurrentGraphType]
+| Lists the current graph type.
+| label:yes[]
+|
+|label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.02]
 
 | xref::planning-and-tuning/operators/operators-detail.adoc#query-plan-show-functions[ShowFunctions]
 | Lists the available functions.

--- a/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
+++ b/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
@@ -7815,3 +7815,46 @@ Total database accesses: 0, total allocated memory: 64
 ----
 
 ======
+
+
+[role=label--cypher-25-only label--new-Neo4j-2026.XX]
+[[query-plan-show-databases]]
+=== Show Databases
+
+The `ShowDatabases` operator lists databases.
+It may include filtering on all databases, a single database, the DBMS default database or the users home database as well as if the user can access the database.
+The output can either be default or full output.
+
+
+.ShowDatabases
+======
+
+.Query
+[source, cypher]
+----
+PROFILE
+SHOW DATABASES
+----
+
+.Query Plan
+[role="queryplan", subs="attributes+"]
+----
+Planner ADMINISTRATION
+
+Runtime SYSTEM
+
+Runtime version {neo4j-version}
+
++-----------------+----+----------------------------------------------------------------------------------------------------+------+---------+
+| Operator        | Id | Details                                                                                            | Rows | DB Hits |
++-----------------+----+----------------------------------------------------------------------------------------------------+------+---------+
+| +ProduceResults |  0 | name, type, aliases, access, address, role, writer, requestedStatus, currentStatus, statusMessage, |    0 |       1 |
+| |               |    | default, home, constituents                                                                        |      |         |
+| |               +----+----------------------------------------------------------------------------------------------------+------+---------+
+| +ShowDatabases  |  1 | allDatabases, defaultColumns                                                                       |    0 |       1 |
++-----------------+----+----------------------------------------------------------------------------------------------------+------+---------+
+
+Total database accesses: 2
+----
+
+======

--- a/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
+++ b/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
@@ -7265,6 +7265,203 @@ Total database accesses: 2, total allocated memory: 64
 
 ======
 
+[role=label--cypher-25-only label--new-Neo4j-2026.02]
+[[query-plan-alter-current-graph-type-add]]
+=== Alter Current Graph Type Add
+
+The `AlterCurrentGraphTypeAdd` operator adds the specified graph type elements to the current graph type.
+
+.AlterCurrentGraphTypeAdd
+======
+
+.Query
+[source, cypher]
+----
+PROFILE
+ALTER CURRENT GRAPH TYPE ADD {
+ (:Label1 => :Label2 {prop :: STRING NOT NULL}),
+ (:Label3)-[:REL_TYPE => {prop :: INT NOT NULL}]->()
+}
+----
+
+.Query Plan
+[role="queryplan", subs="attributes+"]
+----
+Planner ADMINISTRATION
+
+Runtime SCHEMA
+
+Runtime version {neo4j-version}
+
++---------------------------+----+------------------------------------------------------------------------------------------------------+
+| Operator                  | Id | Details                                                                                              |
++---------------------------+----+------------------------------------------------------------------------------------------------------+
+| +AlterCurrentGraphTypeAdd |  0 | { (:Label1 => :Label2 {prop :: STRING NOT NULL}), (:Label3)-[:REL_TYPE => {prop :: INTEGER NOT NULL} |
+|                           |    | ]->() }                                                                                              |
++---------------------------+----+------------------------------------------------------------------------------------------------------+
+
+Total database accesses: ?
+----
+
+======
+
+[role=label--cypher-25-only label--new-Neo4j-2026.02]
+[[query-plan-alter-current-graph-type-alter]]
+=== Alter Current Graph Type Alter
+
+The `AlterCurrentGraphTypeAlter` operator updates the specified graph type elements.
+This is done by replacing the current definition of those elements with the specified definition.
+
+.AlterCurrentGraphTypeAlter
+======
+
+.Query
+[source, cypher]
+----
+PROFILE
+ALTER CURRENT GRAPH TYPE ALTER {
+ (:Label1 => {prop :: STRING NOT NULL}),
+ (:Label3)-[:REL_TYPE => {prop :: INT}]->()
+}
+----
+
+.Query Plan
+[role="queryplan", subs="attributes+"]
+----
+Planner ADMINISTRATION
+
+Runtime SCHEMA
+
+Runtime version {neo4j-version}
+
++-----------------------------+----+--------------------------------------------------------------------------------------------+
+| Operator                    | Id | Details                                                                                    |
++-----------------------------+----+--------------------------------------------------------------------------------------------+
+| +AlterCurrentGraphTypeAlter |  0 | { (:Label1 => {prop :: STRING NOT NULL}), (:Label3)-[:REL_TYPE => {prop :: INTEGER}]->() } |
++-----------------------------+----+--------------------------------------------------------------------------------------------+
+
+Total database accesses: ?
+----
+
+======
+
+[role=label--cypher-25-only label--new-Neo4j-2026.02]
+[[query-plan-alter-current-graph-type-drop]]
+=== Alter Current Graph Type Drop
+
+The `AlterCurrentGraphTypeDrop` operator drops the specified graph type elements.
+
+.AlterCurrentGraphTypeDrop
+======
+
+.Query
+[source, cypher]
+----
+PROFILE
+ALTER CURRENT GRAPH TYPE DROP {
+ (:Label1 =>),
+ ()-[:REL_TYPE =>]->()
+}
+----
+
+.Query Plan
+[role="queryplan", subs="attributes+"]
+----
+Planner ADMINISTRATION
+
+Runtime SCHEMA
+
+Runtime version {neo4j-version}
+
++----------------------------+----+-----------------------------------------+
+| Operator                   | Id | Details                                 |
++----------------------------+----+-----------------------------------------+
+| +AlterCurrentGraphTypeDrop |  0 | { (:Label1 =>), ()-[:REL_TYPE =>]->() } |
++----------------------------+----+-----------------------------------------+
+
+Total database accesses: ?
+----
+
+======
+
+[role=label--cypher-25-only label--new-Neo4j-2026.02]
+[[query-plan-alter-current-graph-type-set]]
+=== Alter Current Graph Type Set
+
+The `AlterCurrentGraphTypeSet` operator replaces the current graph type with the specified graph type.
+
+.AlterCurrentGraphTypeSet
+======
+
+.Query
+[source, cypher]
+----
+PROFILE
+ALTER CURRENT GRAPH TYPE SET {
+ (:Label1 => :Label2 {prop :: STRING NOT NULL}),
+ (:Label3)-[:REL_TYPE => {prop :: INT NOT NULL}]->()
+}
+----
+
+.Query Plan
+[role="queryplan", subs="attributes+"]
+----
+Planner ADMINISTRATION
+
+Runtime SCHEMA
+
+Runtime version {neo4j-version}
+
++---------------------------+----+------------------------------------------------------------------------------------------------------+
+| Operator                  | Id | Details                                                                                              |
++---------------------------+----+------------------------------------------------------------------------------------------------------+
+| +AlterCurrentGraphTypeSet |  0 | { (:Label1 => :Label2 {prop :: STRING NOT NULL}), (:Label3)-[:REL_TYPE => {prop :: INTEGER NOT NULL} |
+|                           |    | ]->() }                                                                                              |
++---------------------------+----+------------------------------------------------------------------------------------------------------+
+
+Total database accesses: ?
+----
+
+======
+
+[role=label--cypher-25-only label--new-Neo4j-2026.02]
+[[query-plan-show-current-graph-type]]
+=== Show Current Graph Type
+
+The `ShowCurrentGraphType` operator lists the current graph type.
+
+.ShowCurrentGraphType
+======
+
+.Query
+[source, cypher]
+----
+PROFILE
+SHOW CURRENT GRAPH TYPE
+----
+
+.Query Plan
+[role="queryplan", subs="attributes+"]
+----
+Planner COST
+
+Runtime SLOTTED
+
+Runtime version {neo4j-version}
+
++-----------------------+----+----------------+----------------+------+---------+------------------------+
+| Operator              | Id | Details        | Estimated Rows | Rows | DB Hits | Page Cache Hits/Misses |
++-----------------------+----+----------------+----------------+------+---------+------------------------+
+| +ProduceResults       |  0 | specification  |             10 |    1 |       0 |                    0/0 |
+| |                     +----+----------------+----------------+------+---------+------------------------+
+| +ShowCurrentGraphType |  1 | defaultColumns |             10 |    1 |       1 |                    0/0 |
++-----------------------+----+----------------+----------------+------+---------+------------------------+
+
+Total database accesses: 1, total allocated memory: 64
+----
+
+======
+
 
 [[query-plan-create-index]]
 === Create Index

--- a/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
+++ b/modules/ROOT/pages/planning-and-tuning/operators/operators-detail.adoc
@@ -7817,7 +7817,7 @@ Total database accesses: 0, total allocated memory: 64
 ======
 
 
-[role=label--cypher-25-only label--new-Neo4j-2026.XX]
+[role=label--cypher-25-only label--new-Neo4j-2026.05]
 [[query-plan-show-databases]]
 === Show Databases
 

--- a/modules/ROOT/pages/schema/constraints/list-constraints.adoc
+++ b/modules/ROOT/pages/schema/constraints/list-constraints.adoc
@@ -257,7 +257,7 @@ YIELD name, type, createStatement
 ======
 
 
-[role=label--cypher-25-only label--new-Neo4j-2026.XX]
+[role=label--cypher-25-only label--new-Neo4j-2026.05]
 [[listing-constraints-with-general-cypher]]
 == Listing constraints combined with general Cypher
 

--- a/modules/ROOT/pages/schema/constraints/list-constraints.adoc
+++ b/modules/ROOT/pages/schema/constraints/list-constraints.adoc
@@ -258,8 +258,8 @@ YIELD name, type, createStatement
 
 
 [role=label--cypher-25-only label--new-Neo4j-2026.05]
-[[listing-constraints-with-general-cypher]]
-== Listing constraints combined with general Cypher
+[[composable-show-constraints]]
+== Combine `SHOW CONSTRAINTS` with other Cypher clauses
 
 The `SHOW CONSTRAINTS` command can be combined with general Cypher clauses in a single query.
 

--- a/modules/ROOT/pages/schema/constraints/list-constraints.adoc
+++ b/modules/ROOT/pages/schema/constraints/list-constraints.adoc
@@ -302,8 +302,8 @@ RETURN name AS constraint, labels(n) AS labels, properties(n) AS properties
 [NOTE]
 ====
 When combining `SHOW CONSTRAINTS` with other clauses, the `YIELD` clause is mandatory and must not be omitted.
-In addition, `YIELD *` is not permitted.
-Instead, the `YIELD` clause needs to explicitly list the yielded columns.
+`YIELD` must explicitly list the yielded columns.
+`YIELD *` is not permitted.
 The query must also end with a valid last clause (like a `RETURN` or an updating clause).
 ====
 

--- a/modules/ROOT/pages/schema/constraints/list-constraints.adoc
+++ b/modules/ROOT/pages/schema/constraints/list-constraints.adoc
@@ -62,7 +62,7 @@ FOR ()-[knows:KNOWS]-() REQUIRE (knows.since, knows.how) IS RELATIONSHIP KEY;
 CREATE CONSTRAINT node_uniqueness_param
 FOR (book:Book) REQUIRE book.prop1 IS UNIQUE;
 CREATE CONSTRAINT rel_exist_param
-FOR ()-[wrote:WROTE]-() REQUIRE wrote.published IS NOT NULL
+FOR ()-[wrote:WROTE]-() REQUIRE wrote.published IS NOT NULL;
 ----
 ////
 
@@ -256,6 +256,56 @@ YIELD name, type, createStatement
 
 ======
 
+
+[role=label--cypher-25-only label--new-Neo4j-2026.XX]
+[[listing-constraints-with-general-cypher]]
+== Listing constraints combined with general Cypher
+
+The `SHOW CONSTRAINTS` command can be combined with general Cypher clauses in a single query.
+
+For example, returning the labels and properties of nodes in the graph that are constrained by a node key constraint.
+
+////
+The graph below are created on schema/constraints/create-constraints.adoc, except for the `Director` label and `imdbId` property on Jensen Ackles.
+
+[source, cypher, role=test-setup]
+----
+CREATE (:Actor:Director {firstname: 'Jensen', surname: 'Ackles', imdbId: 'nm0010075'})-[:KNOWS {since: 2008, how: 'coworkers', friend: true}]->(:Actor {firstname: 'Misha', surname: 'Collins'});
+----
+////
+
+.Return labels and properties of node key constrained nodes
+[source, cypher]
+----
+SHOW CONSTRAINTS
+YIELD name, type, labelsOrTypes, properties
+WHERE type = 'NODE_KEY'
+WITH name, labelsOrTypes[0] AS label, properties
+MATCH (n:$(label))
+WHERE all(p IN properties WHERE p IN keys(n))
+RETURN name AS constraint, labels(n) AS labels, properties(n) AS properties
+----
+
+.Result
+[queryresult]
+----
++----------------------------------------------------------------------------------------------------------------+
+| constraint        | labels               | properties                                                          |
++----------------------------------------------------------------------------------------------------------------+
+| "actor_fullname"  | ["Director","Actor"] | {firstname -> "Jensen", imdbId -> "nm0010075", surname -> "Ackles"} |
+| "actor_fullname"  | ["Actor"]            | {firstname -> "Misha", surname -> "Collins"}                        |
+| "director_imdbId" | ["Director","Actor"] | {firstname -> "Jensen", imdbId -> "nm0010075", surname -> "Ackles"} |
++----------------------------------------------------------------------------------------------------------------+
+3 rows
+----
+
+[NOTE]
+====
+When combining `SHOW CONSTRAINTS` with other clauses, the `YIELD` clause is mandatory and must not be omitted.
+In addition, `YIELD *` is not permitted.
+Instead, the `YIELD` clause needs to explicitly list the yielded columns.
+The query must also end with a valid last clause (like a `RETURN` or an updating clause).
+====
 
 [[list-constraints-result-columns]]
 == Result columns for listing constraints

--- a/modules/ROOT/pages/schema/constraints/list-constraints.adoc
+++ b/modules/ROOT/pages/schema/constraints/list-constraints.adoc
@@ -4,6 +4,7 @@
 To list all constraints with the default output columns, use `SHOW CONSTRAINTS`.
 If all columns are required, use `SHOW CONSTRAINTS YIELD *`.
 For the full command syntax to list constraints, see xref:schema/syntax.adoc#list-constraints[Syntax -> Show constraints].
+For general information about the `SHOW` command, see the xref:clauses/show.adoc[`SHOW`] page.
 The constraints listed on this page are created on the page xref:schema/constraints/create-constraints.adoc[].
 
 [NOTE]

--- a/modules/ROOT/pages/schema/graph-types/list-graph-types.adoc
+++ b/modules/ROOT/pages/schema/graph-types/list-graph-types.adoc
@@ -61,7 +61,7 @@ SHOW CURRENT GRAPH TYPE
 [NOTE]
 Regardless of which syntax was used to define a property uniqueness or key constraint, they are all shown in the `specification` returned by `SHOW CURRENT GRAPH TYPE` using the `CONSTRAINT … FOR … REQUIRE` syntax.
 
-[role=label--new-Neo4j-2026.XX]
+[role=label--new-Neo4j-2026.05]
 [[listing-graph-type-with-general-cypher]]
 == Listing current graph type combined with general Cypher
 

--- a/modules/ROOT/pages/schema/graph-types/list-graph-types.adoc
+++ b/modules/ROOT/pages/schema/graph-types/list-graph-types.adoc
@@ -3,6 +3,7 @@
 = Show graph types
 
 The `SHOW CURRENT GRAPH TYPE` command allows you to show the graph type specification for the current database.
+For general information about the `SHOW` command, see the xref:clauses/show.adoc[`SHOW`] page.
 
 [NOTE]
 Showing a graph type requires the link:{neo4j-docs-base-uri}/operations-manual/current/authentication-authorization/database-administration/#access-control-database-administration-constraints[`SHOW CONSTRAINTS` privilege].
@@ -74,22 +75,19 @@ For example, splitting the graph type specification into separate strings.
 ----
 SHOW CURRENT GRAPH TYPE
 YIELD specification
-
-// Filter out the empty graph type
-FILTER specification <> '{}'
-
-// Split string definition into separate lines
-WITH split(specification, '\r\n') AS specificationLines
-
-// Remove the { and } lines
-WITH specificationLines[1..-1] AS elementLines
-
-// Remove leading indention and trailing commas
-WITH [line IN elementLines | rtrim(trim(line), ',')] AS graphTypeLines
+FILTER specification <> '{}' // <1>
+WITH split(specification, '\r\n') AS specificationLines // <2>
+WITH specificationLines[1..-1] AS elementLines // <3>
+WITH [line IN elementLines | rtrim(trim(line), ',')] AS graphTypeLines // <4>
 
 UNWIND graphTypeLines AS graphTypeElement
 RETURN graphTypeElement
 ----
+
+<1> Filter out the empty graph type.
+<2> Split `STRING` definition into separate lines.
+<3> Remove the opening and closing lines of the graph type (`{` and `}`).
+<4> Remove leading indention and trailing commas.
 
 .Result
 [queryresult]

--- a/modules/ROOT/pages/schema/graph-types/list-graph-types.adoc
+++ b/modules/ROOT/pages/schema/graph-types/list-graph-types.adoc
@@ -118,8 +118,8 @@ RETURN graphTypeElement
 [NOTE]
 ====
 When combining `SHOW CURRENT GRAPH TYPE` with other clauses, the `YIELD` clause is mandatory and must not be omitted.
-In addition, `YIELD *` is not permitted.
-Instead, the `YIELD` clause needs to explicitly list the yielded columns.
+`YIELD` must explicitly list the yielded columns.
+`YIELD *` is not permitted.
 The query must also end with a valid last clause (like a `RETURN` or an updating clause).
 ====
 

--- a/modules/ROOT/pages/schema/graph-types/list-graph-types.adoc
+++ b/modules/ROOT/pages/schema/graph-types/list-graph-types.adoc
@@ -62,8 +62,8 @@ SHOW CURRENT GRAPH TYPE
 Regardless of which syntax was used to define a property uniqueness or key constraint, they are all shown in the `specification` returned by `SHOW CURRENT GRAPH TYPE` using the `CONSTRAINT … FOR … REQUIRE` syntax.
 
 [role=label--new-Neo4j-2026.05]
-[[listing-graph-type-with-general-cypher]]
-== Listing current graph type combined with general Cypher
+[[composable-show-graph-types]]
+== Combine `SHOW CURRENT GRAPH TYPE` with other Cypher clauses
 
 The `SHOW CURRENT GRAPH TYPE` command can be combined with general Cypher clauses in a single query.
 

--- a/modules/ROOT/pages/schema/graph-types/list-graph-types.adoc
+++ b/modules/ROOT/pages/schema/graph-types/list-graph-types.adoc
@@ -61,6 +61,67 @@ SHOW CURRENT GRAPH TYPE
 [NOTE]
 Regardless of which syntax was used to define a property uniqueness or key constraint, they are all shown in the `specification` returned by `SHOW CURRENT GRAPH TYPE` using the `CONSTRAINT … FOR … REQUIRE` syntax.
 
+[role=label--new-Neo4j-2026.XX]
+[[listing-graph-type-with-general-cypher]]
+== Listing current graph type combined with general Cypher
+
+The `SHOW CURRENT GRAPH TYPE` command can be combined with general Cypher clauses in a single query.
+
+For example, splitting the graph type specification into separate strings.
+
+.Return separate strings for each part of the graph type
+[source, cypher]
+----
+SHOW CURRENT GRAPH TYPE
+YIELD specification
+
+// Filter out the empty graph type
+FILTER specification <> '{}'
+
+// Split string definition into separate lines
+WITH split(specification, '\r\n') AS specificationLines
+
+// Remove the { and } lines
+WITH specificationLines[1..-1] AS elementLines
+
+// Remove leading indention and trailing commas
+WITH [line IN elementLines | rtrim(trim(line), ',')] AS graphTypeLines
+
+UNWIND graphTypeLines AS graphTypeElement
+RETURN graphTypeElement
+----
+
+.Result
+[queryresult]
+----
++--------------------------------------------------------------------------------------------------------------------+
+| graphTypeElement                                                                                                   |
++--------------------------------------------------------------------------------------------------------------------+
+| "(:`City` => {`name` :: STRING NOT NULL, `population` :: INTEGER})"                                                |
+| "(:`Company` => {`address` :: STRING, `name` :: STRING})"                                                          |
+| "(:`Person` => :`Resident` {`name` :: STRING, `ssn` :: INTEGER})"                                                  |
+| "(:`Pet` => :`Animal`&`Resident` {`healthCertificate` :: STRING, `insuranceNumber` :: INTEGER, `name` :: STRING})" |
+| "(:`Robot` => :`Machine`&`Resident` {`application` :: STRING NOT NULL, `id` :: INTEGER NOT NULL})"                 |
+| "(:`Resident`)-[:`LIVES_IN` => {`since` :: ANY NOT NULL}]->(:`City` =>)"                                           |
+| "(:`Person` =>)-[:`WORKS_FOR` => {`role` :: STRING}]->(:`Company` =>)"                                             |
+| "CONSTRAINT `constraint_1324d6fc` FOR (`n`:`Company` =>) REQUIRE (`n`.`address`) IS UNIQUE"                        |
+| "CONSTRAINT `company_name` FOR (`n`:`Company` =>) REQUIRE (`n`.`name`) IS KEY"                                     |
+| "CONSTRAINT `constraint_5d8979dd` FOR (`n`:`Person` =>) REQUIRE (`n`.`name`, `n`.`ssn`) IS KEY"                    |
+| "CONSTRAINT `constraint_bbcb9835` FOR (`n`:`Pet` =>) REQUIRE (`n`.`healthCertificate`) IS UNIQUE"                  |
+| "CONSTRAINT `constraint_550b510e` FOR (`n`:`Pet` =>) REQUIRE (`n`.`insuranceNumber`) IS KEY"                       |
+| "CONSTRAINT `animal_id` FOR (`n`:`Animal`) REQUIRE (`n`.`id`) IS UNIQUE"                                           |
+| "CONSTRAINT `resident_address` FOR (`n`:`Resident`) REQUIRE (`n`.`address`) IS :: STRING"                          |
++--------------------------------------------------------------------------------------------------------------------+
+14 rows
+----
+
+[NOTE]
+====
+When combining `SHOW CURRENT GRAPH TYPE` with other clauses, the `YIELD` clause is mandatory and must not be omitted.
+In addition, `YIELD *` is not permitted.
+Instead, the `YIELD` clause needs to explicitly list the yielded columns.
+The query must also end with a valid last clause (like a `RETURN` or an updating clause).
+====
 
 [[result-columns]]
 == Result columns for `SHOW CURRENT GRAPH TYPE`

--- a/modules/ROOT/pages/schema/syntax.adoc
+++ b/modules/ROOT/pages/schema/syntax.adoc
@@ -247,7 +247,7 @@ SHOW CURRENT GRAPH TYPE
   [WHERE expression]
 ----
 
-.Syntax to list the current graph type with full return columns
+.Syntax to list the current graph type with full or given return columns
 [source, syntax]
 ----
 SHOW CURRENT GRAPH TYPE 
@@ -258,6 +258,7 @@ YIELD { * | field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]
 
 For more information, see xref:schema/graph-types/list-graph-types.adoc[].
 For full details of the columns returned by the `SHOW CURRENT GRAPH TYPE` command, see xref:schema/graph-types/list-graph-types.adoc#result-columns[Show graph types -> Result columns for `SHOW CURRENT GRAPH TYPE`].
+From 2026.XX, it is possible to combine `SHOW CURRENT GRAPH TYPE` with general Cypher clauses in a single query.
 
 [[drop-graph-type-elements]]
 === Drop graph type elements
@@ -535,7 +536,7 @@ SHOW [
   [WHERE expression]
 ----
 
-.Syntax for listing constraints with full return columns
+.Syntax for listing constraints with full or given return columns
 [source, syntax]
 ----
 SHOW [
@@ -619,6 +620,7 @@ This is the default if none is given.
 
 For examples on how to list constraints, see  xref:schema/constraints/list-constraints.adoc[Show constraints].
 For full details of the result columns for the `SHOW CONSTRAINTS` command, see xref:schema/constraints/list-constraints.adoc#list-constraints-result-columns[Show constraints -> Result columns for listing constraints].
+In Cypher 25 from 2026.XX, it is possible to combine `SHOW CONSTRAINTS` with general Cypher clauses in a single query.
 
 [[drop-constraint]]
 === Drop constraints

--- a/modules/ROOT/pages/schema/syntax.adoc
+++ b/modules/ROOT/pages/schema/syntax.adoc
@@ -258,7 +258,7 @@ YIELD { * | field[, ...] } [ORDER BY field[, ...]] [SKIP n] [LIMIT n]
 
 For more information, see xref:schema/graph-types/list-graph-types.adoc[].
 For full details of the columns returned by the `SHOW CURRENT GRAPH TYPE` command, see xref:schema/graph-types/list-graph-types.adoc#result-columns[Show graph types -> Result columns for `SHOW CURRENT GRAPH TYPE`].
-From 2026.XX, it is possible to combine `SHOW CURRENT GRAPH TYPE` with general Cypher clauses in a single query.
+From 2026.05, it is possible to combine `SHOW CURRENT GRAPH TYPE` with general Cypher clauses in a single query.
 
 [[drop-graph-type-elements]]
 === Drop graph type elements
@@ -620,7 +620,7 @@ This is the default if none is given.
 
 For examples on how to list constraints, see  xref:schema/constraints/list-constraints.adoc[Show constraints].
 For full details of the result columns for the `SHOW CONSTRAINTS` command, see xref:schema/constraints/list-constraints.adoc#list-constraints-result-columns[Show constraints -> Result columns for listing constraints].
-In Cypher 25 from 2026.XX, it is possible to combine `SHOW CONSTRAINTS` with general Cypher clauses in a single query.
+In Cypher 25 from 2026.05, it is possible to combine `SHOW CONSTRAINTS` with general Cypher clauses in a single query.
 
 [[drop-constraint]]
 === Drop constraints


### PR DESCRIPTION
Also includes 
* adding the plan operators for graph type alter and show plans (was missed during the graph type documentation)
* ~~adding notes on updated behaviour on null input for SHOW SETTINGS, SHOW TRANSACTIONS and TERMINATE TRANSACTIONS (will be updated in 2026.05) ~~ (broken out into separate PRs when the sections moved)
* adding the plan operator for show databases (part of https://github.com/neo-technology/neo4j/pull/36480 to make the show commands have nicer query plans when run against the system database)

TODO:
- [x] Update 2026.XX to relevant version once released
- [x] Do we want any of this on the cheat sheet? -> https://github.com/neo4j/docs-cheat-sheet/pull/281
- [x] Talked to Jens about maybe making a single page for the composable commands instead of having them spread out like they are now -> https://github.com/neo4j/docs-cypher/pull/1531