### PR TITLE
SURF-1204: Explicitly state difference of + to || with toString

### DIFF
--- a/modules/ROOT/pages/expressions/string-operators.adoc
+++ b/modules/ROOT/pages/expressions/string-operators.adoc
@@ -7,8 +7,27 @@ Cypher contains two operators for the concatenation of `STRING` values:
 * `||`
 * `+`
 
-The two operators are functionally equivalent.
+The two operators are functionally equivalent on `STRING` values.
 However, `||` is xref:appendix/gql-conformance/index.adoc[GQL conformant], while `+` is not.
+
+When `+` is used to concatenate a `STRING` with a non-`STRING` value (excluding `LIST` values), the non-`STRING` value is implicitly converted to a `STRING` using xref:functions/string.adoc#functions-tostring[`toString()`].
+`||` does not perform this implicit conversion, so a `STRING` can only be concatenated with another `STRING` when using `||`; non-`STRING` values must first be explicitly converted using `toString()`.
+
+.Implicit `toString()` conversion with `+`
+[source, cypher]
+----
+RETURN 'The number is: ' + 42 AS result
+----
+
+.Result
+[role="queryresult",options="header,footer",cols="1*<m"]
+|===
+| result
+
+| "The number is: 42"
+
+1+d| Rows: 1
+|===
 
 For additional expressions that evaluate to `STRING` values, see xref:functions/string.adoc[String functions].
 


### PR DESCRIPTION
We got a github issue showing confusion around why `+` allows non-string values and `||` does not, this PR makes this more explicit.