### PR TITLE
DOCOPS-147 Remove cheat sheet content from PDF

### DIFF
--- a/modules/cheat-sheet/pages/index.adoc
+++ b/modules/cheat-sheet/pages/index.adoc
@@ -5,6 +5,16 @@
 :github-raw-page-uri: https://raw.githubusercontent.com/neo4j
 
 
+ifdef::backend-pdf[]
+
+The Cypher Cheat Sheet is a reference guide that contains syntax examples and usage notes for Cypher queries.
+
+link:https://neo4j.com/docs/cypher-manual/{page-version}/cheat-sheet/[Cypher {page-version} Cheat Sheet]
+
+endif::[]
+
+ifndef::backend-pdf[]
+
 == Read Query
 
 include::read-query-structure.adoc[leveloffset=2]
@@ -277,3 +287,5 @@ include::on-dbms-alias-management-privileges.adoc[leveloffset=2]
 include::on-dbms-role-management-privileges.adoc[leveloffset=2]
 
 include::on-dbms-privilege-management-privileges.adoc[leveloffset=2]
+
+endif::[]


### PR DESCRIPTION
Adds conditional statements to the cheat sheet index page.

- if the output is PDF, provides a link to the cheat sheet in the published version of the Cypher manual
- if the output is not PDF, outputs the cheat sheet content as normal

Note that the link does not use the `{neo4j-docs-base-uri}` attribute because if it did, the PDF preprocessor would attempt to parse that into a link to the Cypher manual PDF.