### PR TITLE
DOCOPS-160 Harden docs-deploy-surge.yml against artifact poisoning (sync from docs-template)

### DIFF
--- a/.github/workflows/docs-deploy-surge.yml
+++ b/.github/workflows/docs-deploy-surge.yml
@@ -22,7 +22,7 @@ on:
       - completed
 
 jobs:
-  # [Optional] Restrict automatic dpeloyment to PRs from the upstream repo
+  # [Optional] Restrict automatic deployment to PRs from the upstream repo
   # For fork PRs, requires manual approval via the "preview" environment.
   # For PRs from the main repository this job is skipped and deploy-docs runs immediately.
   # Setup: create a "preview" environment in Settings → Environments with required reviewers.
@@ -56,7 +56,7 @@ jobs:
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,
-               run_id: ${{ env.RUN_ID }},
+               run_id: process.env.RUN_ID,
             });
 
             var matchArtifactDocs = artifacts.data.artifacts.filter((artifact) => {
@@ -86,13 +86,32 @@ jobs:
 
       - id: suspicious-path-check
         name: Suspicious paths check
+        shell: bash
         env:
           ARTIFACT_DIR: ${{ runner.temp }}/artifacts/docs
         run: |
+          set -euo pipefail
           cd "$ARTIFACT_DIR"
-          if unzip -l docs.zip | grep -q "\.\./"; then
+          
+          mapfile -t ZIP_ENTRIES < <(zipinfo -1 docs.zip)
+          if [ "${#ZIP_ENTRIES[@]}" -eq 0 ]; then
+            echo "docs.zip is empty"
             exit 1
           fi
+          for entry in "${ZIP_ENTRIES[@]}"; do
+            if [[ "$entry" =~ ^/ ]]; then
+              echo "Blocked absolute path in artifact: $entry"
+              exit 1
+            fi
+            if [[ "$entry" =~ (^|/)\.\.(/|$) ]]; then
+              echo "Blocked path traversal in artifact: $entry"
+              exit 1
+            fi
+            if [[ "$entry" == *\\* ]]; then
+              echo "Blocked Windows-style path separator in artifact: $entry"
+              exit 1
+            fi
+          done
 
       - id: hidden-files-check
         name: Hidden files check
@@ -131,7 +150,27 @@ jobs:
         run: |
           cd "$ARTIFACT_DIR"
           unzip changelog.zip
-      
+
+      # The changelog file is built from untrusted PR content and its contents
+      # are posted to the PR as a comment. A malicious artifact could make
+      # `changelog` a symlink pointing at an arbitrary file the runner can read,
+      # turning the comment step into an arbitrary-file-read. Reject anything
+      # that isn't a plain regular file before we read it.
+      - id: validate-changelog
+        name: Validate changelog is a regular file
+        if: ${{ steps.find-changelog.outputs.has-changelog == 'true' }}
+        env:
+          CHANGELOG_FILE: ${{ runner.temp }}/artifacts/changelog/changelog
+        run: |
+          if [ -L "$CHANGELOG_FILE" ]; then
+            echo "Security Alert: changelog is a symlink — refusing!"
+            exit 1
+          fi
+          if [ ! -f "$CHANGELOG_FILE" ]; then
+            echo "changelog missing or not a regular file"
+            exit 1
+          fi
+
       - id: get-deploy-id
         name: Get deploy ID
         env:


### PR DESCRIPTION
## What

Syncs `.github/workflows/docs-deploy-surge.yml` to the canonical [`neo4j/docs-template`](https://github.com/neo4j/docs-template) version, resolving the **critical** CodeQL *artifact poisoning* alert on this repo.

The sync brings in three hardening changes this repo was missing:
- **`validate-changelog` step** — rejects a symlinked `changelog` before its contents are read into the PR comment (blocks arbitrary-file-read from a poisoned fork artifact).
- **`process.env.RUN_ID`** instead of `${{ env.RUN_ID }}` in the `github-script` step (avoids GitHub Actions expression injection).
- **Extended `suspicious-path-check`** (`zipinfo` loop under `set -euo pipefail`) — rejects empty archives, absolute paths, path traversal (`..`), and Windows-style backslash separators.

## Why

`docs-deploy-surge.yml` runs on `workflow_run` and unpacks/deploys an artifact built from (potentially fork) PR content. See docs-template#59 and neo4j/neo4j-spark-connector#1042 for the upstream hardening.

**No branch or path filters were changed** — the result is byte-identical to the canonical template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
