### PR TITLE
Fix tag and source order in remove.adoc

### DIFF
--- a/modules/ROOT/pages/clauses/remove.adoc
+++ b/modules/ROOT/pages/clauses/remove.adoc
@@ -145,8 +145,8 @@ REMOVE n:$(expr)
 The expression must evaluate to a `STRING NOT NULL | LIST<STRING NOT NULL> NOT NULL` value.
 
 .Query
-[source, cypher]
 // tag::clauses_remove_dynamic_label[]
+[source, cypher]
 ----
 MATCH (n {name: 'Peter'})
 UNWIND labels(n) AS label


### PR DESCRIPTION
Adjusts the order of tag and source marker to be consistent to the other source snippets in the site.

Also fixes the broken syntax highlighting (for `Dynamically remove a node label`) in the cheatsheet:

before:
<img width="auto" height="150" alt="image" src="https://github.com/user-attachments/assets/c5dcff36-eb7b-4963-8e72-2dcfc49c81f3" />
after:
<img width="auto" height="150" alt="image" src="https://github.com/user-attachments/assets/ef908eb3-ea58-4e8a-9688-ae7a290b685d" />
