### PR TITLE
SURF-1269: document bounds of `left()`,  `right()`, and `substring()`

### DIFF
--- a/modules/ROOT/pages/functions/string.adoc
+++ b/modules/ROOT/pages/functions/string.adoc
@@ -87,7 +87,7 @@ RETURN btrim('   hello    '), btrim('xxyyhelloxyxy', 'xy')
 | `left(null, null)` return `null`.
 | `left(original, null)` will raise an error.
 // Should be: If `length` is a negative integer, an error is raised.
-| If `length` is a negative `INTEGER` or larger `2_147_483_647` (2^31-1), an error is raised.
+| If `length` is a negative `INTEGER` or larger than `2_147_483_647` (2^31-1), an error is raised.
 | If `length` exceeds the size of `original`, `original` is returned.
 
 |===
@@ -449,7 +449,7 @@ RETURN reverse('palindrome')
 | `right(null, null)` return `null`.
 | `right(original, null)` will raise an error.
 // Should be: If `length` is a negative integer, an error is raised.
-| If `length` is a negative `INTEGER` or larger `2_147_483_647` (2^31-1), an error is raised.
+| If `length` is a negative `INTEGER` or larger than `2_147_483_647` (2^31-1), an error is raised.
 | If `length` exceeds the size of `original`, `original` is returned.
 
 |===
@@ -737,7 +737,7 @@ RETURN string.regexReplace("hello", "l.", "w")
 | `start` uses a zero-based index.
 | If `length` is omitted, the function returns the substring starting at the position given by `start` and extending to the end of `original`.
 | If `original` is `null`, `null` is returned.
-| If either `start` or `length` is `null`, a negative `INTEGER` or larger `2_147_483_647` (2^31-1), an error is raised.
+| If either `start` or `length` is `null`, a negative `INTEGER` or larger than `2_147_483_647` (2^31-1), an error is raised.
 | If `start` is `0`, the substring will start at the beginning of `original`.
 | If `length` is `0`, the empty `STRING` will be returned.
 

--- a/modules/ROOT/pages/functions/string.adoc
+++ b/modules/ROOT/pages/functions/string.adoc
@@ -76,7 +76,7 @@ RETURN btrim('   hello    '), btrim('xxyyhelloxyxy', 'xy')
 | *Description* 3+| Returns a `STRING` containing the specified number (`INTEGER`) of leftmost characters in the given `STRING`.
 .3+| *Arguments* | *Name* | *Type* | *Description*
 | `original` | `STRING` | A string value whose rightmost characters will be trimmed.
-| `length` | `INTEGER` | The length of the leftmost characters to be returned.
+| `length` | `INTEGER` | An integer between `0` and `2_147_483_647` (2^31-1) that specifies the length of the leftmost characters to be returned.
 | *Returns* 3+| `STRING`
 |===
 
@@ -87,7 +87,7 @@ RETURN btrim('   hello    '), btrim('xxyyhelloxyxy', 'xy')
 | `left(null, null)` return `null`.
 | `left(original, null)` will raise an error.
 // Should be: If `length` is a negative integer, an error is raised.
-| If `length` is not a positive `INTEGER`, an error is raised.
+| If `length` is a negative `INTEGER` or larger `2_147_483_647` (2^31-1), an error is raised.
 | If `length` exceeds the size of `original`, `original` is returned.
 
 |===
@@ -438,7 +438,7 @@ RETURN reverse('palindrome')
 | *Description* 3+| Returns a `STRING` containing the specified number of rightmost characters in the given `STRING`.
 .3+| *Arguments* | *Name* | *Type* | *Description*
 | `original` | `STRING` | A string value whose leftmost characters will be trimmed.
-| `length` | `INTEGER` | The length of the rightmost characters to be returned.
+| `length` | `INTEGER` | An integer between `0` and `2_147_483_647` (2^31-1) that specifies the length of the rightmost characters to be returned.
 | *Returns* 3+| `STRING`
 |===
 
@@ -449,7 +449,7 @@ RETURN reverse('palindrome')
 | `right(null, null)` return `null`.
 | `right(original, null)` will raise an error.
 // Should be: If `length` is a negative integer, an error is raised.
-| If `length` is not a positive `INTEGER`, an error is raised.
+| If `length` is a negative `INTEGER` or larger `2_147_483_647` (2^31-1), an error is raised.
 | If `length` exceeds the size of `original`, `original` is returned.
 
 |===
@@ -726,8 +726,8 @@ RETURN string.regexReplace("hello", "l.", "w")
 | *Description* 3+| Returns a substring of a given `length` from the given `STRING`, beginning with a 0-based index start.
 .4+| *Arguments* | *Name* | *Type* | *Description*
 | `original` | `STRING` | The string to be shortened.
-| `start` | `INTEGER` | The start position of the new string.
-| `length` | `INTEGER` | The length of the new string.
+| `start` | `INTEGER` | An integer between `0` and `2_147_483_647` (2^31-1) that specifies the start position of the new string.
+| `length` | `INTEGER` | An integer between `0` and `2_147_483_647` (2^31-1) that specifies the length of the new string.
 | *Returns* 3+| `STRING`
 |===
 
@@ -737,7 +737,7 @@ RETURN string.regexReplace("hello", "l.", "w")
 | `start` uses a zero-based index.
 | If `length` is omitted, the function returns the substring starting at the position given by `start` and extending to the end of `original`.
 | If `original` is `null`, `null` is returned.
-| If either `start` or `length` is `null` or a negative integer, an error is raised.
+| If either `start` or `length` is `null`, a negative `INTEGER` or larger `2_147_483_647` (2^31-1), an error is raised.
 | If `start` is `0`, the substring will start at the beginning of `original`.
 | If `length` is `0`, the empty `STRING` will be returned.
 


### PR DESCRIPTION
This is related to fixes in this [Product PR](https://github.com/neo-technology/neo4j/pull/38913).

See also issue https://github.com/neo4j/neo4j/issues/13871.