### PR TITLE
DOCOPS-176 Add page-tabs attributes to publish playbook

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -36,6 +36,8 @@ asciidoc:
   - "@neo4j-antora/mark-terms"
   - asciidoctor-kroki
   attributes:
+    page-tabs: cypher@
+    page-tabs-index: 10
     page-theme: docs@
     page-type: Docs
     page-search-type: Docs


### PR DESCRIPTION
Adds `page-tabs` and `page-tabs-index` to `publish.yml`:

```yaml
page-tabs: cypher@
page-tabs-index: 10
```

Places this docset in the `cypher` tab of the aggregated tabbed navigation, at the
position matching its order in the Docs menu on neo4j.com/docs. The value is
soft-set with a trailing `@` so it can be overridden in `antora.yml` or on a page.
