### PR TITLE
DOCOPS-176 Promote all sections to docset level

### DIFF
--- a/preview.yml
+++ b/preview.yml
@@ -7,11 +7,6 @@ content:
   sources:
   - url: ./
     branches: ['HEAD']
-    edit_url: https://github.com/neo4j/docs-cypher/tree/{refname}/{path}
-    exclude:
-    - '!**/_includes/*'
-    - '!**/readme.adoc'
-    - '!**/README.adoc'
 
 ui:
   bundle:
@@ -36,6 +31,9 @@ asciidoc:
   - "@neo4j-antora/mark-terms"
   - asciidoctor-kroki
   attributes:
+    page-tabs: cypher@
+    page-tabs-index: 10
+    page-tabs-promote-all: true
     page-theme: docs@
     page-type: Docs
     page-search-type: Docs
@@ -69,3 +67,4 @@ asciidoc:
     page-ad-link: https://sessionize.com/nodes26/
     page-ad-underline-role: button
     page-ad-underline: Submit your talk
+    

--- a/publish.yml
+++ b/publish.yml
@@ -7,11 +7,6 @@ content:
   sources:
   - url: ./
     branches: ['4.4', 'cypher-5', 'HEAD']
-    edit_url: https://github.com/neo4j/docs-cypher/tree/{refname}/{path}
-    exclude:
-    - '!**/_includes/*'
-    - '!**/readme.adoc'
-    - '!**/README.adoc'
 
 ui:
   bundle:
@@ -38,6 +33,7 @@ asciidoc:
   attributes:
     page-tabs: cypher@
     page-tabs-index: 10
+    page-tabs-promote-all: true
     page-theme: docs@
     page-type: Docs
     page-search-type: Docs


### PR DESCRIPTION
Use the new `page-tabs-promote-all` attribute to promote every section in _content-nav.adoc_ to the top level.

Instead of Cypher Manual listed under the Cypher tab, this has the effect of listing each section, using the same style.