### PR TITLE
SURF-1206: Fix signature for trim function

### DIFF
--- a/modules/ROOT/pages/functions/index.adoc
+++ b/modules/ROOT/pages/functions/index.adoc
@@ -687,7 +687,7 @@ label:cypher[Cypher 25 only] label:new[Introduced in Neo4j 2026.05]
 | Returns the given `STRING` in uppercase.
 
 1.1+| xref::functions/string.adoc#functions-trim[`trim()`]
-| `trim(trimCharacterString :: STRING, trimSpecification :: STRING, input :: STRING) :: STRING`
+| `trim([[LEADING \| TRAILING \| BOTH] [trimCharacterString :: STRING] FROM] input :: STRING) :: STRING`
 | Returns the given `STRING` with the leading and/or trailing `trimCharacterString` character removed.
 
 1.1+| xref::functions/string.adoc#functions-upper[`upper()`]

--- a/modules/ROOT/pages/functions/string.adoc
+++ b/modules/ROOT/pages/functions/string.adoc
@@ -960,7 +960,7 @@ RETURN toUpper('hello')
 
 .Details
 |===
-| *Syntax* 3+| `trim(trimSpecification, trimCharacterString, input)`
+| *Syntax* 3+| `trim([[LEADING \| TRAILING \| BOTH] [trimCharacterString] FROM] input)`
 | *Description* 3+| Returns the given `STRING` with leading and/or trailing `trimCharacterString` removed.
 .4+| *Arguments* | *Name* | *Type* | *Description*
 | `trimSpecification` | `[LEADING, TRAILING, BOTH]` | The parts of the string to trim; LEADING, TRAILING, BOTH
@@ -976,6 +976,7 @@ RETURN toUpper('hello')
 | `trim(null FROM "hello")` returns `null`.
 | `trim(" " FROM null)` returns `null`.
 | `trim(BOTH null FROM null)` returns `null`.
+| `trim(INVALID null FROM null)` throws an invalid trimSpecification error.
 | If `trimSpecification` and a `trimCharacterString` are not specified all leading and/or trailing whitespace will be removed.
 
 |===


### PR DESCRIPTION
The signature for trim was not showing the intended usage and was mismatching the examples.