### PR TITLE
Clarify version and limitations for IN vector SEARCH filters

### DIFF
--- a/modules/ROOT/pages/clauses/search.adoc
+++ b/modules/ROOT/pages/clauses/search.adoc
@@ -479,11 +479,14 @@ RETURN movie.title AS title, movie.releaseDate.year AS year, movie.rating AS rat
 [[vector-search-filtering-predicates]]
 === Predicates for vector search with filters
 
-When used within `SEARCH`, xref:clauses/where.adoc[`WHERE`] is limited to filtering the following predicates:
+When used within `SEARCH`, xref:clauses/where.adoc[`WHERE`] supports the following predicates:
 
 * Property predicates
-* Property predicates separated by the xref::expressions/predicates/boolean-operators.adoc[`AND`] operator
-* Property predicates followed by the xref::expressions/predicates/list-operators.adoc[`IN`] operator label:new[Introduced in Neo4j 2026.06]
+* Multiple supported property predicates joined by the xref::expressions/predicates/boolean-operators.adoc[`AND`] operator
+* Property predicates using the xref::expressions/predicates/list-operators.adoc[`IN`] operator label:new[Introduced in Neo4j 2026.06]
+
+`IN` is supported in vector search filter predicates from Neo4j 2026.06.
+Earlier versions do not support `IN` within the `WHERE` subclause of `SEARCH`.
 
 .Vector search with filter with an AND predicate on the same property
 ====
@@ -559,9 +562,10 @@ In the example above, only three nodes are returned despite the `LIMIT` being fo
 Due to the approximate nature of vector search, this can also happen if the `LIMIT` is smaller than but close to the total number of indexed vectors fulfilling the predicate.
 ====
 
-
-.Vector search with filter using `IN` label:new[Introduced in Neo4j 2026.06]
+.Vector search with filter using `IN`
 ====
+label:new[Introduced in Neo4j 2026.06]
+
 .Query
 // tag::clauses_search_filter_in[]
 [source, cypher]
@@ -849,6 +853,10 @@ For example, given that `seen` has been added as an additional property for filt
 `WHERE movie.rating > 8 OR movie.releaseDate \<= date("2000")`
 |
 
+| Before Neo4j 2026.06, the predicate cannot include the xref::expressions/predicates/list-operators.adoc[`IN` operator].
+| `WHERE movie.rating IN [7, 7.5, 8]`
+| Neo4j 2026.06
+
 | The predicate cannot include a xref::expressions/predicates/string-operators.adoc[string operator].
 | `WHERE movie.rating STARTS WITH '8'`
 |
@@ -865,7 +873,8 @@ For example, given that `seen` has been added as an additional property for filt
 | `WHERE movie.rating < vector([8.2, 8.5], 2, FLOAT)`
 |
 
-| The expression in the predicate cannot be of type `LIST`.
+| A `LIST` expression cannot be used with a xref::expressions/predicates/comparison-operators.adoc[comparison operator].
+Lists are supported only as the right-hand operand of `IN`.
 | `WHERE movie.rating < [8, 8.5]`
 |
 

--- a/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
+++ b/modules/ROOT/pages/indexes/semantic-indexes/vector-indexes.adoc
@@ -112,7 +112,7 @@ Vectors stored as `LIST <INTEGER \| FLOAT>` properties.
 
 | *2026.01*
 | Adds support for multi-label and multi-relationship-type vector indexes with additional properties used for filtering.
-These properties can later be used for filtering in xref:indexes/semantic-indexes/vector-indexes.adoc#query-vector-index-search[`SEARCH ... WHERE`], but they cannot be vector properties.
+These properties can later be used in xref::clauses/search.adoc#vector-search-filtering[vector search with filters using `SEARCH ... WHERE`], but they cannot be vector properties.
 A vector index can store only one vector property per node or relationship.
 |===
 


### PR DESCRIPTION
## Summary

- state explicitly that `IN` within vector `SEARCH` filters is supported from Neo4j 2026.06
- retain the earlier limitation with its version lifted
- clarify that lists are valid as the right-hand operand of `IN`, but not with comparison operators
- place the feature label on its own line and improve the supported-predicate wording
- link vector index filtering properties directly to the `SEARCH` filtering documentation

The main `IN` example is already present on `dev` from #1554. This companion keeps the next-release documentation aligned with the targeted current-release backport in #1601.

## Validation

- `npm run build:preview` in a normal repository clone
- `git diff --check`
- live Neo4j 2026.06.0 validation using literal and parameterized lists; both returned the documented results

The live validation used equivalent list-backed embeddings because the Community distribution uses the aligned store format; this does not affect the filter behavior under test.