### PR TITLE
Link semantic indexes to hybrid search guide

### DIFF
--- a/modules/ROOT/pages/clauses/search.adoc
+++ b/modules/ROOT/pages/clauses/search.adoc
@@ -45,6 +45,10 @@ In the result, the column for the similarity scores will be called `score_alias`
 - The `SEARCH` clause puts some restrictions on which `pattern` the enclosing `MATCH` or `OPTIONAL MATCH` clause is allowed to have.
 For more information, see xref::clauses/search.adoc#limitations[Limitations of the `SEARCH` clause].
 
+The `SCORE` value is a vector similarity score from the vector index query.
+When combining `SEARCH` results with full-text results or other scored sources, rank each source independently rather than comparing raw score values directly.
+For a worked example, see link:https://neo4j.com/developer/genai-ecosystem/vector-search/#_hybrid_full_text_and_vector_search[Developer Guide -> Hybrid full-text and vector search].
+
 
 [[search-example-graph]]
 == Example graph and vector index

--- a/modules/ROOT/pages/indexes/semantic-indexes/full-text-indexes.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/full-text-indexes.adoc
@@ -171,6 +171,9 @@ Thus, in addition to any exact matches, full-text indexes return _approximate_ m
 This is possible because both the property values that are indexed, and the queries to the index, are processed through the analyzer such that the index can find data entities which do not exactly match the provided `STRING`.
 
 The `score` results are always returned in _descending score order_, where the best matching result entry is put first.
+Full-text scores are meaningful within the result set from a full-text query.
+When combining full-text results with vector results or other scored sources, rank each source independently rather than comparing raw score values directly.
+For a worked example, see link:https://neo4j.com/developer/genai-ecosystem/vector-search/#_hybrid_full_text_and_vector_search[Developer Guide -> Hybrid full-text and vector search].
 
 This query uses the `db.index.fulltext.queryRelationships()` procedure to query the previously created `communications` full-text index for any `message` containing "meeting":
 

--- a/modules/ROOT/pages/indexes/semantic-indexes/index.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/index.adoc
@@ -9,6 +9,11 @@ Two semantic indexes are available in Neo4j:
 * xref:indexes/semantic-indexes/full-text-indexes.adoc[Full-text indexes]: enables searching within the content of `STRING` properties and for similarity comparisons between query strings and `STRING` values stored in the database.
 * xref:indexes/semantic-indexes/vector-indexes.adoc[Vector indexes]: enables similarity searches and complex analytical queries by representing nodes or properties as vectors in a multidimensional space.
 
+Full-text and vector indexes can also be used together for hybrid search.
+This is useful when an application needs both lexical matches, such as exact terms, names, acronyms, or identifiers, and semantic matches from vector search.
+When combining results from different semantic indexes, rank each source independently rather than comparing raw score values directly.
+For a worked example, see link:https://neo4j.com/developer/genai-ecosystem/vector-search/#_hybrid_full_text_and_vector_search[Developer Guide -> Hybrid full-text and vector search].
+
 [NOTE]
 Unlike search-performance indexes, semantic indexes are not automatically used by the xref:planning-and-tuning/execution-plans.adoc[Cypher planner].
 To use semantic indexes, they must be explicitly called with specific procedures or, for vector indexes, by using the Cypher xref::clauses/search.adoc[SEARCH] clause.

--- a/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
@@ -42,6 +42,9 @@ An embedding is a numerical representation of a data object, such as a text, ima
 Each word or token in a text is typically represented as high-dimensional vector where each dimension represents a certain aspect of the word’s meaning.
 
 The embedding for a particular data object can be created by both proprietary (such as https://cloud.google.com/vertex-ai[Vertex AI] or https://openai.com/[OpenAI]) and open source (such as https://github.com/huggingface/sentence-transformers[sentence-transformers]) embedding generators, which can produce vector embeddings with dimensions such as 256, 768, 1536, and 3072.
+Embeddings can also represent graph structure, not only the semantic content of text, images, or documents.
+For example, link:https://neo4j.com/docs/graph-data-science/current/machine-learning/node-embeddings/[Neo4j Graph Data Science node embedding algorithms] can write embeddings that capture graph topology to node properties.
+Those properties can then be indexed with a vector index and queried with Neo4j vector search as a structural search signal, either on their own or as one source in a hybrid search query.
 
 Vector embeddings are stored as `LIST<INTEGER | FLOAT>` properties on a node or relationship.
 As of Neo4j 2025.10, they can also be more efficiently stored as xref:values-and-types/vector.adoc[`VECTOR`] properties using Cypher 25.

--- a/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
@@ -6,6 +6,8 @@ include::https://raw.githubusercontent.com/neo4j-graphacademy/courses/main/ascii
 = Vector indexes
 
 Vector indexes enable similarity searches and complex analytical queries by representing nodes or properties as vectors in a multidimensional space.
+Vector search is often used on its own for semantic matching, but it can also be combined with full-text search or other ranked result sources for hybrid search.
+For a worked example, see link:https://neo4j.com/developer/genai-ecosystem/vector-search/#_hybrid_full_text_and_vector_search[Developer Guide -> Hybrid full-text and vector search].
 
 The following resources provide hands-on tutorials for working with LLMs and vector indexes in Neo4j:
 
@@ -257,6 +259,10 @@ Default value::: `100`
 As of Neo4j 2026.01, the preferred way of querying vector indexes is by using the Cypher xref::clauses/search.adoc[SEARCH] clause.
 A less powerful alternative, which also works for earlier Neo4j versions, is using the procedures link:https://neo4j.com/docs/operations-manual/current/procedures/#procedure_db_index_vector_queryNodes[db.index.vector.queryNodes] and link:https://neo4j.com/docs/operations-manual/current/procedures/#procedure_db_index_vector_queryRelationships[db.index.vector.queryRelationships].
 These procedures are deprecated as of Neo4j 2026.04.
+
+Vector index scores are meaningful within the result set from a vector query.
+When combining vector results with full-text results or other scored sources, rank each source independently rather than comparing raw score values directly.
+For more information, see link:https://neo4j.com/developer/genai-ecosystem/vector-search/#_hybrid_full_text_and_vector_search[Developer Guide -> Hybrid full-text and vector search].
 
 [NOTE]
 An index cannot be used while its `state` is `POPULATING`, which occurs immediately after it is created.


### PR DESCRIPTION
## Summary

- add hybrid-search context to the semantic indexes overview
- add worked-example links from vector indexes, full-text indexes, and the SEARCH clause page
- clarify that raw scores from different ranked sources should not be compared directly

## Validation

- git diff --check
- npm run build:preview
