### PR TITLE
feat(PLAN-3383) Explicit path mode + Shortest

### DIFF
--- a/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
+++ b/modules/ROOT/pages/deprecations-additions-removals-compatibility.adoc
@@ -26,6 +26,26 @@ For more information, see xref:queries/select-version.adoc[].
 [[cypher-deprecations-additions-removals-2026.05]]
 == Neo4j 2026.05
 
+=== Updated in Cypher 25
+
+[cols="2", options="header"]
+|===
+| Feature
+| Details
+
+a|
+label:functionality[]
+label:updated[]
+[source, cypher, role="noheader"]
+----
+MATCH p = ANY SHORTEST ACYCLIC (a:A)-->+(b:!A)
+RETURN p
+----
+| Explicit path modes such as `ACYCLIC` can now be combined with restrictive path selectors, such as `SHORTEST`.
+For more information, see xref:patterns/reference.adoc#mixing-restrictive-path-selectors-and-explicit-path-modes[Patterns -> Mixing restrictive path selectors and explicit path modes].
+
+|===
+
 === New in Cypher 25
 
 [cols="2", options="header"]

--- a/modules/ROOT/pages/patterns/reference.adoc
+++ b/modules/ROOT/pages/patterns/reference.adoc
@@ -2034,25 +2034,41 @@ RETURN p
 link:https://neo4j.com/docs/status-codes/current/errors/gql-errors/42001/[42001]: error: syntax error or access rule violation - invalid syntax
 |===
 
-[[mixing-restrictive-path-selectors-and-explicit-path-modes-is-not-allowed]]
-==== Mixing explicit path modes and variable-length relationships
+[[mixing-explicit-path-modes-and-variable-length-relationships-is-not-allowed]]
+==== Mixing explicit path modes and variable-length relationships is not allowed
 
 Explicit path modes cannot currently be combined with xref:patterns/reference.adoc#variable-length-relationships[variable-length relationships] (e.g., `+-[*]->+`).
 Use xref:patterns/reference.adoc#quantified-path-patterns[quantified path patterns] or xref:patterns/reference.adoc#quantified-relationships[quantified relationships] instead.
 Note that this also means that explicit path modes cannot be combined with xref:patterns/reference.adoc#shortest-functions[legacy shortest path functions] like `shortestPath()`.
 Use xref:patterns/reference.adoc#shortest-paths[SHORTEST] instead.
 
-For example, the following queries are not supported:
+For example:
 
+.Not supported
 [source, cypher, role=test-fail]
 ----
-MATCH ACYCLIC (start)-[*4..7]->(target) // Instead use: MATCH ACYCLIC (start)-[]->{4,7}(target)
+MATCH ACYCLIC (start)-[*4..7]->(target)
 RETURN start, target
 ----
 
+.Supported
+[source, cypher]
+----
+MATCH ACYCLIC (start)-[]->{4,7}(target)
+RETURN start, target
+----
+
+.Not supported
 [source, cypher, role=test-fail]
 ----
-MATCH p = ACYCLIC shortestPath((a:A)-[*]->(b:!A)) // Instead use: MATCH p = ANY SHORTEST ACYCLIC (a:A)-[]->+(b:!A)
+MATCH p = ACYCLIC shortestPath((a:A)-[*]->(b:!A))
+RETURN p
+----
+
+.Supported
+[source, cypher]
+----
+MATCH p = ANY SHORTEST ACYCLIC (a:A)-[]->+(b:!A)
 RETURN p
 ----
 

--- a/modules/ROOT/pages/patterns/reference.adoc
+++ b/modules/ROOT/pages/patterns/reference.adoc
@@ -2035,21 +2035,31 @@ link:https://neo4j.com/docs/status-codes/current/errors/gql-errors/42001/[42001]
 |===
 
 [[mixing-restrictive-path-selectors-and-explicit-path-modes-is-not-allowed]]
-==== Mixing restrictive path selectors and explicit path modes is not allowed
+==== Mixing explicit path modes and variable-length relationships
 
-Explicit path modes cannot currently be combined with restrictive path selectors (e.g., `ANY`, `SHORTEST`) or legacy shortest path functions like `shortestPath()`.
-For example:
+Explicit path modes cannot currently be combined with xref:patterns/reference.adoc#variable-length-relationships[variable-length relationships] (e.g., `+-[*]->+`).
+Use xref:patterns/reference.adoc#quantified-path-patterns[quantified path patterns] or xref:patterns/reference.adoc#quantified-relationships[quantified relationships] instead.
+Note that this also means that explicit path modes cannot be combined with xref:patterns/reference.adoc#shortest-functions[legacy shortest path functions] like `shortestPath()`.
+Use xref:patterns/reference.adoc#shortest-paths[SHORTEST] instead.
+
+For example, the following queries are not supported:
 
 [source, cypher, role=test-fail]
 ----
-MATCH p = ANY ACYCLIC (start)-->(target)
+MATCH ACYCLIC (start)-[*4..7]->(target) // Instead use: MATCH ACYCLIC (start)-[]->{4,7}(target)
+RETURN start, target
+----
+
+[source, cypher, role=test-fail]
+----
+MATCH p = ACYCLIC shortestPath((a:A)-[*]->(b:!A)) // Instead use: MATCH p = ANY SHORTEST ACYCLIC (a:A)-[]->+(b:!A)
 RETURN p
 ----
 
 .GQLSTATUS error chain
 [role="queryresult",stripes="all",cols="1"]
 |===
-| link:https://neo4j.com/docs/status-codes/current/errors/gql-errors/51N26/[51N26]: error: system configuration or operation exception - not supported in this version. Using `SHORTEST` together with explicit path mode `ACYCLIC` is not available. This implementation of Cypher does not support SHORTEST with path mode `ACYCLIC`.
+| link:https://neo4j.com/docs/status-codes/current/errors/gql-errors/51N26/[51N26]: error: system configuration or operation exception - not supported in this version. Using explicit path modes on a pattern containing a variable-length relationship is not available. This implementation of Cypher does not support `ACYCLIC` on variable-length relationships.
 
 link:https://neo4j.com/docs/status-codes/current/errors/gql-errors/42001/[42001]: error: syntax error or access rule violation - invalid syntax
 |===

--- a/modules/ROOT/pages/patterns/reference.adoc
+++ b/modules/ROOT/pages/patterns/reference.adoc
@@ -2034,54 +2034,46 @@ RETURN p
 link:https://neo4j.com/docs/status-codes/current/errors/gql-errors/42001/[42001]: error: syntax error or access rule violation - invalid syntax
 |===
 
-[[mixing-explicit-path-modes-and-variable-length-relationships-is-not-allowed]]
-==== Mixing explicit path modes and variable-length relationships is not allowed
+[[mixing-restrictive-path-selectors-and-explicit-path-modes]]
+==== Mixing restrictive path selectors and explicit path modes
 
-Explicit path modes cannot currently be combined with xref:patterns/reference.adoc#variable-length-relationships[variable-length relationships] (e.g., `+-[*]->+`).
-Use xref:patterns/reference.adoc#quantified-path-patterns[quantified path patterns] or xref:patterns/reference.adoc#quantified-relationships[quantified relationships] instead.
-Note that this also means that explicit path modes cannot be combined with xref:patterns/reference.adoc#shortest-functions[legacy shortest path functions] like `shortestPath()`.
-Use xref:patterns/reference.adoc#shortest-paths[SHORTEST] instead.
+.Neo4j versions and rules for mixing restrictive path selectors and explicit path modes
+[%header,cols="a,5a"]
+|===
+| Neo4j versions | Behavior
 
-For example:
+| 2026.03 - 2026.4
+| Explicit path modes cannot be combined with restrictive path selectors (e.g., `ANY`, `SHORTEST`) or legacy shortest path functions like `shortestPath()`.
 
-.Not supported
-[source, cypher, role=test-fail]
-----
-CYPHER 25
-MATCH ACYCLIC (start)-[:R*4..7]->(target)
-RETURN start, target
-----
+| 2026.5 - current
+a| Explicit path modes can be combined with restrictive path selectors.
 
 .Supported
 [source, cypher]
 ----
-CYPHER 25
+MATCH p = ANY SHORTEST ACYCLIC (a:A)-->+(b:!A)
+RETURN p
+----
+
+Explicit path modes cannot be combined with xref:patterns/reference.adoc#variable-length-relationships[variable-length relationships] (e.g., `+-[*]->+`).
+Use xref:patterns/reference.adoc#quantified-path-patterns[quantified path patterns] or xref:patterns/reference.adoc#quantified-relationships[quantified relationships] instead.
+Note that this also means that explicit path modes cannot be combined with xref:patterns/reference.adoc#shortest-functions[legacy shortest path functions] like `shortestPath()`.
+Use xref:patterns/reference.adoc#shortest-paths[`SHORTEST`] instead.
+
+.Supported -- explicit path mode with quantified relationship syntax
+[source, cypher]
+----
 MATCH ACYCLIC (start)-[:R]->{4,7}(target)
 RETURN start, target
 ----
 
-.Not supported
+.Not supported -- explicit path mode with variable-length relationship syntax
 [source, cypher, role=test-fail]
 ----
-CYPHER 25
 MATCH p = ACYCLIC shortestPath((a:A)-[*]->(b:!A))
 RETURN p
 ----
 
-.Supported
-[source, cypher]
-----
-CYPHER 25
-MATCH p = ANY SHORTEST ACYCLIC (a:A)-[]->+(b:!A)
-RETURN p
-----
-
-.GQLSTATUS error chain
-[role="queryresult",stripes="all",cols="1"]
-|===
-| link:https://neo4j.com/docs/status-codes/current/errors/gql-errors/51N26/[51N26]: error: system configuration or operation exception - not supported in this version. Using explicit path modes on a pattern containing a variable-length relationship is not available. This implementation of Cypher does not support `ACYCLIC` on variable-length relationships.
-
-link:https://neo4j.com/docs/status-codes/current/errors/gql-errors/42001/[42001]: error: syntax error or access rule violation - invalid syntax
 |===
 
 [[path-modes-cannot-be-applied-to-merge]]

--- a/modules/ROOT/pages/patterns/reference.adoc
+++ b/modules/ROOT/pages/patterns/reference.adoc
@@ -2043,10 +2043,10 @@ link:https://neo4j.com/docs/status-codes/current/errors/gql-errors/42001/[42001]
 | Neo4j versions | Behavior
 
 | 2026.03 - 2026.4
-| Explicit path modes cannot be combined with restrictive path selectors (e.g., `ANY`, `SHORTEST`) or legacy shortest path functions like `shortestPath()`.
+| Explicit path modes cannot be combined with restrictive path selectors (e.g., `ANY`, `SHORTEST`) or with xref:patterns/reference.adoc#shortest-functions[legacy shortest path functions] like `shortestPath()`.
 
 | 2026.5 - current
-a| Explicit path modes can be combined with restrictive path selectors.
+a| Explicit path modes can be combined with restrictive path selectors, but not with legacy shortest path functions.
 
 .Supported
 [source, cypher]
@@ -2055,10 +2055,13 @@ MATCH p = ANY SHORTEST ACYCLIC (a:A)-->+(b:!A)
 RETURN p
 ----
 
-Explicit path modes cannot be combined with xref:patterns/reference.adoc#variable-length-relationships[variable-length relationships] (e.g., `+-[*]->+`).
+|===
+
+[[path-modes-and-variable-length-paths]]
+==== Path modes and variable-length paths
+
+Explicit path modes cannot be used with the xref:patterns/reference.adoc#variable-length-relationships[variable-length relationships syntax] (e.g., `+-[*]->+`).
 Use xref:patterns/reference.adoc#quantified-path-patterns[quantified path patterns] or xref:patterns/reference.adoc#quantified-relationships[quantified relationships] instead.
-Note that this also means that explicit path modes cannot be combined with xref:patterns/reference.adoc#shortest-functions[legacy shortest path functions] like `shortestPath()`.
-Use xref:patterns/reference.adoc#shortest-paths[`SHORTEST`] instead.
 
 .Supported -- explicit path mode with quantified relationship syntax
 [source, cypher]
@@ -2070,11 +2073,18 @@ RETURN start, target
 .Not supported -- explicit path mode with variable-length relationship syntax
 [source, cypher, role=test-fail]
 ----
-MATCH p = ACYCLIC shortestPath((a:A)-[*]->(b:!A))
-RETURN p
+MATCH ACYCLIC (start)-[*4..7]->(target)
+RETURN start, target
 ----
 
+.GQLSTATUS error chain
+[role="queryresult",stripes="all",cols="1"]
 |===
+| link:https://neo4j.com/docs/status-codes/current/errors/gql-errors/51N26/[51N26]: error: system configuration or operation exception - not supported in this version. Using explicit path modes on a pattern containing a variable-length relationship is not available. This implementation of Cypher does not support `ACYCLIC` on variable-length relationships.
+
+link:https://neo4j.com/docs/status-codes/current/errors/gql-errors/42001/[42001]: error: syntax error or access rule violation - invalid syntax
+|===
+
 
 [[path-modes-cannot-be-applied-to-merge]]
 ==== Path modes cannot be applied to `MERGE` clauses

--- a/modules/ROOT/pages/patterns/reference.adoc
+++ b/modules/ROOT/pages/patterns/reference.adoc
@@ -2047,20 +2047,23 @@ For example:
 .Not supported
 [source, cypher, role=test-fail]
 ----
-MATCH ACYCLIC (start)-[*4..7]->(target)
+CYPHER 25
+MATCH ACYCLIC (start)-[:R*4..7]->(target)
 RETURN start, target
 ----
 
 .Supported
 [source, cypher]
 ----
-MATCH ACYCLIC (start)-[]->{4,7}(target)
+CYPHER 25
+MATCH ACYCLIC (start)-[:R]->{4,7}(target)
 RETURN start, target
 ----
 
 .Not supported
 [source, cypher, role=test-fail]
 ----
+CYPHER 25
 MATCH p = ACYCLIC shortestPath((a:A)-[*]->(b:!A))
 RETURN p
 ----
@@ -2068,6 +2071,7 @@ RETURN p
 .Supported
 [source, cypher]
 ----
+CYPHER 25
 MATCH p = ANY SHORTEST ACYCLIC (a:A)-[]->+(b:!A)
 RETURN p
 ----


### PR DESCRIPTION
Allow explicit path mode + Shortest, disallow explicit path mode + variable-length relationships.

We will support explicit path modes in combination with GPM Shortest.
Explicit path modes are not supported in combination with variable-length relationships or legacy shortest path functions.